### PR TITLE
Chore: Mark register a birth content as alpha

### DIFF
--- a/src/app/[...slug]/page.tsx
+++ b/src/app/[...slug]/page.tsx
@@ -91,7 +91,7 @@ export default async function EntryPointPage({ params }: EntryPointPageProps) {
             </Typography>
           ))}
 
-        {frontmatter.stage ? (
+        {frontmatter.stage?.length > 0 ? (
           <div className="border-[#1E787D] border-l-4 bg-[#DEF5F6] px-4 py-3">
             <Typography variant="paragraph">
               This Page is in{" "}

--- a/src/content/register-a-birth.md
+++ b/src/content/register-a-birth.md
@@ -1,5 +1,6 @@
 ---
 title: "Register a birth"
+stage: "alpha"
 ---
 
 It is a legal requirement that all births in Barbados (including stillbirths) are registered within 28 days. 


### PR DESCRIPTION
## Add Alpha Stage Label to Birth Registration Page

### Summary
This PR adds an "alpha" stage label to the birth registration service page and includes a defensive check to prevent rendering issues when the stage field is undefined.

### Changes Made

#### 🏷️ Content Updates
- **Added alpha stage label** to `register-a-birth.md`
  - Added `stage: "alpha"` to the frontmatter metadata
  - This will display a visual indicator that the birth registration service is in alpha stage

#### 🛡️ Code Improvements  
- **Enhanced stage field validation** in `src/app/[...slug]/page.tsx`
  - Changed condition from `frontmatter.stage` to `frontmatter.stage?.length > 0`
  - Prevents rendering of empty stage banners when stage field exists but is empty
  - Adds defensive programming to handle edge cases gracefully

### Files Changed
- `src/content/register-a-birth.md` - Added alpha stage metadata
- `src/app/[...slug]/page.tsx` - Improved stage field validation logic

### Visual Impact
Users will now see an alpha stage indicator banner on the birth registration page, clearly communicating that this service is still in development and may undergo changes.

### Testing
- ✅ Verified that pages with stage labels display correctly
- ✅ Verified that pages without stage labels don't show empty banners
- ✅ Confirmed that empty stage values are handled properly