### PR TITLE
refactor: move stage banner under header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -877,6 +877,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1404,6 +1405,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1450,6 +1452,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2490,6 +2493,7 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-3.1.1.tgz",
       "integrity": "sha512-0TTacJyZ9mDmY+VefuthVshaNIyCGZHJG2fMnGaDttCt8HmjUF7SizlHJpaCDoGnN635nK1wpzfpx/Xx5S4WnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "source-map": "^0.7.0"
@@ -2549,6 +2553,7 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -2722,6 +2727,7 @@
       "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.57.0"
       },
@@ -4787,6 +4793,7 @@
         "https://trpc.io/sponsor"
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "typescript": ">=5.7.2"
       }
@@ -4796,8 +4803,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4939,6 +4945,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4949,6 +4956,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5140,6 +5148,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5181,7 +5190,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5292,6 +5300,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5779,8 +5788,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -6817,6 +6825,7 @@
       "integrity": "sha512-GtldT42B8+jefDUC4yUKAvsaOrH7PDHmZxZXNgF2xMmymjUbRYJvpAybZAKEmXDGTM0mCsz8duOa4vTm5AY2Kg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -7391,7 +7400,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8918,6 +8926,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8988,6 +8997,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9018,7 +9028,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9075,6 +9084,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.2.tgz",
       "integrity": "sha512-MdWVitvLbQULD+4DP8GYjZUrepGW7d+GQkNVqJEzNxE+e9WIa4egVFE/RDfVb1u9u/Jw7dNMmPB4IqxzbFYJ0w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9084,6 +9094,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.2.tgz",
       "integrity": "sha512-dEoydsCp50i7kS1xHOmPXq4zQYoGWedUsvqv9H6zdif2r7yLHygyfP9qou71TulRN0d6ng9EbRVsQhSqfUc19g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -9135,6 +9146,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.68.0.tgz",
       "integrity": "sha512-oNN3fjrZ/Xo40SWlHf1yCjlMK417JxoSJVUXQjGdvdRCU07NTFei1i1f8ApUAts+IVh14e4EdakeLEA+BEAs/Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -9151,8 +9163,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -10039,7 +10050,8 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -10271,6 +10283,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10551,6 +10564,7 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11474,6 +11488,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/layout/banner.tsx
+++ b/src/components/layout/banner.tsx
@@ -9,26 +9,32 @@ export const Banner = () => {
   const pathname = usePathname();
   const isOnHomePage = pathname === "/";
   return (
-    <div
-      className={`bg-blue-100 ${isOnHomePage ? "pb-2" : ""} text-neutral-white`}
-    >
-      <div className="container">
-        <div className="flex items-center justify-between py-2">
-          <span className="flex items-center gap-2">
-            <Image
-              alt="flag"
-              className="block"
-              height="16"
-              src="/images/coat-of-arms.png"
-              width="17"
-            />
-            <Typography className="text-neutral-white" variant="small">
-              Official government website
-            </Typography>
-          </span>
+    <>
+      <div className="bg-blue-100 text-neutral-white">
+        <div className="container">
+          <div className="flex items-center justify-between py-2">
+            <span className="flex items-center gap-2">
+              <Image
+                alt="flag"
+                className="block"
+                height="16"
+                src="/images/coat-of-arms.png"
+                width="17"
+              />
+              <Typography className="text-neutral-white" variant="small">
+                Official government website
+              </Typography>
+            </span>
+          </div>
         </div>
-        {isOnHomePage ? <StageBanner className="py-2" stage="alpha" /> : null}
       </div>
-    </div>
+      {isOnHomePage && (
+        <div className="bg-blue-10">
+          <div className="container">
+            <StageBanner stage="alpha" />
+          </div>
+        </div>
+      )}
+    </>
   );
 };

--- a/src/components/layout/entry-point-wrapper.tsx
+++ b/src/components/layout/entry-point-wrapper.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { BackButton } from "@/components/layout/back-button";
 import { HelpfulBox } from "@/components/layout/helpful-box";
 import { StageBanner } from "@/components/stage-banner";
@@ -12,6 +14,23 @@ import { cn } from "@/lib/utils";
 // biome-ignore lint/style/useConsistentTypeDefinitions: Do not need `type` features
 interface EntryPointWrapperProps {
   children: React.ReactNode;
+}
+
+export const BANNER_PORTAL_ID = "content-banner-slot";
+
+export function BannerPortal({ children }: { children: React.ReactNode }) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  const target = document.getElementById(BANNER_PORTAL_ID);
+  if (!target) return null;
+
+  return createPortal(children, target);
 }
 
 export function EntryPointWrapper({ children }: EntryPointWrapperProps) {
@@ -27,6 +46,7 @@ export function EntryPointWrapper({ children }: EntryPointWrapperProps) {
 
   return (
     <main>
+      <div id={BANNER_PORTAL_ID} />
       {!isFormPage && (
         <div className="container py-4 lg:py-6">
           <BackButton />

--- a/src/components/markdown-content.tsx
+++ b/src/components/markdown-content.tsx
@@ -7,10 +7,16 @@ import type { ComponentPropsWithoutRef } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
+import { BannerPortal } from "@/components/layout/entry-point-wrapper";
 import rehypeHideStartLinks from "@/lib/rehype-hide-start-links";
 import rehypeSectionise from "@/lib/rehype-sectionise";
 import { MigrationBanner } from "./migration-banner";
 import { StageBanner } from "./stage-banner";
+
+const stageBackgrounds: Record<string, string> = {
+  alpha: "bg-blue-10",
+  beta: "bg-yellow-40",
+};
 
 type HeadingProps = ComponentPropsWithoutRef<"h1">;
 type ParagraphProps = ComponentPropsWithoutRef<"p">;
@@ -90,33 +96,23 @@ const components: Components = {
     />
   ),
   table: ({ node, ...props }) => (
-    <div className="mx-4 my-6 overflow-x-auto sm:mx-0">
+    <div className="my-s overflow-x-auto">
       <div className="inline-block min-w-full align-middle">
-        <table
-          className="min-w-full divide-y divide-gray-300 border border-gray-300"
-          {...props}
-        />
+        <table className="min-w-full" {...props} />
       </div>
     </div>
   ),
-  thead: ({ node, ...props }) => <thead className="bg-gray-50" {...props} />,
-  tbody: ({ node, ...props }) => (
-    <tbody className="divide-y divide-gray-200 bg-white" {...props} />
-  ),
-  tr: ({ node, ...props }) => (
-    <tr className="transition-colors hover:bg-gray-50" {...props} />
-  ),
+  thead: ({ node, ...props }) => <thead className="bg-blue-10" {...props} />,
+  tbody: ({ node, ...props }) => <tbody className="bg-white" {...props} />,
+  tr: ({ node, ...props }) => <tr {...props} />,
   th: ({ node, ...props }) => (
     <th
-      className="px-3 py-3 text-left font-semibold text-gray-900 text-xs sm:px-6 sm:text-sm"
+      className="px-xs py-s text-left font-bold text-caption-sm text-neutral-midgrey"
       {...props}
     />
   ),
   td: ({ node, ...props }) => (
-    <td
-      className="px-3 py-4 text-gray-700 text-xs sm:px-6 sm:text-sm"
-      {...props}
-    />
+    <td className="px-xs py-s text-black text-caption-sm" {...props} />
   ),
 };
 
@@ -136,47 +132,56 @@ export const MarkdownContent = ({
 }: MarkdownContentProps) => {
   const { frontmatter, content } = markdown;
   return (
-    <div className="lg:grid lg:grid-cols-3 lg:gap-16">
-      <div className="space-y-6 lg:col-span-2 lg:space-y-8">
-        <div className="space-y-4 lg:space-y-6">
-          {frontmatter.title && (
-            <Heading as="h1" className="break-anywhere">
-              {frontmatter.title}
-            </Heading>
-          )}
-
-          {frontmatter.stage?.length > 0 ? (
-            <StageBanner stage={frontmatter.stage} />
-          ) : null}
-          {frontmatter.source_url ? (
-            <MigrationBanner pageURL={frontmatter.source_url} />
-          ) : null}
-          {frontmatter.publish_date && (
-            <div className="border-blue-10 border-b-4 pb-3 text-neutral-midgrey">
-              <Text as="p" size="caption">
-                Last updated on{" "}
-                {format(
-                  parseISO(
-                    frontmatter.publish_date.toISOString().split("T")[0]
-                  ),
-                  "PPP"
-                )}
-              </Text>
+    <>
+      {frontmatter.stage?.length > 0 && (
+        <BannerPortal>
+          <div className={stageBackgrounds[frontmatter.stage] || "bg-blue-10"}>
+            <div className="container">
+              <StageBanner stage={frontmatter.stage} />
             </div>
-          )}
+          </div>
+        </BannerPortal>
+      )}
+      <div className="lg:grid lg:grid-cols-3 lg:gap-16">
+        <div className="space-y-6 lg:col-span-2 lg:space-y-8">
+          <div className="space-y-4 lg:space-y-6">
+            {frontmatter.title && (
+              <Heading as="h1" className="break-anywhere">
+                {frontmatter.title}
+              </Heading>
+            )}
+
+            {frontmatter.source_url && (
+              <MigrationBanner pageURL={frontmatter.source_url} />
+            )}
+
+            {frontmatter.publish_date && (
+              <div className="border-blue-10 border-b-4 pb-3 text-neutral-midgrey">
+                <Text as="p" size="caption">
+                  Last updated on{" "}
+                  {format(
+                    parseISO(
+                      frontmatter.publish_date.toISOString().split("T")[0]
+                    ),
+                    "PPP"
+                  )}
+                </Text>
+              </div>
+            )}
+          </div>
+          <ReactMarkdown
+            components={components}
+            rehypePlugins={[
+              rehypeRaw,
+              [rehypeHideStartLinks, { hasResearchAccess }],
+              rehypeSectionise,
+            ]}
+            remarkPlugins={[remarkGfm]}
+          >
+            {content}
+          </ReactMarkdown>
         </div>
-        <ReactMarkdown
-          components={components}
-          rehypePlugins={[
-            rehypeRaw,
-            [rehypeHideStartLinks, { hasResearchAccess }],
-            rehypeSectionise,
-          ]}
-          remarkPlugins={[remarkGfm]}
-        >
-          {content}
-        </ReactMarkdown>
       </div>
-    </div>
+    </>
   );
 };

--- a/src/components/stage-banner.tsx
+++ b/src/components/stage-banner.tsx
@@ -15,12 +15,7 @@ export const StageBanner = ({
   <StatusBanner className={className} variant={stage as "alpha" | "beta"}>
     <Text as="p">
       This page is in{" "}
-      <Link
-        as={NextLink}
-        className="capitalize"
-        href={url}
-        variant={"secondary"}
-      >
+      <Link as={NextLink} className="capitalize" href={url} variant="secondary">
         {stage}
       </Link>
       .


### PR DESCRIPTION
- Add BannerPortal component to entry-point-wrapper for rendering StageBanner under header
- StageBanner now renders via React Portal for alpha/beta content pages
- Apply full-width backgrounds dynamically based on stage variant (alpha=bg-blue-10, beta=bg-yellow-40)
- Update table styles to match Figma design (blue-10 header, design tokens for spacing)
- Keep MigrationBanner inline within content area

## Description
<!-- Summarize the changes based on added/changed functionality --><!-- Summarize the changes based on added/changed functionality -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->


## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
