### PR TITLE
fix: only apply flag to pages with protected prop

### DIFF
--- a/src/app/(content)/[...slug]/page.tsx
+++ b/src/app/(content)/[...slug]/page.tsx
@@ -6,7 +6,11 @@ import { MarkdownContent } from "@/components/markdown-content";
 import { Typography } from "@/components/ui/typography";
 import { INFORMATION_ARCHITECTURE } from "@/data/content-directory";
 import { getMarkdownContent } from "@/lib/markdown";
-import { hasResearchAccess, isProtectedSubpage } from "@/lib/research-access";
+import {
+  hasResearchAccess,
+  isProtectedSubpage,
+  hasProtectedSubpages,
+} from "@/lib/research-access";
 import { findSubPageTitleFromPath } from "@/lib/utils";
 
 type ContentPageProps = {
@@ -82,8 +86,11 @@ export default async function Page({ params }: ContentPageProps) {
       notFound();
     }
 
-    // Check if user has research access cookie to show/hide start page links
-    const hasAccess = await hasResearchAccess();
+    // Only check research access for pages with protected subpages
+    // For non-protected pages, always show /start links
+    const hasAccess = hasProtectedSubpages(page)
+      ? await hasResearchAccess()
+      : true;
 
     return (
       <MarkdownContent
@@ -109,8 +116,11 @@ export default async function Page({ params }: ContentPageProps) {
       notFound();
     }
 
-    // Check research access once for both protected pages and hiding start links
-    const hasAccess = await hasResearchAccess();
+    // Only check research access if this page has protected subpages
+    const pageHasProtectedSubpages = hasProtectedSubpages(page);
+    const hasAccess = pageHasProtectedSubpages
+      ? await hasResearchAccess()
+      : true;
 
     // Protected subpages require research access
     if (isProtectedSubpage(page, subPageSlug) && !hasAccess) {

--- a/src/lib/research-access.ts
+++ b/src/lib/research-access.ts
@@ -31,3 +31,10 @@ export function isProtectedSubpage(
   const subPage = page.subPages?.find((sp) => sp.slug === subPageSlug);
   return subPage?.protected === true;
 }
+
+/**
+ * Check if a page has any protected subpages
+ */
+export function hasProtectedSubpages(page: PageType): boolean {
+  return page.subPages?.some((p) => p.protected === true) ?? false;
+}


### PR DESCRIPTION
## Description
<!-- Summarize the changes based on added/changed functionality --><!-- Summarize the changes based on added/changed functionality -->

Previously, the feature flag check was applied to ALL content pages, causing /start links to be hidden on every service page when users didn't have the access cookie. This should only happen for pages that have `protected: true`.

Added `hasProtectedSubpages()` helper and updated the page logic to only check research access when the page actually has protected content.

## Type of Change
- [x] Bug fix (Feature Flagging)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->
Fixes #305

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
