### PR TITLE
fix: show error messages for all dynamic field array items

### DIFF
--- a/src/components/forms/builder/dynamic-field-array.tsx
+++ b/src/components/forms/builder/dynamic-field-array.tsx
@@ -150,15 +150,11 @@ export function DynamicFieldArray({ field }: DynamicFieldArrayProps) {
         return (
           <div className="flex flex-col gap-2" key={item.id}>
             <div className="flex items-end gap-2">
-              <div className="flex-1">
+              <div className={`flex-1 ${index > 0 ? "[&_label]:sr-only" : ""}`}>
                 <Input
                   error={itemError?.message}
                   id={`${field.name}-${index}`}
-                  label={
-                    index === 0
-                      ? fieldArrayConfig?.itemLabel || field.label
-                      : undefined
-                  }
+                  label={fieldArrayConfig?.itemLabel || field.label}
                   placeholder={field.placeholder}
                   type="text"
                   {...register(fieldName)}


### PR DESCRIPTION
## Description
Previously, only the first field in a dynamic field array displayed validation error messages. Subsequent fields showed the error state (red border) but no error message label. This was caused by conditionally removing the label prop for non-first items, which prevented the Input component from rendering error messages.

Now all items always receive a label, with non-first items using `sr-only` to visually hide the label while maintaining accessibility.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
Fixes #225 


## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated