### PR TITLE
fix: correct font to use Figtree instead of fallback sans-serif

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,8 @@
 /* @custom-variant dark (&:is(.dark *)); */
 
 @theme inline {
+  --font-sans: var(--font-figtree);
+
   /* Yellow */
   --color-yellow-dark: hsla(39, 80%, 55%, 1);
   --color-yellow-bright: hsla(45, 100%, 57%, 1);

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -1,11 +1,7 @@
-import { Figtree, Inter } from "next/font/google";
+import { Figtree } from "next/font/google";
 
 export const figtree = Figtree({
   subsets: ["latin"],
   variable: "--font-figtree",
-});
-
-export const inter = Inter({
-  subsets: ["latin"],
-  variable: "--font-inter",
+  display: "swap",
 });


### PR DESCRIPTION
## Description
Fixed font configuration to ensure Figtree font is properly applied throughout the application instead of falling back to the default sans-serif. 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

`src/app/globals.css`

  - Added --font-sans: var(--font-figtree) to the theme configuration to properly wire up the    
   Figtree font as the default sans-serif font

 `src/app/layout.tsx`

  - Moved figtree.variable class from <body> to <html> element for proper CSS variable
  scoping
  - Cleaned up className to use direct font-sans utility without manual variable
  interpolation

  `src/lib/fonts.ts`

  - Removed unused Inter font import and configuration
  - Added display: "swap" to Figtree font for better performance (prevents invisible text        
  during font loading)

### Notes
This fix ensures that the font-sans Tailwind utility correctly references the Figtree font family. Previously, the CSS variable wasn't properly defined, causing the app to fall back to the browser's default sans-serif font. 

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->


## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
