### PR TITLE
Chore: remove broken links

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,12 @@
 import Link from "next/link";
 import { Typography } from "@/components/ui/typography";
 
-const GOVERNMENT_LINKS = [
-  "Have your say",
-  "What's changing",
-  "How we choose what to work on first",
-  "Digital roadmap",
-];
+// const GOVERNMENT_LINKS = [
+//   "Have your say",
+//   "What's changing",
+//   "How we choose what to work on first",
+//   "Digital roadmap",
+// ];
 
 const EXISTING_SERVICES = [
   {
@@ -132,7 +132,7 @@ export default function Home() {
           ))}
         </div>
       </div>
-      <div className="space-y-6 border-[#FF94D9] border-b-4 bg-[#FFD4F0] px-4 py-8">
+      {/* <div className="space-y-6 border-[#FF94D9] border-b-4 bg-[#FFD4F0] px-4 py-8">
         <Typography variant="h3">Make government work for you</Typography>
 
         <div className="flex flex-col gap-2">
@@ -146,7 +146,7 @@ export default function Home() {
             </Link>
           ))}
         </div>
-      </div>
+      </div> */}
     </div>
   );
 }

--- a/src/components/layout/banner.tsx
+++ b/src/components/layout/banner.tsx
@@ -16,9 +16,9 @@ export const Banner = () => {
         </Typography>
       </span>
 
-      <Typography className="text-white underline" variant="small">
+      {/* <Typography className="text-white underline" variant="small">
         Learn More
-      </Typography>
+      </Typography> */}
     </div>
   );
 };

--- a/src/content/register-summer-camp.md
+++ b/src/content/register-summer-camp.md
@@ -8,14 +8,15 @@ The deadline to register for a place is approximately 2 weeks before the start o
 
 You can see a list of camps and their location. 
 
-Registration opens in May 2026.
+---
 
+## Registration opens in May 2026.
+
+---
 
 ## How to register
 
 Parents and guardians can register for a summer camp on behalf of a child/ward online.  
-
-[Register for a summer camp](#)
 
 If you do not have access to the internet or a smart device, colleagues at any  community centre can help you register.
 


### PR DESCRIPTION
## Summary

This update removes broken links

## Details

- **Why?**  
The removed sections/text included broken links which reduced user experience

- **Where?**  
  - Updated file: `src/content/register-summer-camp.md`
    - Changed formatting of "Registration opens in May 2026"
    - Removed dead link "Register for a summer camp"

