### PR TITLE
fix(feature-flag): hide placeholder entry pages behind research access flag 

### DIFF
--- a/src/data/content-directory.ts
+++ b/src/data/content-directory.ts
@@ -6,6 +6,7 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
     slug: "family-birth-relationships",
     description:
       "Managing key life events and family responsibilities, from registering a birth to caring for others",
+
     pages: [
       {
         title: "Register a birth",
@@ -40,11 +41,12 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
         description:
           "Information on how to obtain a copy of a death certificate in Barbados.",
         subPages: [
-          { slug: "start", type: "markdown" },
+          { slug: "start", type: "markdown", protected: true },
           {
             slug: "form",
             title: "Get a Death Certificate form",
             type: "component",
+            protected: true,
           },
         ],
       },
@@ -55,11 +57,12 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
         description:
           "Information on how to obtain a copy of a marriage certificate in Barbados.",
         subPages: [
-          { slug: "start", type: "markdown" },
+          { slug: "start", type: "markdown", protected: true },
           {
             slug: "form",
             title: "Get a Marriage Certificate form",
             type: "component",
+            protected: true,
           },
         ],
       },
@@ -318,12 +321,14 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
         title: "Redirect My Mail (Individual)",
         slug: "post-office-redirection-individual",
         description: "Redirect mail for an individual",
+        protected: true,
         subPages: [
-          { slug: "start", type: "markdown" },
+          { slug: "start", type: "markdown", protected: true },
           {
             slug: "form",
             title: "Redirect My Mail (Individual) form",
             type: "component",
+            protected: true,
           },
         ],
       },
@@ -331,12 +336,14 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
         title: "Redirect My Mail (Deceased)",
         slug: "post-office-redirection-deceased",
         description: "Redirect mail for a deceased person",
+        protected: true,
         subPages: [
-          { slug: "start", type: "markdown" },
+          { slug: "start", type: "markdown", protected: true },
           {
             slug: "form",
             title: "Redirect My Mail (Deceased) form",
             type: "component",
+            protected: true,
           },
         ],
       },
@@ -344,12 +351,14 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
         title: "Redirect My Mail (Business)",
         slug: "post-office-redirection-business",
         description: "Redirect mail for a Business",
+        protected: true,
         subPages: [
-          { slug: "start", type: "markdown" },
+          { slug: "start", type: "markdown", protected: true },
           {
             slug: "form",
             title: "Redirect My Mail (Business) form",
             type: "component",
+            protected: true,
           },
         ],
       },

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -5,6 +5,7 @@ export type PageType = {
   slug: string;
   source_url?: string;
   description: string; // date when content was published, updated or migrated
+  protected?: boolean;
   subPages?: {
     slug: string;
     title?: string;


### PR DESCRIPTION
## Description
<!-- Summarize the changes based on added/changed functionality --><!-- Summarize the changes based on added/changed functionality -->

  - Extends the existing research access feature flag to also protect entry pages (index.md) that have placeholder content                                
  - Adds protected property at the page level in content-directory (previously only existed on subPages)     
  
Added the following pages:
  - Redirect My Mail (Individual)
  - Redirect My Mail (Deceased)
  - Redirect My Mail (Business)
  

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->


## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
