### PR TITLE
fix: add validation for showHide child fields

### DIFF
--- a/src/lib/schema-generator.ts
+++ b/src/lib/schema-generator.ts
@@ -501,8 +501,16 @@ export function generateFormSchema(formSteps: FormStep[]) {
 
         // Add child field schemas as optional - they'll be validated conditionally via superRefine
         for (const childField of field.showHide.fields) {
-          // Make child fields optional at schema level
-          setNestedValue(schemaShape, childField.name, z.string().optional());
+          // Make child fields optional at schema level, respecting field type
+          if (childField.type === "number") {
+            setNestedValue(
+              schemaShape,
+              childField.name,
+              z.coerce.number().optional()
+            );
+          } else {
+            setNestedValue(schemaShape, childField.name, z.string().optional());
+          }
         }
       }
     }


### PR DESCRIPTION
## Description
<!-- Summarize the changes based on added/changed functionality --><!-- Summarize the changes based on added/changed functionality -->

ShowHide child fields were not being validated when clicking Continue because `methods.trigger()` only validates against the base schema, not superRefine. This allowed users to bypass validation by opening a showHide and leaving required fields empty.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->
- Add manual validation for showHide child fields (required, minLength, pattern) in `multi-step-form.tsx`                 
- Fix `schema-generator` to use `z.coerce.number().optional()` for number fields inside showHide groups instead of           
   `z.string().optional()`

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->


## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
