### PR TITLE
fix: escape dots in CSS selectors for error summary links

### DIFF
--- a/src/components/forms/builder/dynamic-step.tsx
+++ b/src/components/forms/builder/dynamic-step.tsx
@@ -35,10 +35,12 @@ export function DynamicStep({ step, serviceTitle }: DynamicStepProps) {
       }
 
       if (field) {
+        const escapedSelector = `#${CSS.escape(fieldName)}`;
+
         // If it's a field error with a direct message
         if (error && "message" in error && typeof error.message === "string") {
           return {
-            target: `#${fieldName}`,
+            target: escapedSelector,
             text: error.message,
           };
         }
@@ -50,7 +52,7 @@ export function DynamicStep({ step, serviceTitle }: DynamicStepProps) {
             (typeof error === "object" && Object.keys(error).length > 0))
         ) {
           return {
-            target: `#${fieldName}`,
+            target: escapedSelector,
             text: field.validation.required || "This field is required",
           };
         }

--- a/src/components/forms/builder/multi-step-form.tsx
+++ b/src/components/forms/builder/multi-step-form.tsx
@@ -780,7 +780,8 @@ export default function DynamicMultiStepForm({
           )
         );
         if (firstErrorField) {
-          const element = document.querySelector(`#${String(firstErrorField)}`);
+          const escapedSelector = `#${CSS.escape(firstErrorField)}`;
+          const element = document.querySelector(escapedSelector);
           if (element) {
             element.scrollIntoView({ behavior: "smooth", block: "center" });
           }


### PR DESCRIPTION
## Description
<!-- Summarize the changes based on added/changed functionality --><!-- Summarize the changes based on added/changed functionality -->

Field names with dot notation (e.g. applicant.firstName) were breaking error summary links because dots are interpreted as class selectors in CSS.

  - Escape dots in error targets in `dynamic-step.tsx`
  - Escape dots in querySelector in `multi-step-form.tsx`

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->
Fixes #286 

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
