### PR TITLE
fix: skip father validation when details not included

### DIFF
--- a/src/components/forms/register-birth/tests/schema.test.ts
+++ b/src/components/forms/register-birth/tests/schema.test.ts
@@ -3,6 +3,7 @@ import {
   childDetailsValidation,
   contactInfoValidation,
   fatherDetailsValidation,
+  finalSubmissionSchema,
   motherDetailsValidation,
 } from "../schema";
 
@@ -524,6 +525,151 @@ describe("contactInfoValidation", () => {
         );
         expect(error?.message).toBe("Enter a valid email address");
       }
+    });
+  });
+});
+
+describe("finalSubmissionSchema", () => {
+  describe("when father details are included", () => {
+    it("should require valid father details when includeFatherDetails is yes", () => {
+      const data = {
+        includeFatherDetails: "yes",
+        mother: {
+          firstName: "Jane",
+          lastName: "Smith",
+          dateOfBirth: "1990-03-15",
+          address: "123 Main St",
+          nationalRegistrationNumber: "123456-7890",
+          occupation: "Teacher",
+        },
+        child: {
+          firstNames: "John",
+          lastName: "Smith",
+          dateOfBirth: "2024-10-22",
+          sexAtBirth: "Male",
+          parishOfBirth: "St. Michael",
+        },
+        email: "test@example.com",
+        // father is missing but required
+      };
+      const result = finalSubmissionSchema.safeParse(data);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const fatherError = result.error.issues.find((e) =>
+          e.path.includes("father")
+        );
+        expect(fatherError).toBeDefined();
+      }
+    });
+
+    it("should require valid father details when marriageStatus is yes", () => {
+      const data = {
+        marriageStatus: "yes",
+        mother: {
+          firstName: "Jane",
+          lastName: "Smith",
+          dateOfBirth: "1990-03-15",
+          address: "123 Main St",
+          nationalRegistrationNumber: "123456-7890",
+          occupation: "Teacher",
+        },
+        child: {
+          firstNames: "John",
+          lastName: "Smith",
+          dateOfBirth: "2024-10-22",
+          sexAtBirth: "Male",
+          parishOfBirth: "St. Michael",
+        },
+        email: "test@example.com",
+        // father is missing but required
+      };
+      const result = finalSubmissionSchema.safeParse(data);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const fatherError = result.error.issues.find((e) =>
+          e.path.includes("father")
+        );
+        expect(fatherError).toBeDefined();
+      }
+    });
+  });
+
+  describe("when father details are excluded", () => {
+    it("should accept valid data when includeFatherDetails is no", () => {
+      const data = {
+        includeFatherDetails: "no",
+        mother: {
+          firstName: "Jane",
+          lastName: "Smith",
+          dateOfBirth: "1990-03-15",
+          address: "123 Main St",
+          nationalRegistrationNumber: "123456-7890",
+          occupation: "Teacher",
+        },
+        child: {
+          firstNames: "John",
+          lastName: "Smith",
+          dateOfBirth: "2024-10-22",
+          sexAtBirth: "Male",
+          parishOfBirth: "St. Michael",
+        },
+        email: "test@example.com",
+        // father is not provided and should not be required
+      };
+      const result = finalSubmissionSchema.safeParse(data);
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept data with empty father object when includeFatherDetails is no", () => {
+      const data = {
+        includeFatherDetails: "no",
+        father: {
+          // Empty father object - should be ignored
+        },
+        mother: {
+          firstName: "Jane",
+          lastName: "Smith",
+          dateOfBirth: "1990-03-15",
+          address: "123 Main St",
+          nationalRegistrationNumber: "123456-7890",
+          occupation: "Teacher",
+        },
+        child: {
+          firstNames: "John",
+          lastName: "Smith",
+          dateOfBirth: "2024-10-22",
+          sexAtBirth: "Male",
+          parishOfBirth: "St. Michael",
+        },
+        email: "test@example.com",
+      };
+      const result = finalSubmissionSchema.safeParse(data);
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept valid data when marriageStatus is no", () => {
+      const data = {
+        marriageStatus: "no",
+        includeFatherDetails: "no",
+        mother: {
+          firstName: "Jane",
+          lastName: "Smith",
+          dateOfBirth: "1990-03-15",
+          address: "123 Main St",
+          nationalRegistrationNumber: "123456-7890",
+          occupation: "Teacher",
+        },
+        child: {
+          firstNames: "John",
+          lastName: "Smith",
+          dateOfBirth: "2024-10-22",
+          sexAtBirth: "Male",
+          parishOfBirth: "St. Michael",
+        },
+        email: "test@example.com",
+      };
+      const result = finalSubmissionSchema.safeParse(data);
+      expect(result.success).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Fixed validation bug where users received an error on the check-answers page when they selected "no" to include father's details. The schema was attempting to validate empty/partial father data even when not required.

Changes:
- Added superRefine to finalSubmissionSchema for conditional validation
- Father details only validated when marriageStatus=yes OR includeFatherDetails=yes
- Empty father objects ignored when father details not required
- Added comprehensive test coverage for finalSubmissionSchema (5 new tests)

All 435 unit tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

  Fixed a validation bug where users received an error on the check-answers
  page when they selected "no" to include father's details. The issue
  occurred because the validation schema was attempting to validate empty or
   partial father data objects even when father details were explicitly
  marked as not required.

  The fix implements conditional validation that only checks father details
  when they are actually required (i.e., when parents were married OR when
  user chose to include father details).

  ## Type of Change
  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Documentation update

  ## Changes Made

  ### `src/components/forms/register-birth/schema.ts`
  - Modified `finalSubmissionSchema` to use `.superRefine()` for conditional
   validation logic
  - Changed father field from `fatherDetailsValidation.optional()` to
  `personDetailsSchema.optional()`
  - Added conditional validation that only applies `fatherDetailsValidation`
   when:
    - `marriageStatus === "yes"` OR
    - `includeFatherDetails === "yes"`
  - Empty/partial father objects are now ignored when father details are not
   required

  ### `src/components/forms/register-birth/tests/schema.test.ts`
  - Added `finalSubmissionSchema` to imports
  - Added 5 comprehensive test cases covering:
    - Father details required when `includeFatherDetails === "yes"`
    - Father details required when `marriageStatus === "yes"`
    - Valid submission when `includeFatherDetails === "no"` (no father
  object)
    - Valid submission when `includeFatherDetails === "no"` (with empty
  father object) - **this is the bug scenario**
    - Valid submission when both marriage status and include father details
  are "no"

  ### Notes
  The ultracite pre-commit hook auto-fixed 1 file during commit
  (formatting).

  ## Testing
  - [x] All 435 unit tests passing
  - [x] New test cases specifically cover the reported bug scenario
  - [x] Test validates empty father objects are ignored when not required
  - [x] Test validates father details are still enforced when required
  - [ ] Visual regression tests added for all device sizes
  - [ ] Verify all pages render correctly
  - [ ] Test responsive layout across device sizes (snapshots created)
  - [ ] Check accessibility standards are met
  - [ ] Validate markdown formatting renders properly
  - [ ] Test navigation and breadcrumbs

  ## Related Github Issue(s)/Trello Ticket(s)
  <!-- No issue number provided - bug reported via user testing -->

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-review completed
  - [x] Tests added/updated (5 new unit tests for finalSubmissionSchema)
  - [x] Documentation updated (inline comments explaining conditional logic)


