### PR TITLE
refactor: update birth registration forms and components

### DIFF
--- a/src/components/forms/register-birth/schema.ts
+++ b/src/components/forms/register-birth/schema.ts
@@ -166,18 +166,13 @@ function createPersonDetailsSchema(personType: "father" | "mother") {
       ),
       hadOtherSurname: z.enum(["yes", "no", ""]).optional(),
       otherSurname: z.string().optional(),
-      dateOfBirth: dateValidation.past(
-        dateValidation.required(
-          createDateSchema(`${personType}'s date of birth`),
-          `${personType}'s date of birth`
-        ),
-        `${personType}'s date of birth`
-      ),
-
-      address: z.preprocess(
-        (val) => val ?? "",
-        z.string().min(1, `Enter the ${personType}'s current address`)
-      ),
+      dateOfBirth: dateInputValueSchema.optional(),
+      address: z.string().optional(),
+      parish: z.string().optional(),
+      streetAddress: z.string().optional(),
+      maidenName: z.string().optional(),
+      telephoneNumber: z.string().optional(),
+      emailAddress: z.string().email("Enter a valid email address").optional(),
       nationalRegistrationNumber: z.string().optional(),
       passportNumber: z.string().optional(),
       passportPlaceOfIssue: z.string().optional(),
@@ -216,10 +211,7 @@ export const childDetailsValidation = z.object({
   sexAtBirth: z.enum(["Male", "Female"], {
     message: "Select the child's sex at birth",
   }),
-  parishOfBirth: z.preprocess(
-    (val) => val ?? "",
-    z.string().min(1, "Enter the child's place of birth")
-  ),
+  parishOfBirth: z.string().optional(),
 });
 
 // Marriage status validation

--- a/src/components/forms/register-birth/steps/child-details.tsx
+++ b/src/components/forms/register-birth/steps/child-details.tsx
@@ -6,8 +6,7 @@ import {
   DateInput,
   ErrorSummary,
   Input,
-  Radio,
-  RadioGroup,
+  Select,
 } from "@govtech-bb/react";
 import { useStepFocus } from "../../common/hooks/use-step-focus";
 import { useStepValidation } from "../../common/hooks/use-step-validation";
@@ -125,63 +124,23 @@ export function ChildDetails({
             value={value.dateOfBirth}
           />
 
-          {/* Sex at birth */}
-          <fieldset>
-            <legend className="font-bold text-[24px]">Sex at birth</legend>
-            <p className="mb-4 text-[20px] leading-[1.7]">
-              We ask this so that we can monitor population trends.
-            </p>
-            {fieldErrors.sexAtBirth && (
-              <p className="mb-4 text-red-600" id="child-sexAtBirth-error">
-                {fieldErrors.sexAtBirth}
-              </p>
-            )}
-            <RadioGroup
-              aria-describedby={
-                fieldErrors.sexAtBirth ? "child-sexAtBirth-error" : undefined
-              }
-              aria-invalid={!!fieldErrors.sexAtBirth}
-              aria-label="Sex at birth"
-              onValueChange={(val) =>
-                handleChange("sexAtBirth", val as "Male" | "Female")
-              }
-              value={value.sexAtBirth || undefined}
-            >
-              <Radio id="child-sexAtBirth-male" label="Male" value="Male" />
-              <Radio
-                id="child-sexAtBirth-female"
-                label="Female"
-                value="Female"
-              />
-            </RadioGroup>
-          </fieldset>
-
-          {/* Place of birth */}
-          <div>
-            <label
-              className="block font-bold text-[20px] leading-[1.7]"
-              htmlFor="child-parishOfBirth"
-            >
-              Place of birth
-            </label>
-            <div className="mb-2 text-[20px] leading-[1.7]">
-              <p className="mb-4">
-                Include the town and parish in your answer.
-              </p>
-              <p>
-                For example, Queen Elizabeth Hospital, Bridgetown, St. Michael.
-                <br />
-                Or a home address if they were born at home.
-              </p>
-            </div>
-            <Input
-              error={fieldErrors.parishOfBirth}
-              id="child-parishOfBirth"
-              onChange={(e) => handleChange("parishOfBirth", e.target.value)}
-              type="text"
-              value={value.parishOfBirth || ""}
-            />
-          </div>
+          {/* Sex */}
+          <Select
+            error={fieldErrors.sexAtBirth}
+            id="child-sexAtBirth"
+            label="Sex"
+            onChange={(e) =>
+              handleChange("sexAtBirth", e.target.value as "Male" | "Female")
+            }
+            value={value.sexAtBirth || ""}
+          >
+            <option key="male" value="Male">
+              Male
+            </option>
+            <option key="female" value="Female">
+              Female
+            </option>
+          </Select>
         </div>
         <div className="flex gap-4">
           <Button onClick={onBack} type="button" variant="secondary">

--- a/src/components/forms/register-birth/steps/fathers-details.tsx
+++ b/src/components/forms/register-birth/steps/fathers-details.tsx
@@ -3,12 +3,13 @@
 import type { ErrorItem } from "@govtech-bb/react";
 import {
   Button,
-  DateInput,
   ErrorSummary,
   Input,
+  Select,
   ShowHide,
   TextArea,
 } from "@govtech-bb/react";
+import { barbadosParishes } from "@/data/constants";
 import { useStepFocus } from "../../common/hooks/use-step-focus";
 import { useStepValidation } from "../../common/hooks/use-step-validation";
 import { fatherDetailsValidation } from "../schema";
@@ -117,33 +118,12 @@ export function FathersDetails({
             value={value.lastName || ""}
           />
 
-          {/* Date of birth */}
-          <DateInput
-            description="For example, 27 3 2007"
-            error={dateFieldErrors.dateOfBirth || fieldErrors.dateOfBirth}
-            id="father-dateOfBirth"
-            label="Date of birth"
-            name="father-dateOfBirth"
-            onChange={(dateValue) => handleChange("dateOfBirth", dateValue)}
-            value={value.dateOfBirth}
-          />
-
-          {/* Address */}
-          <TextArea
-            error={fieldErrors.address}
-            id="father-address"
-            label="Current address"
-            onChange={(e) => handleChange("address", e.target.value)}
-            rows={3}
-            value={value.address || ""}
-          />
-
-          {/* National registration number */}
+          {/* National Identification (ID) number */}
           <div>
             <Input
               error={fieldErrors.nationalRegistrationNumber}
               id="father-nationalRegistrationNumber"
-              label="National registration number"
+              label="National Identification (ID) number"
               onChange={(e) =>
                 handleChange("nationalRegistrationNumber", e.target.value)
               }
@@ -153,35 +133,70 @@ export function FathersDetails({
             />
 
             {/* Passport number disclosure */}
-            <ShowHide summary="Use passport number instead">
+            <ShowHide className="mt-3" summary="Use passport number instead">
               <div>
                 <p className="mb-4 text-[20px] text-neutral-midgrey leading-[1.7]">
-                  If you don't have a National Registration number, you can use
-                  your passport number instead.
+                  If you don't have a National Identification number, you can
+                  use your passport number instead.
                 </p>
-                <Input
-                  error={fieldErrors.passportNumber}
-                  id="father-passportNumber"
-                  label="Passport number"
-                  onChange={(e) =>
-                    handleChange("passportNumber", e.target.value)
-                  }
-                  type="text"
-                  value={value.passportNumber || ""}
-                />
-                <Input
-                  error={fieldErrors.passportPlaceOfIssue}
-                  id="father-passportPlaceOfIssue"
-                  label="Place of issue"
-                  onChange={(e) =>
-                    handleChange("passportPlaceOfIssue", e.target.value)
-                  }
-                  type="text"
-                  value={value.passportPlaceOfIssue || ""}
-                />
+                <div className="space-y-2">
+                  <Input
+                    error={fieldErrors.passportNumber}
+                    id="father-passportNumber"
+                    label="Passport number"
+                    onChange={(e) =>
+                      handleChange("passportNumber", e.target.value)
+                    }
+                    type="text"
+                    value={value.passportNumber || ""}
+                  />
+                  <Input
+                    error={fieldErrors.passportPlaceOfIssue}
+                    id="father-passportPlaceOfIssue"
+                    label="Place of issue"
+                    onChange={(e) =>
+                      handleChange("passportPlaceOfIssue", e.target.value)
+                    }
+                    type="text"
+                    value={value.passportPlaceOfIssue || ""}
+                  />
+                </div>
               </div>
             </ShowHide>
           </div>
+
+          <hr className="my-5 border-2 border-gray-200" />
+
+          <h2 className="mb-4 font-bold text-[40px] leading-[1.25]">
+            Current address
+          </h2>
+
+          {/* Parish */}
+          <Select
+            error={fieldErrors.parish}
+            id="father-parish"
+            label="Parish"
+            onChange={(e) => handleChange("parish", e.target.value)}
+            value={value.parish || ""}
+          >
+            {barbadosParishes.map((parish) => (
+              <option key={parish.value} value={parish.value}>
+                {parish.label}
+              </option>
+            ))}
+          </Select>
+
+          {/* Street address */}
+          <TextArea
+            error={fieldErrors.streetAddress}
+            id="father-streetAddress"
+            label="Street address"
+            onChange={(e) => handleChange("streetAddress", e.target.value)}
+            rows={3}
+            value={value.streetAddress || ""}
+          />
+
+          <hr className="my-5 border-2 border-gray-200" />
 
           {/* Occupation */}
           <Input

--- a/src/components/forms/register-birth/steps/marriage-status.tsx
+++ b/src/components/forms/register-birth/steps/marriage-status.tsx
@@ -2,6 +2,7 @@
 
 import type { ErrorItem } from "@govtech-bb/react";
 import { Button, ErrorSummary, Radio, RadioGroup } from "@govtech-bb/react";
+import { usePathname, useRouter } from "next/navigation";
 import { useStepFocus } from "../../common/hooks/use-step-focus";
 import { useStepValidation } from "../../common/hooks/use-step-validation";
 import { marriageStatusValidation } from "../schema";
@@ -25,8 +26,20 @@ export function MarriageStatus({
   value,
   onChange,
   onNext,
+  onBack,
 }: MarriageStatusProps) {
   const titleRef = useStepFocus("Marriage status", "Register a Birth");
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const handleBack = () => {
+    if (pathname?.includes("/form")) {
+      const startPath = pathname.replace("/form", "/start");
+      router.push(startPath);
+    } else {
+      onBack();
+    }
+  };
 
   // Wrap value in object for validation hook, converting empty string to undefined
   const formValue = { marriageStatus: value === "" ? undefined : value };
@@ -119,8 +132,11 @@ export function MarriageStatus({
           </RadioGroup>
         </div>
         <div className="flex gap-4">
+          <Button onClick={handleBack} type="button" variant="secondary">
+            Back
+          </Button>
           <Button type="submit">Continue</Button>
-        </div>{" "}
+        </div>
       </div>
     </form>
   );

--- a/src/components/forms/register-birth/steps/mothers-details.tsx
+++ b/src/components/forms/register-birth/steps/mothers-details.tsx
@@ -3,14 +3,13 @@
 import type { ErrorItem } from "@govtech-bb/react";
 import {
   Button,
-  DateInput,
   ErrorSummary,
   Input,
-  Radio,
-  RadioGroup,
+  Select,
   ShowHide,
   TextArea,
 } from "@govtech-bb/react";
+import { barbadosParishes } from "@/data/constants";
 import { useStepFocus } from "../../common/hooks/use-step-focus";
 import { useStepValidation } from "../../common/hooks/use-step-validation";
 import { motherDetailsValidation } from "../schema";
@@ -118,63 +117,12 @@ export function MothersDetails({
             value={value.lastName || ""}
           />
 
-          {/* Had other surname */}
-          <div>
-            <RadioGroup
-              description="For example, a maiden name"
-              label="Has the mother had any other last name?"
-              onValueChange={(val) => handleChange("hadOtherSurname", val)}
-              value={value.hadOtherSurname || ""}
-            >
-              <Radio id="mother-hadOtherSurname-yes" label="Yes" value="yes" />
-
-              {value.hadOtherSurname === "yes" && (
-                <div className="motion-safe:fade-in motion-safe:slide-in-from-top-2 pl-[20px] motion-safe:animate-in motion-safe:duration-200">
-                  <div className="border-neutral-grey border-l-8 border-solid pb-4 pl-[52px]">
-                    <Input
-                      className="w-80"
-                      id="mother-otherSurname"
-                      label="Previous last name"
-                      onChange={(e) =>
-                        handleChange("otherSurname", e.target.value)
-                      }
-                      type="text"
-                      value={value.otherSurname || ""}
-                    />
-                  </div>
-                </div>
-              )}
-              <Radio id="mother-hadOtherSurname-no" label="No" value="no" />
-            </RadioGroup>
-          </div>
-
-          {/* Date of birth */}
-          <DateInput
-            description="For example, 27 3 2007"
-            error={dateFieldErrors.dateOfBirth || fieldErrors.dateOfBirth}
-            id="mother-dateOfBirth"
-            label="Date of birth"
-            name="mother-dateOfBirth"
-            onChange={(dateValue) => handleChange("dateOfBirth", dateValue)}
-            value={value.dateOfBirth}
-          />
-
-          {/* Address */}
-          <TextArea
-            error={fieldErrors.address}
-            id="mother-address"
-            label="Current address"
-            onChange={(e) => handleChange("address", e.target.value)}
-            rows={3}
-            value={value.address || ""}
-          />
-
-          {/* National registration number */}
+          {/* National Identification (ID) number */}
           <div>
             <Input
               error={fieldErrors.nationalRegistrationNumber}
               id="mother-nationalRegistrationNumber"
-              label="National registration number"
+              label="National Identification (ID) number"
               onChange={(e) =>
                 handleChange("nationalRegistrationNumber", e.target.value)
               }
@@ -184,35 +132,106 @@ export function MothersDetails({
             />
 
             {/* Passport number disclosure */}
-            <ShowHide summary="Use passport number instead">
+            <ShowHide className="mt-3" summary="Use passport number instead">
               <div>
                 <p className="mb-4 text-[20px] text-neutral-midgrey leading-[1.7]">
-                  If you don't have a National Registration number, you can use
-                  your passport number instead.
+                  If you don't have a National Identification number, you can
+                  use your passport number instead.
                 </p>
-                <Input
-                  error={fieldErrors.passportNumber}
-                  id="mother-passportNumber"
-                  label="Passport number"
-                  onChange={(e) =>
-                    handleChange("passportNumber", e.target.value)
-                  }
-                  type="text"
-                  value={value.passportNumber || ""}
-                />
-                <Input
-                  error={fieldErrors.passportPlaceOfIssue}
-                  id="mother-passportPlaceOfIssue"
-                  label="Place of issue"
-                  onChange={(e) =>
-                    handleChange("passportPlaceOfIssue", e.target.value)
-                  }
-                  type="text"
-                  value={value.passportPlaceOfIssue || ""}
-                />
+                <div className="space-y-2">
+                  <Input
+                    error={fieldErrors.passportNumber}
+                    id="mother-passportNumber"
+                    label="Passport number"
+                    onChange={(e) =>
+                      handleChange("passportNumber", e.target.value)
+                    }
+                    type="text"
+                    value={value.passportNumber || ""}
+                  />
+                  <Input
+                    error={fieldErrors.passportPlaceOfIssue}
+                    id="mother-passportPlaceOfIssue"
+                    label="Place of issue"
+                    onChange={(e) =>
+                      handleChange("passportPlaceOfIssue", e.target.value)
+                    }
+                    type="text"
+                    value={value.passportPlaceOfIssue || ""}
+                  />
+                </div>
               </div>
             </ShowHide>
           </div>
+
+          {/* Maiden name */}
+          <Input
+            error={fieldErrors.maidenName}
+            id="mother-maidenName"
+            label="Maiden name"
+            onChange={(e) => handleChange("maidenName", e.target.value)}
+            type="text"
+            value={value.maidenName || ""}
+          />
+
+          <hr className="my-5 border-2 border-gray-200" />
+
+          <h2 className="mb-4 font-bold text-[40px] leading-[1.25]">
+            Current address
+          </h2>
+
+          {/* Parish */}
+          <Select
+            error={fieldErrors.parish}
+            id="mother-parish"
+            label="Parish"
+            onChange={(e) => handleChange("parish", e.target.value)}
+            value={value.parish || ""}
+          >
+            {barbadosParishes.map((parish) => (
+              <option key={parish.value} value={parish.value}>
+                {parish.label}
+              </option>
+            ))}
+          </Select>
+
+          {/* Street address */}
+          <TextArea
+            error={fieldErrors.streetAddress}
+            id="mother-streetAddress"
+            label="Street address"
+            onChange={(e) => handleChange("streetAddress", e.target.value)}
+            rows={3}
+            value={value.streetAddress || ""}
+          />
+
+          <hr className="my-5 border-2 border-gray-200" />
+
+          <h2 className="mb-4 font-bold text-[40px] leading-[1.25]">
+            Contact details
+          </h2>
+
+          {/* Telephone number */}
+          <Input
+            error={fieldErrors.telephoneNumber}
+            id="mother-telephoneNumber"
+            label="Telephone number"
+            onChange={(e) => handleChange("telephoneNumber", e.target.value)}
+            type="tel"
+            value={value.telephoneNumber || ""}
+          />
+
+          {/* Email address */}
+          <Input
+            error={fieldErrors.emailAddress}
+            id="mother-emailAddress"
+            label="Email address"
+            onChange={(e) => handleChange("emailAddress", e.target.value)}
+            type="email"
+            value={value.emailAddress || ""}
+          />
+
+          <hr className="my-5 border-2 border-gray-200" />
 
           {/* Occupation */}
           <Input

--- a/src/components/forms/register-birth/types.ts
+++ b/src/components/forms/register-birth/types.ts
@@ -29,11 +29,16 @@ export type PersonDetails = {
   lastName: string;
   hadOtherSurname?: "yes" | "no" | "";
   otherSurname?: string;
-  dateOfBirth: DateInputValue;
-  address: string;
+  maidenName?: string;
+  dateOfBirth?: DateInputValue;
+  address?: string;
+  parish?: string;
+  streetAddress?: string;
   nationalRegistrationNumber?: string;
   passportNumber?: string;
   passportPlaceOfIssue?: string;
+  telephoneNumber?: string;
+  emailAddress?: string;
   occupation?: string;
 };
 
@@ -46,7 +51,7 @@ export type ChildDetails = {
   lastName: string;
   dateOfBirth: DateInputValue;
   sexAtBirth: "Male" | "Female";
-  parishOfBirth: string;
+  parishOfBirth?: string;
 };
 
 /**

--- a/src/components/layout/entry-point-wrapper.tsx
+++ b/src/components/layout/entry-point-wrapper.tsx
@@ -27,16 +27,16 @@ export function EntryPointWrapper({ children }: EntryPointWrapperProps) {
 
   return (
     <main>
-      {!isFormPage && (
-        <div className="container py-4 lg:py-6">
-          <BackButton />
-        </div>
-      )}
       {isFormPage && !isConfirmationPage && (
         <div className="bg-blue-10">
           <div className="container">
             <StageBanner stage="alpha" />
           </div>
+        </div>
+      )}
+      {!isFormPage && (
+        <div className="container py-4 lg:py-6">
+          <BackButton />
         </div>
       )}
       {isConfirmationPage ? (

--- a/src/components/markdown-content.tsx
+++ b/src/components/markdown-content.tsx
@@ -1,7 +1,6 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: Using any to avoid multiple complex types for each html tag */
 
 import { Heading, Link, Text } from "@govtech-bb/react";
-import { format, parseISO } from "date-fns";
 import NextLink from "next/link";
 import type { ComponentPropsWithoutRef } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
@@ -10,7 +9,6 @@ import remarkGfm from "remark-gfm";
 import rehypeHideStartLinks from "@/lib/rehype-hide-start-links";
 import rehypeSectionise from "@/lib/rehype-sectionise";
 import { MigrationBanner } from "./migration-banner";
-import { StageBanner } from "./stage-banner";
 
 type HeadingProps = ComponentPropsWithoutRef<"h1">;
 type ParagraphProps = ComponentPropsWithoutRef<"p">;
@@ -144,26 +142,9 @@ export const MarkdownContent = ({
               {frontmatter.title}
             </Heading>
           )}
-
-          {frontmatter.stage?.length > 0 ? (
-            <StageBanner stage={frontmatter.stage} />
-          ) : null}
           {frontmatter.source_url ? (
             <MigrationBanner pageURL={frontmatter.source_url} />
           ) : null}
-          {frontmatter.publish_date && (
-            <div className="border-blue-10 border-b-4 pb-3 text-neutral-midgrey">
-              <Text as="p" size="caption">
-                Last updated on{" "}
-                {format(
-                  parseISO(
-                    frontmatter.publish_date.toISOString().split("T")[0]
-                  ),
-                  "PPP"
-                )}
-              </Text>
-            </div>
-          )}
         </div>
         <ReactMarkdown
           components={components}

--- a/src/content/register-a-birth/start.md
+++ b/src/content/register-a-birth/start.md
@@ -4,16 +4,20 @@ stage: "alpha"
 publish_date: 2025-11-03
 ---
 
-You can pre-register the birth online. It should take around 10 minutes.
+You should complete the registration form in one go. At the moment, it is not possible to save your answers and come back to them later.
 
-To complete the registration, the parent(s) or guardian(s) must then visit the Registration Department to sign the birth register in person. 
+There is a separate form if you need to register a <a href="/family-birth-relationships/register-a-birth/form" className="text-body">register a stillbirth.</a>.
 
 <!-- Add custom html button to allow necessary styling -->
 <!-- TODO: Make this file MDX so that the Button component can be imported -->
 
-<a href="/family-birth-relationships/register-a-birth/form" className='relative inline-flex items-center justify-center gap-2 rounded-sm text-body whitespace-nowrap transition-[background-color,box-shadow] duration-200 outline-none disabled-state px-6 py-4 bg-teal-dark !text-neutral-white hover:bg-brand-teal-light hover:shadow-[inset_0_0_0_4px_rgba(222,245,246,0.10)] active:bg-brand-teal-darker active:shadow-[inset_0_0_0_3px_rgba(0,0,0,0.20)] active:outline-none active:ring-4 active:ring-teal-100 active:ring-offset-1 active:rounded-sm focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-teal-100 focus-visible:ring-offset-1 focus-visible:rounded-sm no-underline' target="_self">Start now</a>
+## How long does it take?
 
-## Information you need for pre-registering a birth online
+It should take no longer than 15 minutes to pre-register a birth online.
+
+To complete the registration, the parent(s) or guardian(s) must then visit the Registration Department to sign the birth register in person.
+
+## What you will need
 
 You should know:
 
@@ -34,3 +38,5 @@ You should know:
 - parents’ occupations
 
 - how many certified copies of the birth certificate you would like to buy
+
+<a href="/family-birth-relationships/register-a-birth/form" className='mt-2 relative inline-flex items-center justify-center gap-2 rounded-sm text-body whitespace-nowrap transition-[background-color,box-shadow] duration-200 outline-none disabled-state px-6 py-4 bg-teal-dark !text-neutral-white hover:bg-brand-teal-light hover:shadow-[inset_0_0_0_4px_rgba(222,245,246,0.10)] active:bg-brand-teal-darker active:shadow-[inset_0_0_0_3px_rgba(0,0,0,0.20)] active:outline-none active:ring-4 active:ring-teal-100 active:ring-offset-1 active:rounded-sm focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-teal-100 focus-visible:ring-offset-1 focus-visible:rounded-sm no-underline' target="_self">Start now</a>


### PR DESCRIPTION
## Description
Updated the Register a Birth form to match new design requirements. Replaced single address fields with separate parish and street address fields, added contact details for mothers, removed date of birth fields, and converted sex selection from radio buttons to a dropdown.

## Type of Change
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->

### Form Field Updates
- **Fathers Details (`fathers-details.tsx`)**:
  - Replaced single "Current address" TextArea with "Parish" Select dropdown and "Street address" TextArea
  - Removed date of birth field
  - Updated back button to use secondary (gray) variant and navigate to start page when on first step

- **Mothers Details (`mothers-details.tsx`)**:
  - Added "Maiden name" input field after National Identification number
  - Replaced single "Current address" TextArea with "Parish" Select dropdown and "Street address" TextArea
  - Added "Contact details" section with "Telephone number" and "Email address" fields
  - Removed date of birth field

- **Child Details (`child-details.tsx`)**:
  - Changed "Sex at birth" from radio buttons to a Select dropdown with label "Sex"
  - Removed "Place of birth" field

### Schema & Type Updates
- **Schema (`schema.ts`)**:
  - Made `dateOfBirth` optional in person details schema (for both father and mother)
  - Made `address` optional, added `parish` and `streetAddress` as optional fields
  - Added optional fields: `maidenName`, `telephoneNumber`, `emailAddress`
  - Made `parishOfBirth` optional in child details schema

- **Types (`types.ts`)**:
  - Updated `PersonDetails` to make `dateOfBirth` and `address` optional
  - Added optional fields: `parish`, `streetAddress`, `maidenName`, `telephoneNumber`, `emailAddress`
  - Updated `ChildDetails` to make `parishOfBirth` optional

### Notes
<!--Add notes for anything unrelated to the specified categories -->
- Used existing `barbadosParishes` constant for parish dropdown options
- All new fields are optional in the schema to maintain backward compatibility
- Back button navigation logic updated to handle first step navigation to start page

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated