### PR TITLE
Fix: Styling of link in markdown content to appear as a button

### DIFF
--- a/src/content/register-a-birth/start.md
+++ b/src/content/register-a-birth/start.md
@@ -11,7 +11,7 @@ To complete the registration, the parent(s) or guardian(s) must then visit the R
 <!-- Add custom html button to allow necessary styling -->
 <!-- TODO: Make this file MDX so that the Button component can be imported -->
 
-<a href="/family-birth-relationships/register-a-birth/form" className='relative inline-flex items-center justify-center gap-2 rounded-sm text-body whitespace-nowrap transition-[background-color,box-shadow] duration-200 outline-none disabled-state px-6 py-4 bg-teal-dark text-neutral-white hover:bg-brand-teal-light hover:shadow-[inset_0_0_0_4px_rgba(222,245,246,0.10)] active:bg-brand-teal-darker active:shadow-[inset_0_0_0_3px_rgba(0,0,0,0.20)] active:outline-none active:ring-4 active:ring-teal-100 active:ring-offset-1 active:rounded-sm focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-teal-100 focus-visible:ring-offset-1 focus-visible:rounded-sm' target="_self">Start now</a>
+<a href="/family-birth-relationships/register-a-birth/form" className='relative inline-flex items-center justify-center gap-2 rounded-sm text-body whitespace-nowrap transition-[background-color,box-shadow] duration-200 outline-none disabled-state px-6 py-4 bg-teal-dark !text-neutral-white hover:bg-brand-teal-light hover:shadow-[inset_0_0_0_4px_rgba(222,245,246,0.10)] active:bg-brand-teal-darker active:shadow-[inset_0_0_0_3px_rgba(0,0,0,0.20)] active:outline-none active:ring-4 active:ring-teal-100 active:ring-offset-1 active:rounded-sm focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-teal-100 focus-visible:ring-offset-1 focus-visible:rounded-sm no-underline' target="_self">Start now</a>
 
 ## Information you need for pre-registering a birth online
 

--- a/src/content/register-for-community-sports-training-programme/start.md
+++ b/src/content/register-for-community-sports-training-programme/start.md
@@ -8,7 +8,7 @@ Lorem ipsum
 <!-- Add custom html button to allow necessary styling -->
 <!-- TODO: Make this file MDX so that the Button component can be imported -->
 
-<a href="/work-employment/register-for-community-sports-training-programme/form" className='relative inline-flex items-center justify-center gap-2 rounded-sm text-body whitespace-nowrap transition-[background-color,box-shadow] duration-200 outline-none disabled-state px-6 py-4 bg-teal-dark text-neutral-white hover:bg-brand-teal-light hover:shadow-[inset_0_0_0_4px_rgba(222,245,246,0.10)] active:bg-brand-teal-darker active:shadow-[inset_0_0_0_3px_rgba(0,0,0,0.20)] active:outline-none active:ring-4 active:ring-teal-100 active:ring-offset-1 active:rounded-sm focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-teal-100 focus-visible:ring-offset-1 focus-visible:rounded-sm' target="_self">Start now</a>
+<a href="/work-employment/register-for-community-sports-training-programme/form" className='relative inline-flex items-center justify-center gap-2 rounded-sm text-body whitespace-nowrap transition-[background-color,box-shadow] duration-200 outline-none disabled-state px-6 py-4 bg-teal-dark !text-neutral-white hover:bg-brand-teal-light hover:shadow-[inset_0_0_0_4px_rgba(222,245,246,0.10)] active:bg-brand-teal-darker active:shadow-[inset_0_0_0_3px_rgba(0,0,0,0.20)] active:outline-none active:ring-4 active:ring-teal-100 active:ring-offset-1 active:rounded-sm focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-teal-100 focus-visible:ring-offset-1 focus-visible:rounded-sm no-underline' target="_self">Start now</a>
 
 ## Information you need 
 


### PR DESCRIPTION
## Description
<!-- Summarize the changes based on added/changed functionality -->
This fixes a regression where the "Start now" button no longer matched the Figma since it is being styled as a link. This PR overrides some of that styling for this button

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->
Fixes #219 

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
