### PR TITLE
Fix/birth fathers next

### DIFF
--- a/src/components/forms/register-birth/schema.ts
+++ b/src/components/forms/register-birth/schema.ts
@@ -204,6 +204,13 @@ export const marriageStatusValidation = z.object({
   }),
 });
 
+// Include father details validation
+export const includeFatherDetailsValidation = z.object({
+  includeFatherDetails: z.enum(["yes", "no"], {
+    message: "Select yes if you want to include the father's details",
+  }),
+});
+
 // Certificates validation
 export const certificatesValidation = z.object({
   numberOfCertificates: z

--- a/src/components/forms/register-birth/steps/include-father-details.tsx
+++ b/src/components/forms/register-birth/steps/include-father-details.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { Typography } from "@/components/ui/typography";
+import { ErrorSummary } from "../../common/error-summary";
+import { FormFieldError } from "../../common/form-field-error";
 import { useStepFocus } from "../../common/hooks/use-step-focus";
+import { useStepValidation } from "../../common/hooks/use-step-validation";
+import { includeFatherDetailsValidation } from "../schema";
 
 type IncludeFatherDetailsProps = {
   value: "yes" | "no" | "";
@@ -27,15 +31,33 @@ export function IncludeFatherDetails({
 }: IncludeFatherDetailsProps) {
   const titleRef = useStepFocus("Include father's details", "Register a Birth");
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (value) {
-      onNext();
+  // Wrap value in object for validation hook, converting empty string to undefined
+  const formValue = { includeFatherDetails: value === "" ? undefined : value };
+
+  // Wrap onChange to extract includeFatherDetails from object
+  const handleFormChange = (newValue: {
+    includeFatherDetails?: "yes" | "no";
+  }) => {
+    // Only call onChange if value is defined (user made a selection)
+    if (newValue.includeFatherDetails) {
+      onChange(newValue.includeFatherDetails);
     }
   };
 
+  const { errors, fieldErrors, handleChange, handleSubmit } = useStepValidation(
+    {
+      schema: includeFatherDetailsValidation,
+      value: formValue,
+      onChange: handleFormChange,
+      onNext,
+      fieldPrefix: "includeFatherDetails-",
+    }
+  );
+
   return (
     <form className="space-y-6" onSubmit={handleSubmit}>
+      <ErrorSummary errors={errors} />
+
       <div>
         <h1
           className="mb-4 font-bold text-5xl leading-tight focus:outline-none"
@@ -64,11 +86,17 @@ export function IncludeFatherDetails({
         <div className="space-y-3">
           <div className="flex items-start">
             <input
+              aria-describedby={
+                fieldErrors.includeFatherDetails
+                  ? "includeFatherDetails-includeFatherDetails-error"
+                  : undefined
+              }
+              aria-invalid={fieldErrors.includeFatherDetails ? "true" : "false"}
               checked={value === "yes"}
               className="mt-1 size-5 border-2 border-gray-400 text-[#1E787D] focus:ring-2 focus:ring-[#1E787D]"
               id="include-father-yes"
               name="includeFatherDetails"
-              onChange={() => onChange("yes")}
+              onChange={() => handleChange("includeFatherDetails", "yes")}
               type="radio"
               value="yes"
             />
@@ -82,11 +110,17 @@ export function IncludeFatherDetails({
 
           <div className="flex items-start">
             <input
+              aria-describedby={
+                fieldErrors.includeFatherDetails
+                  ? "includeFatherDetails-includeFatherDetails-error"
+                  : undefined
+              }
+              aria-invalid={fieldErrors.includeFatherDetails ? "true" : "false"}
               checked={value === "no"}
               className="mt-1 size-5 border-2 border-gray-400 text-[#1E787D] focus:ring-2 focus:ring-[#1E787D]"
               id="include-father-no"
               name="includeFatherDetails"
-              onChange={() => onChange("no")}
+              onChange={() => handleChange("includeFatherDetails", "no")}
               type="radio"
               value="no"
             />
@@ -98,6 +132,11 @@ export function IncludeFatherDetails({
             </label>
           </div>
         </div>
+
+        <FormFieldError
+          id="includeFatherDetails-includeFatherDetails"
+          message={fieldErrors.includeFatherDetails}
+        />
       </fieldset>
 
       <div className="flex gap-4">
@@ -110,8 +149,7 @@ export function IncludeFatherDetails({
         </button>
 
         <button
-          className="rounded bg-[#1E787D] px-6 py-3 font-normal text-neutral-white text-xl transition-all hover:bg-[#1E787D]/90 disabled:cursor-not-allowed disabled:bg-gray-400"
-          disabled={!value}
+          className="rounded bg-[#1E787D] px-6 py-3 font-normal text-neutral-white text-xl transition-all hover:bg-[#1E787D]/90"
           type="submit"
         >
           Next

--- a/src/components/forms/register-birth/steps/tests/include-father-details.tsx
+++ b/src/components/forms/register-birth/steps/tests/include-father-details.tsx
@@ -67,25 +67,38 @@ describe("IncludeFatherDetails", () => {
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 
-  it("should disable Next button when no selection is made", () => {
+  it("should show validation error when Next button is clicked without selection", () => {
     render(<IncludeFatherDetails {...defaultProps} value="" />);
 
     const nextButton = screen.getByRole("button", { name: /next/i });
-    expect(nextButton).toBeDisabled();
+    fireEvent.click(nextButton);
+
+    // Check that error appears in both error summary and field error
+    expect(
+      screen.getAllByText(
+        "Select yes if you want to include the father's details"
+      )
+    ).toHaveLength(2);
   });
 
-  it("should enable Next button when Yes is selected", () => {
+  it("should not show validation error when Yes is selected", () => {
     render(<IncludeFatherDetails {...defaultProps} value="yes" />);
 
-    const nextButton = screen.getByRole("button", { name: /next/i });
-    expect(nextButton).not.toBeDisabled();
+    expect(
+      screen.queryByText(
+        "Select yes if you want to include the father's details"
+      )
+    ).not.toBeInTheDocument();
   });
 
-  it("should enable Next button when No is selected", () => {
+  it("should not show validation error when No is selected", () => {
     render(<IncludeFatherDetails {...defaultProps} value="no" />);
 
-    const nextButton = screen.getByRole("button", { name: /next/i });
-    expect(nextButton).not.toBeDisabled();
+    expect(
+      screen.queryByText(
+        "Select yes if you want to include the father's details"
+      )
+    ).not.toBeInTheDocument();
   });
 
   it("should check the correct radio button based on value prop", () => {
@@ -138,8 +151,14 @@ describe("IncludeFatherDetails", () => {
     const nextButton = screen.getByRole("button", { name: /next/i });
     fireEvent.click(nextButton);
 
-    // Button is disabled, so click should not trigger onNext
+    // Validation should prevent onNext from being called
     expect(onNext).not.toHaveBeenCalled();
+    // And should show validation error (appears in both error summary and field error)
+    expect(
+      screen.getAllByText(
+        "Select yes if you want to include the father's details"
+      )
+    ).toHaveLength(2);
   });
 
   it("should have accessible form structure", () => {


### PR DESCRIPTION
## Description

  Fixed inconsistent form validation behavior on the "include father's
  details" page. The Next button was disabled until a selection was made,
  which differed from other form steps that show validation errors when
  Next is clicked without input.

  **Before:** Next button disabled until user selects an option
  **After:** Next button always enabled, validation error displayed on
  submit without selection

  This change provides a consistent user experience across all form steps
  and improves accessibility by allowing screen readers to announce
  validation errors.

  ## Type of Change
  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Documentation update

  ## Changes Made

  ### `src/components/forms/register-birth/schema.ts`
  **Why:** Add validation schema for the include father details field

  - Added `includeFatherDetailsValidation` schema with custom error message
  - Follows same pattern as `marriageStatusValidation` for consistency

  ###
  `src/components/forms/register-birth/steps/include-father-details.tsx`
  **Why:** Implement proper validation instead of disabled button approach

  - Integrated `useStepValidation` hook for form validation
  - Added `ErrorSummary` component to display errors at top of form
  - Added `FormFieldError` component below radio buttons for inline errors
  - Removed `disabled={!value}` attribute from Next button
  - Added ARIA attributes (`aria-describedby`, `aria-invalid`) to radio
  inputs for accessibility
  - Updated radio button handlers to use `handleChange` from validation
  hook
  - Wrapped value/onChange in adapter functions for hook compatibility

  ### `src/components/forms/register-birth/steps/tests/include-father-detai
  ls.tsx`
  **Why:** Update tests to reflect new validation behavior

  - Changed "disabled button" tests to "validation error" tests
  - Updated assertions to check for validation error text instead of
  disabled attribute
  - Tests now verify error appears in both ErrorSummary and FormFieldError
  (2 instances)
  - Updated "prevent form submission" test to verify validation error is
  shown

  ### Notes
  - Maintains backward compatibility with existing form flows
  - No changes to data model or submission logic
  - Follows established validation patterns from marriage-status component
  - Error message appears twice (error summary + inline) following GOV.UK
  design pattern for better accessibility

  ## Testing
  - [x] All 396 unit tests passing (Vitest)
  - [x] Manual testing completed:
    - [x] Click Next without selection shows validation error
    - [x] Error appears in both error summary and inline
    - [x] Selecting an option clears the error
    - [x] Form submission works correctly with valid selection
    - [x] Back button continues to work
  - [ ] Visual regression tests added for all device sizes (N/A - behavior
  change only, no visual changes)
  - [x] Verify all pages render correctly
  - [ ] Test responsive layout across device sizes (N/A - no layout
  changes)
  - [x] Check accessibility standards are met (improved with ARIA
  attributes)
  - [ ] Validate markdown formatting renders properly (N/A - no markdown
  changes)
  - [ ] Test navigation and breadcrumbs (navigation tested, no changes to
  breadcrumbs)

  ## Related Github Issue(s)/Trello Ticket(s)
Fixes: https://github.com/govtech-bb/frontend-alpha/issues/156

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-review completed
  - [x] Tests added/updated (3 tests updated to verify validation behavior)
  - [x] Documentation updated (inline comments added explaining adapter
  functions)