### PR TITLE
fix: remove container padding on confirmation pages

### DIFF
--- a/src/components/forms/builder/confirmation-step.tsx
+++ b/src/components/forms/builder/confirmation-step.tsx
@@ -1,7 +1,8 @@
 "use client";
-import { Button, Link } from "@govtech-bb/react";
+import { Button, Heading, Link, Text } from "@govtech-bb/react";
 import NextLink from "next/link";
 import { ChevronLeftSVG } from "@/components/icons/chevron-left";
+import { HelpfulBox } from "@/components/layout/helpful-box";
 
 type ConfirmationPageProps = {
   referenceNumber?: string;
@@ -17,33 +18,35 @@ export function ConfirmationPage({
     <>
       {/* Header section with breadcrumb and title */}
       <div className="bg-green-40">
-        <div className="container pt-4 pb-8">
+        <div className="container pt-4 pb-8 lg:pt-0">
           {/* Breadcrumb */}
-          <div className="flex items-center">
-            <div className="flex items-center gap-x-2">
-              <ChevronLeftSVG className="shrink-0" />
+          <div className="container lg:py-4">
+            <div className="flex items-center">
+              <div className="flex items-center gap-x-2">
+                <ChevronLeftSVG className="shrink-0" />
 
-              <Link
-                as={NextLink}
-                className="text-[20px] leading-normal lg:gap-3 lg:text-[1.5rem] lg:leading-[2rem]"
-                href="#"
-                variant={"secondary"}
-              >
-                Family, birth and relationships
-              </Link>
+                <Link
+                  as={NextLink}
+                  className="text-[20px] leading-normal lg:gap-3 lg:text-[1.5rem] lg:leading-[2rem]"
+                  href="#"
+                  variant={"secondary"}
+                >
+                  Family, birth and relationships
+                </Link>
+              </div>
             </div>
           </div>
 
           {/* Title section */}
           <div className="flex flex-col gap-4 pt-6 lg:pt-16">
-            <h1
-              className="pt-2 font-bold text-[56px] text-black leading-[1.15] focus:outline-none"
-              tabIndex={-1}
-            >
+            <Heading className="focus:outline-none" size="h1" tabIndex={-1}>
               Application submitted
-            </h1>
+            </Heading>
+            {/* <h1 className="pt-2 font-bold text-[56px] text-black leading-[1.15]">
+              Application submitted
+            </h1> */}
 
-            <p className="font-normal text-[20px] text-black leading-[1.7] lg:text-[32px] lg:leading-[1.5]">
+            <p className="font-normal text-[32px] text-neutral-black leading-[1.7] lg:leading-[1.5]">
               Your information has been sent to {submittedTo}.
             </p>
           </div>
@@ -51,19 +54,26 @@ export function ConfirmationPage({
       </div>
       {/* Main content */}
 
-      <div className="container space-y-6 py-4 lg:grid lg:grid-cols-3 lg:space-y-8 lg:pt-8 lg:pb-16">
+      <div className="container space-y-6 py-4 lg:grid lg:grid-cols-3 lg:space-y-8 lg:py-8">
         <div className="col-span-2 space-y-6 lg:space-y-8">
           {/* What to do next */}
-          <div className="pt-2">
-            <h2 className="mb-4 font-bold text-[40px] text-black leading-[1.25]">
-              Header
-            </h2>
-            <div className="space-y-4 font-normal text-[20px] text-black leading-[1.7]">
-              <p>Content</p>
-              <p>Content</p>
-            </div>
+
+          <div>
+            <Heading as="h2" className="pb-4 lg:pb-2">
+              Sub heading
+            </Heading>
+            <Text as="p">Content</Text>
           </div>
+          <div>
+            <Heading as="h3" className="pb-4 lg:pb-2">
+              Sub heading
+            </Heading>
+            <Text as="p">Content</Text>
+          </div>
+
           <Button onClick={onReset}>Start Over</Button>
+
+          <HelpfulBox />
         </div>
       </div>
     </>

--- a/src/components/layout/entry-point-wrapper.tsx
+++ b/src/components/layout/entry-point-wrapper.tsx
@@ -18,7 +18,7 @@ export function EntryPointWrapper({ children }: EntryPointWrapperProps) {
   const searchParams = useSearchParams();
   const pathSegments = pathname.split("/").filter(Boolean);
   const isFormPage = pathSegments.includes("form");
-  const isConfirmationPage = searchParams.get("step") === "check-answers";
+  const isConfirmationPage = searchParams.get("step") === "review";
   const isFeedbackPage = pathname === "/feedback";
 
   return (
@@ -29,12 +29,7 @@ export function EntryPointWrapper({ children }: EntryPointWrapperProps) {
         </div>
       )}
       {isConfirmationPage ? (
-        <div className="pb-8 lg:pb-8">
-          {children}
-          <div className="container">
-            <HelpfulBox />
-          </div>
-        </div>
+        children
       ) : (
         <div
           className={cn(


### PR DESCRIPTION
## Description

Fixed incorrect padding on confirmation pages by updating the `EntryPointWrapper` to render confirmation pages without the container padding wrapper, allowing them to control their own spacing according to Figma design spec.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

`src/components/layout/entry-point-wrapper.tsx`
  - Added confirmation page detection: Check for `step=review` query parameter to identify confirmation pages
   - Conditional rendering: Render children directly for confirmation pages without the container div wrapper

##   Root Cause

The EntryPointWrapper was applying a container `div` with padding to all pages, including confirmation page. This global padding conflicted with the confirmation page's own spacing requirements from the Figma design. 

### Notes

Visual regression is currently broken, so I’ve skipped generating snapshots for now.

## Testing
- [ ] Visual regression tests added for all device sizes
- [x] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [x] Validate markdown formatting renders properly
- [x] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
Fixes #226 

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
