### PR TITLE
feat: make occupation mandatory for both mother and father

### DIFF
--- a/src/components/forms/register-birth/schema.ts
+++ b/src/components/forms/register-birth/schema.ts
@@ -152,7 +152,10 @@ function createPersonDetailsSchema(personType: "father" | "mother") {
       ),
       nationalRegistrationNumber: z.string().optional(),
       passportNumber: z.string().optional(),
-      occupation: z.string().optional(),
+      occupation: z.preprocess(
+        (val) => val ?? "",
+        z.string().min(1, `Enter the ${personType}'s occupation`)
+      ),
     })
   );
 }

--- a/src/components/forms/register-birth/steps/fathers-details.tsx
+++ b/src/components/forms/register-birth/steps/fathers-details.tsx
@@ -265,18 +265,27 @@ export function FathersDetails({
           className="mb-2 block font-bold text-[20px] text-neutral-black leading-[150%]"
           htmlFor="father-occupation"
         >
-          Occupation{" "}
+          Occupation
         </label>
         <p className="mb-2 text-base text-gray-600">
           This will be included on the child's birth certificate and in official
           records.
         </p>
         <input
+          aria-describedby={
+            fieldErrors.occupation ? "father-occupation-error" : undefined
+          }
+          aria-invalid={fieldErrors.occupation ? true : undefined}
           className={getFieldClassName("occupation", fieldErrors)}
           id="father-occupation"
+          onBlur={() => handleBlur("occupation")}
           onChange={(e) => handleChange("occupation", e.target.value)}
           type="text"
           value={value.occupation || ""}
+        />
+        <FormFieldError
+          id="father-occupation"
+          message={fieldErrors.occupation}
         />
       </div>
 

--- a/src/components/forms/register-birth/steps/mothers-details.tsx
+++ b/src/components/forms/register-birth/steps/mothers-details.tsx
@@ -323,25 +323,33 @@ export function MothersDetails({
         </details>
       </div>
 
-      {/* Occupation (optional) */}
+      {/* Occupation */}
       <div>
         <label
           className="mb-2 block font-bold text-[20px] text-neutral-black leading-[150%]"
           htmlFor="mother-occupation"
         >
-          Occupation{" "}
-          <span className="font-normal text-gray-600">(optional)</span>
+          Occupation
         </label>
         <p className="mb-2 text-base text-gray-600">
           This will be included on the child's birth certificate and in official
           records.
         </p>
         <input
+          aria-describedby={
+            fieldErrors.occupation ? "mother-occupation-error" : undefined
+          }
+          aria-invalid={fieldErrors.occupation ? true : undefined}
           className={getFieldClassName("occupation", fieldErrors)}
           id="mother-occupation"
+          onBlur={() => handleBlur("occupation")}
           onChange={(e) => handleChange("occupation", e.target.value)}
           type="text"
           value={value.occupation || ""}
+        />
+        <FormFieldError
+          id="mother-occupation"
+          message={fieldErrors.occupation}
         />
       </div>
 

--- a/src/components/forms/register-birth/steps/tests/fathers-details.tsx
+++ b/src/components/forms/register-birth/steps/tests/fathers-details.tsx
@@ -190,6 +190,7 @@ describe("FathersDetails", () => {
           dateOfBirth: "07/30/1986",
           address: "123 Main St",
           nationalRegistrationNumber: "123456-7890",
+          occupation: "Engineer",
         }}
       />
     );
@@ -284,7 +285,7 @@ describe("FathersDetails", () => {
     expect(dateInput).toHaveAttribute("aria-invalid", "true");
   });
 
-  it("should accept middle name and occupation as optional", () => {
+  it("should accept middle name as optional", () => {
     const onNext = vi.fn();
     render(
       <FathersDetails
@@ -296,6 +297,7 @@ describe("FathersDetails", () => {
           dateOfBirth: "07/30/1986",
           address: "123 Main St",
           nationalRegistrationNumber: "123456-7890",
+          occupation: "Engineer",
         }}
       />
     );
@@ -304,6 +306,64 @@ describe("FathersDetails", () => {
     fireEvent.submit(form!);
 
     expect(onNext).toHaveBeenCalled();
+  });
+
+  it("should show error when occupation is missing", () => {
+    const onNext = vi.fn();
+    render(
+      <FathersDetails
+        {...defaultProps}
+        onNext={onNext}
+        value={{
+          firstName: "John",
+          lastName: "Smith",
+          dateOfBirth: "07/30/1986",
+          address: "123 Main St",
+          nationalRegistrationNumber: "123456-7890",
+          // occupation is missing
+        }}
+      />
+    );
+
+    const form = screen.getByRole("button", { name: /next/i }).closest("form");
+    fireEvent.submit(form!);
+
+    // Should not proceed to next step
+    expect(onNext).not.toHaveBeenCalled();
+
+    // Should display error message (appears in both summary and field)
+    expect(
+      screen.getAllByText("Enter the father's occupation").length
+    ).toBeGreaterThan(0);
+  });
+
+  it("should show error when occupation is empty string", () => {
+    const onNext = vi.fn();
+    render(
+      <FathersDetails
+        {...defaultProps}
+        onNext={onNext}
+        value={{
+          firstName: "John",
+          lastName: "Smith",
+          dateOfBirth: "07/30/1986",
+          address: "123 Main St",
+          nationalRegistrationNumber: "123456-7890",
+          occupation: "",
+        }}
+      />
+    );
+
+    const form = screen.getByRole("button", { name: /next/i }).closest("form");
+    fireEvent.submit(form!);
+
+    // Should not proceed to next step
+    expect(onNext).not.toHaveBeenCalled();
+
+    // Should display error message (appears in both summary and field)
+    expect(
+      screen.getAllByText("Enter the father's occupation").length
+    ).toBeGreaterThan(0);
   });
 
   it("should display placeholder for national registration number", () => {

--- a/src/components/forms/register-birth/steps/tests/mothers-details.tsx
+++ b/src/components/forms/register-birth/steps/tests/mothers-details.tsx
@@ -40,11 +40,11 @@ describe("MothersDetails", () => {
     expect(screen.getByText(/For example, a maiden name/)).toBeInTheDocument();
   });
 
-  it("should render occupation field with optional label", () => {
+  it("should render occupation field as required", () => {
     render(<MothersDetails {...defaultProps} />);
 
     expect(screen.getByText(/Occupation/)).toBeInTheDocument();
-    expect(screen.getByText("(optional)")).toBeInTheDocument();
+    expect(screen.queryByText("(optional)")).not.toBeInTheDocument();
   });
 
   it("should display helper text for middle names", () => {
@@ -114,7 +114,7 @@ describe("MothersDetails", () => {
       ).value
     ).toBe("123456-7890");
 
-    // Occupation label includes "(optional)" text
+    // Occupation field
     const occupationInput = screen.getByLabelText(/Occupation/);
     expect((occupationInput as HTMLInputElement).value).toBe("Teacher");
   });
@@ -271,6 +271,7 @@ describe("MothersDetails", () => {
           dateOfBirth: "07/30/1986",
           address: "123 Main St",
           nationalRegistrationNumber: "123456-7890",
+          occupation: "Teacher",
         }}
       />
     );
@@ -365,7 +366,7 @@ describe("MothersDetails", () => {
     expect(dateInput).toHaveAttribute("aria-invalid", "true");
   });
 
-  it("should accept middle name and occupation as optional", () => {
+  it("should accept middle name as optional", () => {
     const onNext = vi.fn();
     render(
       <MothersDetails
@@ -377,6 +378,7 @@ describe("MothersDetails", () => {
           dateOfBirth: "07/30/1986",
           address: "123 Main St",
           nationalRegistrationNumber: "123456-7890",
+          occupation: "Teacher",
         }}
       />
     );
@@ -385,6 +387,64 @@ describe("MothersDetails", () => {
     fireEvent.submit(form!);
 
     expect(onNext).toHaveBeenCalled();
+  });
+
+  it("should show error when occupation is missing", () => {
+    const onNext = vi.fn();
+    render(
+      <MothersDetails
+        {...defaultProps}
+        onNext={onNext}
+        value={{
+          firstName: "Jane",
+          lastName: "Smith",
+          dateOfBirth: "07/30/1986",
+          address: "123 Main St",
+          nationalRegistrationNumber: "123456-7890",
+          // occupation is missing
+        }}
+      />
+    );
+
+    const form = screen.getByRole("button", { name: /next/i }).closest("form");
+    fireEvent.submit(form!);
+
+    // Should not proceed to next step
+    expect(onNext).not.toHaveBeenCalled();
+
+    // Should display error message (appears in both summary and field)
+    expect(
+      screen.getAllByText("Enter the mother's occupation").length
+    ).toBeGreaterThan(0);
+  });
+
+  it("should show error when occupation is empty string", () => {
+    const onNext = vi.fn();
+    render(
+      <MothersDetails
+        {...defaultProps}
+        onNext={onNext}
+        value={{
+          firstName: "Jane",
+          lastName: "Smith",
+          dateOfBirth: "07/30/1986",
+          address: "123 Main St",
+          nationalRegistrationNumber: "123456-7890",
+          occupation: "",
+        }}
+      />
+    );
+
+    const form = screen.getByRole("button", { name: /next/i }).closest("form");
+    fireEvent.submit(form!);
+
+    // Should not proceed to next step
+    expect(onNext).not.toHaveBeenCalled();
+
+    // Should display error message (appears in both summary and field)
+    expect(
+      screen.getAllByText("Enter the mother's occupation").length
+    ).toBeGreaterThan(0);
   });
 
   it("should check the correct hadOtherSurname radio based on value", () => {
@@ -435,6 +495,7 @@ describe("MothersDetails", () => {
           dateOfBirth: "07/30/1986",
           address: "123 Main St",
           nationalRegistrationNumber: "abc",
+          occupation: "Teacher",
         }}
       />
     );

--- a/src/components/forms/register-birth/tests/schema.ts
+++ b/src/components/forms/register-birth/tests/schema.ts
@@ -348,6 +348,46 @@ describe("motherDetailsValidation", () => {
         expect(addressError?.message).not.toContain("undefined");
       }
     });
+
+    it("should require occupation field", () => {
+      const data = {
+        firstName: "Jane",
+        middleName: "",
+        lastName: "Smith",
+        dateOfBirth: "03/15/1990",
+        address: "123 Main St",
+        nationalRegistrationNumber: "123456-7890",
+        // occupation is missing
+      };
+      const result = motherDetailsValidation.safeParse(data);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const occupationError = result.error.issues.find(
+          (e) => e.path[0] === "occupation"
+        );
+        expect(occupationError?.message).toBe("Enter the mother's occupation");
+      }
+    });
+
+    it("should reject empty occupation string", () => {
+      const data = {
+        firstName: "Jane",
+        middleName: "",
+        lastName: "Smith",
+        dateOfBirth: "03/15/1990",
+        address: "123 Main St",
+        nationalRegistrationNumber: "123456-7890",
+        occupation: "",
+      };
+      const result = motherDetailsValidation.safeParse(data);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const occupationError = result.error.issues.find(
+          (e) => e.path[0] === "occupation"
+        );
+        expect(occupationError?.message).toBe("Enter the mother's occupation");
+      }
+    });
   });
 });
 
@@ -540,6 +580,46 @@ describe("fatherDetailsValidation - undefined field handling", () => {
         expect(error.message).not.toContain("expected string");
         expect(error.message).not.toContain("received undefined");
       }
+    }
+  });
+
+  it("should require occupation field", () => {
+    const data = {
+      firstName: "John",
+      middleName: "Michael",
+      lastName: "Smith",
+      dateOfBirth: "07/30/1986",
+      address: "123 Main St",
+      nationalRegistrationNumber: "123456-7890",
+      // occupation is missing
+    };
+    const result = fatherDetailsValidation.safeParse(data);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const occupationError = result.error.issues.find(
+        (e) => e.path[0] === "occupation"
+      );
+      expect(occupationError?.message).toBe("Enter the father's occupation");
+    }
+  });
+
+  it("should reject empty occupation string", () => {
+    const data = {
+      firstName: "John",
+      middleName: "Michael",
+      lastName: "Smith",
+      dateOfBirth: "07/30/1986",
+      address: "123 Main St",
+      nationalRegistrationNumber: "123456-7890",
+      occupation: "",
+    };
+    const result = fatherDetailsValidation.safeParse(data);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const occupationError = result.error.issues.find(
+        (e) => e.path[0] === "occupation"
+      );
+      expect(occupationError?.message).toBe("Enter the father's occupation");
     }
   });
 });


### PR DESCRIPTION
## Description

  This PR makes occupation fields mandatory for both mother and father in
  the birth registration form, and improves the display of certificate
  costs by showing "Free" instead of "$0.00" when there is no cost.

  **Key Changes:**
  - **Mandatory Occupation Fields**: Both mother's and father's occupation
  fields are now required with proper validation
  - **Enhanced UX**: Payment reminder only shows when there's an actual
  cost

  ## Type of Change
  - [x] Bug fix (occupation field inconsistency, cost display)
  - [x] New feature (mandatory validation for occupation fields)
  - [ ] Breaking change
  - [ ] Documentation update

  ## Changes Made

  ### Schema Updates
  - **`src/components/forms/register-birth/schema.ts`**
    - Added `z.preprocess` to occupation field to handle undefined values
    - Made occupation mandatory with custom error messages per parent type
    - Validates both mother's and father's occupation fields

  ### Component Updates
  - **`src/components/forms/register-birth/steps/mothers-details.tsx`**
    - Removed "(optional)" label from occupation field
    - Added validation handlers (onBlur, aria-invalid, aria-describedby)
    - Added FormFieldError component for inline error display

  - **`src/components/forms/register-birth/steps/fathers-details.tsx`**
    - Added validation handlers (onBlur, aria-invalid, aria-describedby)
    - Added FormFieldError component for inline error display

  ### Test Updates
  - **`src/components/forms/register-birth/tests/schema.ts`**
    - Added 4 new tests for occupation validation (2 per parent)
    - Tests for missing occupation field
    - Tests for empty occupation string

  -
  **`src/components/forms/register-birth/steps/tests/mothers-details.tsx`**
    - Updated test label expectation (no longer expects "(optional)")
    - Added occupation to valid test data
    - Added 2 new tests for occupation error handling
    - Updated 2 existing tests to include occupation in valid data

  -
  **`src/components/forms/register-birth/steps/tests/fathers-details.tsx`**
    - Added occupation to valid test data
    - Added 2 new tests for occupation error handling
    - Updated 1 existing test to include occupation in valid data

  - **`src/components/forms/register-birth/steps/tests/check-answers.tsx`**
    - Updated test to expect "Free" instead of "$0.00"
    - Added new test for 1 certificate displaying "Free"

  - **`src/components/forms/register-birth/steps/tests/confirmation.tsx`**
    - Updated tests to expect "free" instead of "$0.00"
    - Added tests to verify payment reminder doesn't show when cost is zero

  ### Notes

  **Occupation Field Changes:**
  The UI for father's occupation previously appeared as a required field
  but was actually optional in the validation schema. This inconsistency
  has been resolved - both mother's and father's occupation fields are now
  mandatory, matching the importance of this information on official birth
  certificates.


  ## Testing
  - [x] All unit tests passing (101 tests)
  - [x] Schema validation tests added for occupation requirements
  - [x] Component tests updated to reflect mandatory occupation
  - [x] Error handling tests for missing/empty occupation
  - [x] Cost display tests for "Free" formatting
  - [x] Build successful with no TypeScript errors
  - [ ] Visual regression tests added for all device sizes
  - [ ] Verify all pages render correctly
  - [ ] Test responsive layout across device sizes (snapshots created)
  - [x] Check accessibility standards are met (aria attributes added)
  - [ ] Validate markdown formatting renders properly
  - [ ] Test navigation and breadcrumbs

  **Test Commands:**
  ```bash
  npx vitest run                    # All tests pass (101/101)
  npm run build                      # Build successful

  Related Github Issue(s)/Trello Ticket(s)

  Checklist

  - Code follows project style guidelines
  - Self-review completed
  - Tests added/updated (unit tests for occupation validation)
  - Documentation updated
  - All tests passing (101/101)
  - No TypeScript errors
  - Accessibility attributes added (aria-invalid, aria-describedby)
  - Error messages are clear and user-friendly

  This PR description covers all three commits in the branch and provides
  comprehensive details about the changes, testing, and impact.