### PR TITLE
chore: add missing field in jobstart schema

### DIFF
--- a/src/schema/jobstart-plus-programme.ts
+++ b/src/schema/jobstart-plus-programme.ts
@@ -765,20 +765,23 @@ export const formSteps: FormStep[] = [
           { label: "No", value: "no" },
         ],
       },
-      // {
-      //   name: "eligibility.availabilityToWork",
-      //   label: "Tell us when you are available to work",
-      //   hint: "If you are 18 and over you are eligible to work at night. Might you be willing to work between 6pm and 7am?",
-      //   type: "radio",
-      //   rows: 5,
-      //   validation: {
-      //     required: "Field is required",
-      //   },
-      //   options: [
-      //     { label: "Yes", value: "yes" },
-      //     { label: "No", value: "no" },
-      //   ],
-      // },
+      {
+        name: "eligibility.willingToWorkAtNight",
+        label: "Are you willing to work at night?",
+        type: "radio",
+        rows: 5,
+        validation: {
+          required: "Field is required",
+        },
+        options: [
+          { label: "Yes", value: "yes" },
+          { label: "No", value: "no" },
+        ],
+        conditionalOn: {
+          field: "eligibility.areYouOver18",
+          value: "yes",
+        },
+      },
     ],
   },
   {


### PR DESCRIPTION
## Description

Add missing eligibility field to the JobStart Plus Programme form to capture applicant's willingness to work night shifts. This field is conditionally displayed only for applicants aged 18 and over, as per legal working requirements.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- Add conditional field for night shift work eligibility in JobStart Plus Programme form

### Files Changed

- **src/schema/jobstart-plus-programme.ts**
  - Uncommented and refactored the `eligibility.willingToWorkAtNight` field
  - Updated field name from `eligibility.availabilityToWork` to `eligibility.willingToWorkAtNight` for better clarity
  - Simplified label from "Tell us when you are available to work" to "Are you willing to work at night?"
  - Added conditional logic to only display this field when user confirms they are over 18 (`conditionalOn: eligibility.areYouOver18 === "yes"`)
  - Maintains required validation with radio button options (Yes/No)

### Notes

This field was previously commented out but is necessary for the complete eligibility assessment workflow. The conditional display ensures compliance with labor regulations regarding night work for minors.

## Testing

- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs
- [ ] Verify conditional field logic (only shows when age > 18)
- [ ] Test form validation for the new field

## Related Github Issue(s)/Trello Ticket(s)

<!-- Link any related issues: Fixes #123 -->

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated