### PR TITLE
fix: update Careers link to use external prop

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -13,7 +13,12 @@ export const Footer = () => (
           <Link as={NextLink} href="/terms-conditions" variant={"tertiary"}>
             Terms &amp; Conditions
           </Link>
-          <Link as={NextLink} href="https://job-boards.greenhouse.io/govtechbarbados?gh_src=ef2pb1uy9us" variant={"tertiary"} target="_blank">
+          <Link
+            as={NextLink}
+            external
+            href="https://job-boards.greenhouse.io/govtechbarbados?gh_src=ef2pb1uy9us"
+            variant={"tertiary"}
+          >
             Careers
           </Link>
         </div>


### PR DESCRIPTION
## Description
<!-- Summarize the changes based on added/changed functionality --><!-- Summarize the changes based on added/changed functionality -->
Updated the Careers link to use the `external` prop from the Link component instead of manually setting `target="_blank"`. 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->


## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
