### PR TITLE
fix: prevent long page titles from causing horizontal overflow

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -95,3 +95,8 @@
   grid-template-columns: 2fr 1fr;
   gap: 2rem;
 }
+
+@utility break-anywhere {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}

--- a/src/components/markdown-content.tsx
+++ b/src/components/markdown-content.tsx
@@ -126,7 +126,11 @@ export const MarkdownContent = ({
     <div className="lg:grid lg:grid-cols-3 lg:gap-16">
       <div className="space-y-6 lg:col-span-2 lg:space-y-8">
         <div className="space-y-4 lg:space-y-6">
-          {frontmatter.title && <Heading as="h1">{frontmatter.title}</Heading>}
+          {frontmatter.title && (
+            <Heading as="h1" className="break-anywhere">
+              {frontmatter.title}
+            </Heading>
+          )}
 
           {frontmatter.stage?.length > 0 ? (
             <StageBanner stage={frontmatter.stage} />


### PR DESCRIPTION
## Description
<!-- Summarize the changes based on added/changed functionality --><!-- Summarize the changes based on added/changed functionality -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->


## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
