### PR TITLE
Stable Birth Registration Form 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -877,6 +877,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1404,6 +1405,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1450,6 +1452,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2490,6 +2493,7 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-3.1.1.tgz",
       "integrity": "sha512-0TTacJyZ9mDmY+VefuthVshaNIyCGZHJG2fMnGaDttCt8HmjUF7SizlHJpaCDoGnN635nK1wpzfpx/Xx5S4WnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "source-map": "^0.7.0"
@@ -2549,6 +2553,7 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -2722,6 +2727,7 @@
       "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.57.0"
       },
@@ -4787,6 +4793,7 @@
         "https://trpc.io/sponsor"
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "typescript": ">=5.7.2"
       }
@@ -4796,8 +4803,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4939,6 +4945,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4949,6 +4956,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5140,6 +5148,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5181,7 +5190,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5292,6 +5300,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5779,8 +5788,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -6817,6 +6825,7 @@
       "integrity": "sha512-GtldT42B8+jefDUC4yUKAvsaOrH7PDHmZxZXNgF2xMmymjUbRYJvpAybZAKEmXDGTM0mCsz8duOa4vTm5AY2Kg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -7391,7 +7400,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8918,6 +8926,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8988,6 +8997,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9018,7 +9028,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9075,6 +9084,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.2.tgz",
       "integrity": "sha512-MdWVitvLbQULD+4DP8GYjZUrepGW7d+GQkNVqJEzNxE+e9WIa4egVFE/RDfVb1u9u/Jw7dNMmPB4IqxzbFYJ0w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9084,6 +9094,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.2.tgz",
       "integrity": "sha512-dEoydsCp50i7kS1xHOmPXq4zQYoGWedUsvqv9H6zdif2r7yLHygyfP9qou71TulRN0d6ng9EbRVsQhSqfUc19g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -9135,6 +9146,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.68.0.tgz",
       "integrity": "sha512-oNN3fjrZ/Xo40SWlHf1yCjlMK417JxoSJVUXQjGdvdRCU07NTFei1i1f8ApUAts+IVh14e4EdakeLEA+BEAs/Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -9151,8 +9163,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -10039,7 +10050,8 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -10271,6 +10283,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10551,6 +10564,7 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11474,6 +11488,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/forms/builder/confirmation-step.tsx
+++ b/src/components/forms/builder/confirmation-step.tsx
@@ -88,13 +88,13 @@ export function ConfirmationPage({
 
       {/* Main content */}
 
-      <div className="container space-y-6 py-4 lg:grid lg:grid-cols-3 lg:space-y-8 lg:py-8">
+      <div className="container space-y-6 overflow-hidden py-4 lg:grid lg:grid-cols-3 lg:space-y-8 lg:py-8">
         <div className="col-span-2 space-y-6 lg:space-y-8">
           {/* Reference number banner - shown by default unless explicitly set to false */}
           {referenceNumber &&
             confirmationStep.showReferenceNumber !== false && (
-              <div className="w-fit rounded-sm bg-blue-10 px-6 py-4">
-                <Heading as="h2" className="whitespace-nowrap text-black">
+              <div className="rounded-sm bg-blue-10 px-6 py-4 lg:w-fit">
+                <Heading as="h2" className="text-black lg:whitespace-nowrap">
                   {confirmationStep.referenceNumberLabel ??
                     "Your reference number is"}{" "}
                   {referenceNumber}

--- a/src/components/forms/builder/dynamic-field-array.tsx
+++ b/src/components/forms/builder/dynamic-field-array.tsx
@@ -9,7 +9,7 @@ import {
 import { useEffect, useRef } from "react";
 import { Controller, useFieldArray, useFormContext } from "react-hook-form";
 import type { FormData } from "@/lib/schema-generator";
-import { getNestedValue } from "@/lib/utils";
+import { checkNestedConditionalRule, getNestedValue } from "@/lib/utils";
 import type { FieldArrayConfig, FormField } from "@/types";
 
 // Convert index to ordinal word (0 -> "First", 1 -> "Second", etc.)
@@ -155,14 +155,16 @@ export function DynamicFieldArray({ field }: DynamicFieldArrayProps) {
                   const fieldError = itemErrors?.[nestedField.name];
 
                   // Check if field should be shown based on conditionalOn
-                  if (nestedField.conditionalOn) {
-                    const conditionalFieldName =
-                      `${field.name}.${index}.${nestedField.conditionalOn.field}` as keyof FormData;
-                    const conditionalValue = watch(conditionalFieldName);
-
-                    if (conditionalValue !== nestedField.conditionalOn.value) {
-                      return null; // Don't render if condition not met
-                    }
+                  if (
+                    nestedField.conditionalOn &&
+                    !checkNestedConditionalRule(
+                      nestedField.conditionalOn,
+                      field.name,
+                      index,
+                      watch
+                    )
+                  ) {
+                    return null; // Don't render if condition not met
                   }
 
                   // Render select field

--- a/src/components/forms/builder/dynamic-field.tsx
+++ b/src/components/forms/builder/dynamic-field.tsx
@@ -3,6 +3,7 @@ import {
   DateInput,
   type DateInputValue,
   FileUpload,
+  Heading,
   Input,
   NumberInput,
   Radio,
@@ -15,7 +16,12 @@ import {
 import { Fragment, useEffect, useState } from "react";
 import { Controller, type FieldError, useFormContext } from "react-hook-form";
 import type { FormData } from "@/lib/schema-generator";
-import { getNestedValue } from "@/lib/utils";
+import {
+  checkConditionalRule,
+  conditionalHasValue,
+  conditionalReferencesField,
+  getNestedValue,
+} from "@/lib/utils";
 import { uploadFile } from "@/services/api";
 import type { FormField } from "@/types";
 import { DynamicFieldArray } from "./dynamic-field-array";
@@ -97,6 +103,7 @@ function FileUploadField({
 type DynamicFieldProps = {
   field: FormField;
   conditionalFields?: FormField[];
+  className?: string;
 };
 
 /**
@@ -140,13 +147,17 @@ export function DynamicField({
   // Clear conditional field values when they shouldn't be shown
   // biome-ignore lint/correctness/useExhaustiveDependencies: conditionalFields is derived from static schema and causes infinite loop if included
   useEffect(() => {
+    const formValues = getValues() as Record<string, unknown>;
+
     for (const conditionalField of conditionalFields) {
       if (
         conditionalField.conditionalOn &&
-        conditionalField.conditionalOn.field === field.name
+        conditionalReferencesField(conditionalField.conditionalOn, field.name)
       ) {
-        const shouldShow =
-          currentFieldValue === conditionalField.conditionalOn.value;
+        const shouldShow = checkConditionalRule(
+          conditionalField.conditionalOn,
+          formValues
+        );
         const currentValue = getValues(conditionalField.name as keyof FormData);
 
         // Only clear if field should be hidden AND has a value
@@ -156,8 +167,9 @@ export function DynamicField({
           const anotherFieldWithSameNameIsShown = conditionalFields.some(
             (cf) =>
               cf.name === conditionalField.name &&
-              cf.conditionalOn?.field === field.name &&
-              currentFieldValue === cf.conditionalOn?.value
+              cf.conditionalOn &&
+              conditionalReferencesField(cf.conditionalOn, field.name) &&
+              checkConditionalRule(cf.conditionalOn, formValues)
           );
 
           // Only clear if no other conditional field with this name is visible
@@ -192,20 +204,43 @@ export function DynamicField({
       errors as Record<string, unknown>,
       conditionalField.name
     );
-    const watchedValue = conditionalField.conditionalOn
-      ? watch(conditionalField.conditionalOn.field as keyof FormData)
-      : null;
-    const shouldShow = watchedValue === conditionalField.conditionalOn?.value;
+    const formValues = watch() as Record<string, unknown>;
+    const shouldShow = conditionalField.conditionalOn
+      ? checkConditionalRule(conditionalField.conditionalOn, formValues)
+      : false;
 
     if (!shouldShow) return null;
+
+    // Create a stable key from conditionalOn values
+    const conditionKey = conditionalField.conditionalOn
+      ? Array.isArray(conditionalField.conditionalOn)
+        ? conditionalField.conditionalOn.map((r) => r.value).join("-")
+        : conditionalField.conditionalOn.value
+      : "";
 
     return (
       <div
         className="motion-safe:fade-in motion-safe:slide-in-from-top-2 mt-6 pl-5 motion-safe:animate-in motion-safe:duration-200"
-        key={`${conditionalField.name}-${conditionalField.conditionalOn?.value}`}
+        key={`${conditionalField.name}-${conditionKey}`}
       >
         <div className="border-grey-00 border-l-8 border-solid pb-4 pl-[52px]">
-          {conditionalField.type === "fieldArray" ? (
+          {conditionalField.type === "heading" ? (
+            <div className="space-y-xm">
+              <div className="py-5">
+                <hr className="border-grey-00 border-t-4" />
+              </div>
+              {conditionalField.label?.trim() && (
+                <Heading as={conditionalField.as ?? "h2"}>
+                  {conditionalField.label}
+                </Heading>
+              )}
+              {conditionalField.hint?.trim() && (
+                <Text as="p" className="text-mid-grey-00" size="body">
+                  {conditionalField.hint}
+                </Text>
+              )}
+            </div>
+          ) : conditionalField.type === "fieldArray" ? (
             <DynamicFieldArray field={conditionalField} />
           ) : conditionalField.type === "date" ? (
             <Controller
@@ -406,7 +441,21 @@ export function DynamicField({
 
   return (
     <div className={getWidthClass(field.width)} id={field.name}>
-      {field.type === "fieldArray" ? (
+      {field.type === "heading" ? (
+        <div className="space-y-xm">
+          <div className="py-5">
+            <hr className="border-grey-00 border-t-4" />
+          </div>
+          {field.label?.trim() && (
+            <Heading as={field.as ?? "h2"}>{field.label}</Heading>
+          )}
+          {field.hint?.trim() && (
+            <Text as="p" className="text-mid-grey-00" size="body">
+              {field.hint}
+            </Text>
+          )}
+        </div>
+      ) : field.type === "fieldArray" ? (
         <DynamicFieldArray field={field} />
       ) : field.type === "date" ? (
         <Controller
@@ -497,7 +546,11 @@ export function DynamicField({
                   />
                   {/* Render conditional fields that match this option */}
                   {conditionalFields
-                    .filter((cf) => cf.conditionalOn?.value === option.value)
+                    .filter(
+                      (cf) =>
+                        cf.conditionalOn &&
+                        conditionalHasValue(cf.conditionalOn, option.value)
+                    )
                     .map((cf) => renderConditionalField(cf))}
                 </Fragment>
               ))}
@@ -606,6 +659,7 @@ export function DynamicField({
                                 childError?.message ?? childField.hint
                               }
                               error={childError?.message}
+                              id={childField.name}
                               label={childField.hidden ? "" : childField.label}
                               name={controllerField.name}
                               onBlur={controllerField.onBlur}
@@ -723,6 +777,7 @@ export function DynamicField({
             id={field.name}
             type={field.type}
             {...register(field.name as keyof FormData)}
+            className={field.inputClassName || ""}
             placeholder={field.placeholder}
           />
         </div>
@@ -732,6 +787,7 @@ export function DynamicField({
           label={field.hidden ? "" : field.label}
           type={field.type}
           {...register(field.name as keyof FormData)}
+          className={field.inputClassName || ""}
           placeholder={field.placeholder}
         />
       )}

--- a/src/components/forms/builder/multi-step-form.tsx
+++ b/src/components/forms/builder/multi-step-form.tsx
@@ -8,7 +8,11 @@ import { FormProvider, useForm } from "react-hook-form";
 import { ReviewStep } from "@/components/forms/builder/review-step";
 import { FormSkeleton } from "@/components/forms/form-skeleton";
 import { type FormData, generateFormSchema } from "@/lib/schema-generator";
-import { getNestedValue } from "@/lib/utils";
+import {
+  checkConditionalRule,
+  getNestedValue,
+  indexConditionalOn,
+} from "@/lib/utils";
 import { submitFormData } from "@/services/api";
 import { createFormStore } from "@/store/form-store";
 import type { FormField, FormStep } from "@/types";
@@ -155,17 +159,22 @@ function createRepeatableStepInstance(
   // Create indexed field names (e.g., minorDetails.0.firstName)
   // Also update any field references (conditionalOn, skipValidationWhenShowHideOpen, showHide)
   const indexedFields: FormField[] = baseStep.fields.map((field) => {
+    // Heading fields only need name indexed
+    if (field.type === "heading") {
+      return { ...field, name: indexFieldName(field.name) };
+    }
+
     const indexed: FormField = {
       ...field,
       name: indexFieldName(field.name),
     };
 
-    // Update conditionalOn.field reference to include the array index
+    // Update conditionalOn field references to include the array index
     if (field.conditionalOn) {
-      indexed.conditionalOn = {
-        ...field.conditionalOn,
-        field: indexFieldName(field.conditionalOn.field),
-      };
+      indexed.conditionalOn = indexConditionalOn(
+        field.conditionalOn,
+        indexFieldName
+      );
     }
 
     // Update skipValidationWhenShowHideOpen reference
@@ -175,8 +184,8 @@ function createRepeatableStepInstance(
       );
     }
 
-    // Update showHide config with indexed field names
-    if (field.showHide) {
+    // Update showHide config with indexed field names (only for showHide fields)
+    if (field.type === "showHide" && field.showHide) {
       indexed.showHide = {
         ...field.showHide,
         stateFieldName: indexFieldName(field.showHide.stateFieldName),
@@ -185,10 +194,10 @@ function createRepeatableStepInstance(
           name: indexFieldName(nestedField.name),
           // Also update conditionalOn in nested fields if present
           ...(nestedField.conditionalOn && {
-            conditionalOn: {
-              ...nestedField.conditionalOn,
-              field: indexFieldName(nestedField.conditionalOn.field),
-            },
+            conditionalOn: indexConditionalOn(
+              nestedField.conditionalOn,
+              indexFieldName
+            ),
           }),
         })),
       };
@@ -218,11 +227,11 @@ function createRepeatableStepInstance(
   let stepConditionalOn = baseStep.conditionalOn;
 
   if (isSubStep && baseStep.conditionalOn) {
-    // Sub-steps: index the conditionalOn.field reference (e.g., isParentOrGuardian -> beneficiaries.0.isParentOrGuardian)
-    stepConditionalOn = {
-      ...baseStep.conditionalOn,
-      field: indexFieldName(baseStep.conditionalOn.field),
-    };
+    // Sub-steps: index the conditionalOn field references (e.g., isParentOrGuardian -> beneficiaries.0.isParentOrGuardian)
+    stepConditionalOn = indexConditionalOn(
+      baseStep.conditionalOn,
+      indexFieldName
+    );
   } else if (index > 0 && !isSubStep) {
     // Primary steps after the first: conditional on previous "add another" being "yes"
     stepConditionalOn = {
@@ -686,8 +695,7 @@ export default function DynamicMultiStepForm({
       // Check if step is visible (for conditional steps)
       const isVisible =
         !step.conditionalOn ||
-        getNestedValue<unknown>(cleanedData, step.conditionalOn.field) ===
-          step.conditionalOn.value;
+        checkConditionalRule(step.conditionalOn, cleanedData);
 
       for (const field of step.fields) {
         const fieldParts = field.name?.split(".");
@@ -713,12 +721,7 @@ export default function DynamicMultiStepForm({
     for (const step of conditionalSteps) {
       if (!step.conditionalOn) continue;
 
-      const watchedValue = getNestedValue<unknown>(
-        cleanedData,
-        step.conditionalOn.field
-      );
-
-      const isVisible = watchedValue === step.conditionalOn.value;
+      const isVisible = checkConditionalRule(step.conditionalOn, cleanedData);
 
       // Only delete simple (non-nested) fields from hidden steps
       if (!isVisible) {
@@ -780,7 +783,9 @@ export default function DynamicMultiStepForm({
 
         // Mark as submitted in store with customer name and payment data
         markAsSubmitted(
-          result.data?.submissionId || "N/A",
+          result.data?.integrations?.opencrvs?.trackingId ||
+            result.data?.submissionId ||
+            "N/A",
           customerName,
           apiPaymentData
         );
@@ -813,11 +818,10 @@ export default function DynamicMultiStepForm({
     if (!step.conditionalOn) return true;
 
     const formValues = methods.getValues();
-    const watchedValue = getNestedValue<unknown>(
-      formValues as Record<string, unknown>,
-      step.conditionalOn.field
+    return checkConditionalRule(
+      step.conditionalOn,
+      formValues as Record<string, unknown>
     );
-    return watchedValue === step.conditionalOn.value;
   };
 
   // Helper function to find the next visible step index
@@ -893,10 +897,8 @@ export default function DynamicMultiStepForm({
         if (!field.conditionalOn) return true;
 
         // Check if conditional field should be visible
-        const watchedValue = methods.watch(
-          field.conditionalOn.field as keyof FormData
-        );
-        return watchedValue === field.conditionalOn.value;
+        const formValues = methods.getValues() as Record<string, unknown>;
+        return checkConditionalRule(field.conditionalOn, formValues);
       }
     );
 
@@ -952,6 +954,9 @@ export default function DynamicMultiStepForm({
 
     // Manually validate conditional fields (required and pattern)
     for (const field of visibleFields) {
+      // Skip heading fields - they don't have validation
+      if (field.type === "heading") continue;
+
       if (field.conditionalOn) {
         const fieldValue = methods.getValues(field.name as keyof FormData);
         const stringValue = typeof fieldValue === "string" ? fieldValue : "";
@@ -1036,6 +1041,43 @@ export default function DynamicMultiStepForm({
                 methods.setError(childField.name as keyof FormData, {
                   type: "pattern",
                   message: childField.validation.pattern.message,
+                });
+                isValid = false;
+              }
+            }
+
+            // Check number min/max for showHide nested number fields
+            if (childField.type === "number" && childField.validation) {
+              const { min, max } = childField.validation;
+              if (!(min || max)) continue;
+
+              const rawValue = methods.getValues(
+                childField.name as keyof FormData
+              );
+
+              if (
+                rawValue === "" ||
+                rawValue === null ||
+                rawValue === undefined
+              )
+                continue;
+
+              const value = Number(rawValue);
+
+              if (Number.isNaN(value)) continue;
+
+              if (min && value < min.value) {
+                methods.setError(childField.name as keyof FormData, {
+                  type: "min",
+                  message: min.message,
+                });
+                isValid = false;
+              }
+
+              if (max && value > max.value) {
+                methods.setError(childField.name as keyof FormData, {
+                  type: "max",
+                  message: max.message,
                 });
                 isValid = false;
               }

--- a/src/components/forms/builder/review-step.tsx
+++ b/src/components/forms/builder/review-step.tsx
@@ -4,7 +4,7 @@ import { Button, Heading, Text } from "@govtech-bb/react";
 import { useFormContext } from "react-hook-form";
 import { formatForDisplay } from "@/lib/dates";
 import type { FormData } from "@/lib/schema-generator";
-import { getNestedValue } from "@/lib/utils";
+import { checkConditionalRule, getNestedValue } from "@/lib/utils";
 import type { DateObject, FormStep } from "@/types";
 
 type ReviewStepProps = {
@@ -35,14 +35,14 @@ export function ReviewStep({ formSteps, onEdit }: ReviewStepProps) {
       }
 
       // Exclude conditional steps that don't meet their conditions
-      if (step.conditionalOn) {
-        const watchedValue = getNestedValue<unknown>(
-          formValues as Record<string, unknown>,
-          step.conditionalOn.field
-        );
-        if (watchedValue !== step.conditionalOn.value) {
-          return null;
-        }
+      if (
+        step.conditionalOn &&
+        !checkConditionalRule(
+          step.conditionalOn,
+          formValues as Record<string, unknown>
+        )
+      ) {
+        return null;
       }
 
       // Create section data with original step index
@@ -55,14 +55,14 @@ export function ReviewStep({ formSteps, onEdit }: ReviewStepProps) {
           );
 
           // Skip conditional fields that shouldn't be shown
-          if (field.conditionalOn) {
-            const watchedValue = getNestedValue<unknown>(
-              formValues as Record<string, unknown>,
-              field.conditionalOn.field
-            );
-            if (watchedValue !== field.conditionalOn.value) {
-              return null; // Don't show if condition not met
-            }
+          if (
+            field.conditionalOn &&
+            !checkConditionalRule(
+              field.conditionalOn,
+              formValues as Record<string, unknown>
+            )
+          ) {
+            return null; // Don't show if condition not met
           }
 
           // Skip empty optional fields (but allow 0 for number fields)

--- a/src/components/forms/register-a-birth-form.tsx
+++ b/src/components/forms/register-a-birth-form.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import DynamicMultiStepForm from "@/components/forms/builder/multi-step-form";
+import { formSteps } from "@/schema/register-a-birth";
+
+export default function RegisterABirthForm() {
+  return (
+    <DynamicMultiStepForm
+      formSteps={formSteps}
+      serviceTitle="Register a birth"
+      // storageKey="register-a-birth"
+      storageKey="register-birth-form"
+    />
+  );
+}

--- a/src/content/register-a-birth/start.md
+++ b/src/content/register-a-birth/start.md
@@ -1,23 +1,24 @@
 ---
-title: "Register a Birth"
+title: "Register a birth"
 stage: "alpha"
-publish_date: 2025-11-03
+publish_date: 2026-01-23
 ---
 
-You can pre-register the birth online. It should take around 10 minutes.
+You should complete the registration form in one go. At the moment, it is not possible to save your answers and come back to them later.
 
-To complete the registration, the parent(s) or guardian(s) must then visit the Registration Department to sign the birth register in person. 
+## How long does it take?
 
+It should take no longer than 15 minutes to pre-register a birth online.
 
-<a data-start-link href="/family-birth-relationships/register-a-birth/form">Start now</a>
+To complete the registration, the parent(s) or guardian(s) must then visit the Registration Department to sign the birth register in person.
 
-## Information you need for pre-registering a birth online
+## What you will need
 
-You should know:
+You will need to know:
 
 - child’s place and date of the birth
 
-- child’s first name, middle names, last name and sex 
+- child’s first name, middle names, last name and sex
 
 - parents’ first names, middle names, last names and current address(es)
 
@@ -27,8 +28,10 @@ You should know:
 
 - whether the father wants to be named on the official records
 
-- parents’ National Identity number (or passport number for foreign nationals) 
+- parents’ National Identity number (or passport number for foreign nationals)
 
 - parents’ occupations
 
 - how many certified copies of the birth certificate you would like to buy
+
+<a data-start-link href="/family-birth-relationships/register-a-birth/form">Start now</a>

--- a/src/lib/form-registry.ts
+++ b/src/lib/form-registry.ts
@@ -1,9 +1,9 @@
 import { lazy } from "react";
 
 export const FORM_COMPONENTS = {
-  // "register-a-birth": lazy(
-  //   () => import("@/components/forms/register-a-birth-form")
-  // ),
+  "register-a-birth": lazy(
+    () => import("@/components/forms/register-a-birth-form")
+  ),
   "register-for-community-sports-training-programme": lazy(
     () =>
       import(
@@ -59,6 +59,7 @@ export type FormSlug = keyof typeof FORM_COMPONENTS;
  * Used to clear form data when a user visits the /start page.
  */
 export const FORM_STORAGE_KEYS: Record<FormSlug, string> = {
+  "register-a-birth": "register-a-birth",
   "register-for-community-sports-training-programme":
     "community-sports-programme",
   "apply-to-be-a-project-protege-mentor": "project-protege-mentor",

--- a/src/lib/schema-generator.ts
+++ b/src/lib/schema-generator.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { checkConditionalRule } from "@/lib/utils";
 import {
   createDateSchema,
   dateValidation,
@@ -73,6 +74,11 @@ function objectToZodSchema(
 }
 
 function createFieldSchema(field: FormField | NestedFormField): z.ZodTypeAny {
+  // Heading fields don't need schema validation
+  if (field.type === "heading") {
+    return z.any().optional();
+  }
+
   let schema: z.ZodTypeAny = z.string();
 
   const validation = field.validation as NonDateFieldValidation &
@@ -567,17 +573,18 @@ export function generateFormSchema(formSteps: FormStep[]) {
 
     // Validate conditional fields (conditionalOn)
     for (const field of conditionalFields) {
+      // Skip heading fields - they don't have validation
+      if (field.type === "heading") continue;
       if (!field.conditionalOn) continue;
 
-      const parentValue = getNestedValue(
-        data as Record<string, unknown>,
-        field.conditionalOn.field
-      );
       const fieldValue = getNestedValue(
         data as Record<string, unknown>,
         field.name
       );
-      const isVisible = parentValue === field.conditionalOn.value;
+      const isVisible = checkConditionalRule(
+        field.conditionalOn,
+        data as Record<string, unknown>
+      );
 
       if (
         isVisible &&
@@ -611,10 +618,11 @@ export function generateFormSchema(formSteps: FormStep[]) {
               for (const nestedField of field.fieldArray.fields) {
                 if (!nestedField.conditionalOn) continue;
 
-                const parentValue = item[nestedField.conditionalOn.field];
                 const fieldValue = item[nestedField.name];
-                const isVisible =
-                  parentValue === nestedField.conditionalOn.value;
+                const isVisible = checkConditionalRule(
+                  nestedField.conditionalOn,
+                  item
+                );
 
                 if (
                   isVisible &&

--- a/src/schema/register-a-birth.ts
+++ b/src/schema/register-a-birth.ts
@@ -1,0 +1,738 @@
+import { barbadosParishes } from "@/data/constants";
+import type { FormStep } from "@/types";
+
+export const formSteps: FormStep[] = [
+  {
+    id: "marriage-status",
+    title:
+      "When the child was born, were the mother and father married to each other?",
+    description: `We ask this because your answer might determine:
+
+- the surname of the child
+- who can register the birth`,
+    fields: [
+      {
+        name: "marriageStatus",
+        label: "",
+        type: "radio",
+        hint: "",
+        validation: {
+          required: "Select your preference",
+        },
+        options: [
+          { label: "Yes", value: "yes" },
+          { label: "No", value: "no" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "include-father-details",
+    title: "Do you want to include the father's details on the birth record?",
+    description:
+      "If you choose 'Yes', both parents must go to the Registration Department and sign the official register together\n\nIf you choose 'No', the mother must go to the Registration Department but it is not necessary for the father to attend",
+    conditionalOn: {
+      field: "marriageStatus",
+      value: "no",
+    },
+    fields: [
+      {
+        name: "includeFatherDetails",
+        label: "",
+        type: "radio",
+        hint: "",
+        validation: {
+          required: "Select your preference",
+        },
+        options: [
+          { label: "Yes, include the father's details", value: "yes" },
+          { label: "No, do not include the father's details", value: "no" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "father-details",
+    title: "Tell us about the child's father",
+    description: "",
+    conditionalOn: [
+      {
+        field: "includeFatherDetails",
+        value: "yes",
+      },
+      { field: "marriageStatus", value: "yes" },
+    ],
+    fields: [
+      {
+        name: "father.firstName",
+        label: "First Name",
+        type: "text",
+        placeholder: "",
+        validation: {
+          required: "First name is required",
+          minLength: {
+            value: 2,
+            message: "First name must be at least 2 characters",
+          },
+        },
+      },
+      {
+        name: "father.middleName",
+        label: "Middle Name(s)",
+        hint: "If they have more than one, add them in order",
+        type: "text",
+        placeholder: "",
+        validation: {
+          required: false,
+        },
+      },
+      {
+        name: "father.lastName",
+        label: "Last Name",
+        type: "text",
+        placeholder: "",
+        validation: {
+          required: "Last name is required",
+          minLength: {
+            value: 2,
+            message: "Last name must be at least 2 characters",
+          },
+        },
+      },
+
+      {
+        name: "father.idNumber",
+        label: "Barbados National Identification (ID) Number",
+        width: "medium",
+        type: "text",
+        placeholder: "",
+        validation: {
+          required: "ID Number is required",
+          pattern: {
+            value: "^\\d{2}(0[1-9]|1[0-2])(0[1-9]|[12]\\d|3[01])-\\d{4}$",
+            message: "Enter a valid ID number (e.g., 991231-0001)",
+          },
+        },
+        // Note: ID Number validation is skipped when ShowHide is open (handled in step validation)
+        skipValidationWhenShowHideOpen: "father.usePassportInstead",
+      },
+      {
+        name: "father.passportDetails",
+        label: "",
+        type: "showHide",
+        validation: {},
+        showHide: {
+          summary: "Use passport number instead",
+          stateFieldName: "father.usePassportInstead",
+          description:
+            "If you don't have a National ID number, you can use your passport number instead.",
+          fields: [
+            {
+              name: "father.passportNumber",
+              label: "Passport Number",
+              type: "text",
+              placeholder: "",
+              validation: {
+                required: "Passport number is required",
+                minLength: {
+                  value: 6,
+                  message: "Passport number must be at least 6 characters",
+                },
+              },
+            },
+            {
+              name: "father.age",
+              label: "Age",
+              type: "number",
+              placeholder: "",
+              validation: {
+                required: "Age is required",
+                min: {
+                  value: 12,
+                  message: "Age must be 12 or greater",
+                },
+                max: {
+                  value: 120,
+                  message: "Age must be 120 or less",
+                },
+              },
+            },
+          ],
+        },
+      },
+
+      {
+        name: "father.currentAddressHeading",
+        label: "Current address",
+        type: "heading",
+      },
+      {
+        name: "father.parish",
+        label: "Parish",
+        type: "select",
+        width: "medium",
+        validation: {
+          required: "Parish is required",
+        },
+        options: barbadosParishes,
+      },
+      {
+        name: "father.streetAddress",
+        label: "Street address",
+        type: "textarea",
+        placeholder: "",
+        rows: 3,
+        validation: {
+          required: "Street address is required",
+          minLength: {
+            value: 5,
+            message: "Address must be at least 5 characters",
+          },
+        },
+      },
+      {
+        name: "father.seperator1",
+        label: "",
+        type: "heading",
+      },
+      {
+        name: "father.occupation",
+        label: "Occupation",
+        hint: "This will be included on the child's birth certificate and in official records",
+        type: "text",
+        placeholder: "",
+        validation: {
+          required: "Occupation is required",
+          minLength: {
+            value: 2,
+            message: "Occupation must be at least 2 characters",
+          },
+        },
+      },
+    ],
+  },
+
+  {
+    id: "mother-details",
+    title: "Tell us about the child's mother",
+    description: "",
+    fields: [
+      {
+        name: "mother.firstName",
+        label: "First Name",
+        type: "text",
+        placeholder: "",
+        validation: {
+          required: "First name is required",
+          minLength: {
+            value: 2,
+            message: "First name must be at least 2 characters",
+          },
+        },
+      },
+      {
+        name: "mother.middleName",
+        label: "Middle Name(s)",
+        hint: "If they have more than one, add them in order",
+        type: "text",
+        placeholder: "",
+        validation: {},
+      },
+      {
+        name: "mother.lastName",
+        label: "Last Name",
+        type: "text",
+        placeholder: "",
+        validation: {
+          required: "Last name is required",
+          minLength: {
+            value: 2,
+            message: "Last name must be at least 2 characters",
+          },
+        },
+      },
+      {
+        name: "mother.idNumber",
+        label: "Barbados National Identification (ID) Number",
+        type: "text",
+        placeholder: "",
+        validation: {
+          required: "ID Number is required",
+          pattern: {
+            value: "^\\d{2}(0[1-9]|1[0-2])(0[1-9]|[12]\\d|3[01])-\\d{4}$",
+            message: "Enter a valid ID number (e.g., 991231-0001)",
+          },
+        },
+        // Note: ID Number validation is skipped when ShowHide is open (handled in step validation)
+        skipValidationWhenShowHideOpen: "mother.usePassportInstead",
+      },
+      {
+        name: "mother.passportDetails",
+        label: "",
+        type: "showHide",
+        validation: {},
+        showHide: {
+          summary: "Use passport number instead",
+          stateFieldName: "mother.usePassportInstead",
+          description:
+            "If you don't have a National ID number, you can use your passport number instead.",
+          fields: [
+            {
+              name: "mother.passportNumber",
+              label: "Passport Number",
+              type: "text",
+              placeholder: "",
+              validation: {
+                required: "Passport number is required",
+                minLength: {
+                  value: 6,
+                  message: "Passport number must be at least 6 characters",
+                },
+              },
+            },
+            {
+              name: "mother.age",
+              label: "Age",
+              type: "number",
+              placeholder: "",
+              validation: {
+                required: "Age is required",
+                min: {
+                  value: 12,
+                  message: "Age must be 12 or greater",
+                },
+                max: {
+                  value: 120,
+                  message: "Age must be 120 or less",
+                },
+              },
+            },
+          ],
+        },
+      },
+      {
+        name: "mother.maidenName",
+        label: "Maiden Name",
+        type: "text",
+        validation: {
+          required: false,
+        },
+      },
+      {
+        name: "mother.currentAddressHeading",
+        label: "Current address",
+        type: "heading",
+      },
+      {
+        name: "mother.parish",
+        label: "Parish",
+        type: "select",
+        width: "medium",
+        validation: {
+          required: "Parish is required",
+        },
+        options: barbadosParishes,
+      },
+      {
+        name: "mother.streetAddress",
+        label: "Street address",
+        type: "textarea",
+        placeholder: "",
+        rows: 3,
+        validation: {
+          required: "Street address is required",
+          minLength: {
+            value: 5,
+            message: "Address must be at least 5 characters",
+          },
+        },
+      },
+      {
+        name: "mother.contactDetailsHeading",
+        label: "Contact details",
+        type: "heading",
+      },
+      {
+        name: "mother.telephoneNumber",
+        label: "Telephone number",
+        type: "tel",
+        placeholder: "",
+        validation: {
+          required: "Telephone number is required",
+          pattern: {
+            value:
+              "^(1[-]246[-]\\d{3}[-]\\d{4}|1[\\s]246[\\s]\\d{3}[\\s]\\d{4}|1246\\d{7})$",
+            message:
+              "Please enter a valid phone number (for example, 12462345678, 1-246-234-5678, or 1 246 234 5678)",
+          },
+        },
+      },
+      {
+        name: "mother.emailAddress",
+        label: "Email address",
+        type: "email",
+        placeholder: "",
+        validation: {
+          required: "Email address is required",
+        },
+      },
+      { name: "mother.seperator1", label: "", type: "heading" },
+      {
+        name: "mother.occupation",
+        label: "Occupation",
+        hint: "This will be included on the child's birth certificate and in official records",
+        type: "text",
+        placeholder: "",
+        validation: {
+          required: "Occupation is required",
+          minLength: {
+            value: 2,
+            message: "Occupation must be at least 2 characters",
+          },
+        },
+      },
+    ],
+  },
+  {
+    id: "birth-details",
+    title: "Tell us about the birth",
+    description: "",
+    fields: [
+      {
+        name: "birth.placeOfBirth",
+        label: "Where did the birth take place?",
+        type: "radio",
+        placeholder: "",
+        validation: {
+          required: "Select a location",
+        },
+        options: [
+          { label: "Health facility", value: "health-facility" },
+          { label: "Residential", value: "residential" },
+          { label: "Other", value: "other" },
+        ],
+      },
+      {
+        name: "birth.healthFacility",
+        label: "Health Facility",
+        type: "select",
+        validation: {
+          required: "Health Facility is required",
+        },
+        conditionalOn: {
+          field: "birth.placeOfBirth",
+          value: "health-facility",
+        },
+        options: [
+          { label: "", value: "" },
+          {
+            label: "Queen Elizabeth Hospital",
+            value: "3d5cd721-df37-493c-86c0-41b8aa42e27d",
+          },
+          {
+            label: "Bayview Hospital",
+            value: "9ddfdd4a-4219-4ca0-ad34-5a9fc1071225",
+          },
+          {
+            label: "MD Alliance Surgery and Birthing Centre",
+            value: "a1abb507-4a25-4795-a280-c99226cb916f",
+          },
+        ],
+      },
+      {
+        name: "birth.parish",
+        label: "Parish",
+        type: "select",
+        width: "medium",
+        validation: {
+          required: "Parish is required",
+        },
+        conditionalOn: {
+          field: "birth.placeOfBirth",
+          value: "residential",
+        },
+        options: barbadosParishes,
+      },
+      {
+        name: "birth.streetAddress",
+        label: "Street address",
+        type: "textarea",
+        placeholder: "",
+        rows: 3,
+        validation: {
+          required: "Street address is required",
+          minLength: {
+            value: 5,
+            message: "Address must be at least 5 characters",
+          },
+        },
+        conditionalOn: {
+          field: "birth.placeOfBirth",
+          value: "residential",
+        },
+      },
+      {
+        name: "birth.parish",
+        label: "Parish",
+        type: "select",
+        width: "medium",
+        validation: {
+          required: "Parish is required",
+        },
+        conditionalOn: {
+          field: "birth.placeOfBirth",
+          value: "other",
+        },
+        options: barbadosParishes,
+      },
+      {
+        name: "birth.streetAddress",
+        label: "Street address",
+        type: "textarea",
+        placeholder: "",
+        rows: 3,
+        validation: {
+          required: "Street address is required",
+          minLength: {
+            value: 5,
+            message: "Address must be at least 5 characters",
+          },
+        },
+        conditionalOn: {
+          field: "birth.placeOfBirth",
+          value: "other",
+        },
+      },
+
+      {
+        name: "birth.separator1",
+        label: "",
+        type: "heading",
+      },
+
+      {
+        name: "birth.numberOfBirths",
+        label: "How many births do you need to register?",
+        type: "radio",
+        placeholder: "",
+        validation: {
+          required: "Select a location",
+        },
+        options: [
+          { label: "Single", value: "single" },
+          { label: "Twins", value: "twins" },
+          { label: "Triplets", value: "triplets" },
+          { label: "Higher multiple births", value: "n" },
+        ],
+      },
+      {
+        name: "birth.attendantAtBirth",
+        label: "Attendant at birth",
+        type: "select",
+        width: "medium",
+        validation: {
+          required: false,
+        },
+        options: [
+          { label: "", value: "" },
+          { label: "Doctor", value: "doctor" },
+          { label: "Midwife", value: "midwife" },
+          { label: "Nurse", value: "nurse" },
+          { label: "Relative", value: "relative" },
+          { label: "None", value: "none" },
+        ],
+      },
+      {
+        name: "birth.textLabel1",
+        label:
+          "How many births has this mother had in total (including the one(s) you are registering now)",
+        type: "heading",
+        as: "h3",
+      },
+      {
+        name: "birth.bornAlive",
+        label: "Born alive",
+        type: "text",
+        placeholder: "",
+        inputClassName: "w-20",
+        validation: {
+          required: false,
+          pattern: {
+            value: "^\\d*$",
+            message: "Please enter numbers only",
+          },
+        },
+      },
+      {
+        name: "birth.stillborn",
+        label: "Still born",
+        type: "text",
+        placeholder: "",
+        inputClassName: "w-20",
+        validation: {
+          required: false,
+          pattern: {
+            value: "^\\d*$",
+            message: "Please enter numbers only",
+          },
+        },
+      },
+      {
+        name: "birth.totalStillAlive",
+        label: "Total still alive",
+        type: "text",
+        placeholder: "",
+        inputClassName: "w-20",
+        validation: {
+          required: false,
+          pattern: {
+            value: "^\\d*$",
+            message: "Please enter numbers only",
+          },
+        },
+      },
+    ],
+  },
+  {
+    id: "child-details",
+    title: "Tell us about the child",
+    description: "",
+    fields: [
+      {
+        name: "child.firstName",
+        label: "First Name",
+        type: "text",
+        placeholder: "",
+        validation: {
+          required: "First name is required",
+          minLength: {
+            value: 2,
+            message: "First name must be at least 2 characters",
+          },
+        },
+      },
+      {
+        name: "child.middleName",
+        label: "Middle Name(s)",
+        hint: "If they have more than one, add them in order",
+        type: "text",
+        placeholder: "",
+        validation: {},
+      },
+      {
+        name: "child.lastName",
+        label: "Last Name",
+        type: "text",
+        placeholder: "",
+        validation: {
+          required: "Last name is required",
+          minLength: {
+            value: 2,
+            message: "Last name must be at least 2 characters",
+          },
+        },
+      },
+
+      {
+        name: "child.dateOfBirth",
+        label: "Date of Birth",
+        type: "date",
+        placeholder: "For example, December 30 1986",
+        validation: {
+          required: "Date of birth is required",
+          date: {
+            type: "past",
+          },
+        },
+      },
+      {
+        name: "child.sexAtBirth",
+        label: "Sex",
+        type: "select",
+        width: "short",
+        validation: {
+          required: "Sex at birth is required",
+        },
+        options: [
+          { label: "", value: "" },
+          { label: "Male", value: "male" },
+          { label: "Female", value: "female" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "order-details",
+    title: "Order a birth certificate",
+    description:
+      "A birth certificate is essential for access to some public services. You wil need to pay BBD$5.00 for each certificate when you collect them. We keep the original so you can order a certified copy at any point. The birth registration is free of charge.",
+    fields: [
+      {
+        name: "order.numberOfCopies",
+        label: "Number of Copies",
+        type: "number",
+        width: "short",
+        validation: {
+          required: "Number of copies is required",
+          min: {
+            value: 1,
+            message: "You must order at least 1 copy",
+          },
+        },
+      },
+    ],
+  },
+
+  {
+    id: "check-your-answers",
+    title: "Check your answers",
+    fields: [],
+  },
+  {
+    id: "declaration",
+    title: "Declaration",
+    fields: [
+      {
+        name: "declaration.confirmed",
+        label:
+          "I confirm that my information is correct and I am happy for it to be verified. I understand that false details may lead to my application being rejected, and that the Government of Barbados will keep my information confidential.",
+        type: "checkbox",
+        validation: {
+          required: "You must confirm the declaration to continue",
+        },
+      },
+      {
+        name: "dateOfDeclaration",
+        label: "Date of declaration",
+        hidden: true,
+        type: "date",
+        validation: {
+          required: "Date is required",
+          date: {
+            type: "pastOrToday",
+          },
+        },
+      },
+    ],
+  },
+  {
+    id: "confirmation",
+    title: "Thank you for pre-registering a birth",
+    description: "The Registration Department has received your information.",
+    fields: [],
+    bodyContent: `## What happens next
+
+The Registration Department will contact you within 3 working days and invite you to visit, in person, to sign the birth register.
+
+Show your reference number to the Applications Desk at the Registration Department. You will need to:
+
+1. Sign the register and complete the registration.
+2. Collect your copy or copies of the birth certificate. You will be able to pay in cash or by card.
+
+### Who must attend the appointment
+
+[See what you need to bring with you](https://alpha.gov.bb/)  
+[Who should register a birth?](https://alpha.gov.bb/)`,
+    enableFeedback: true,
+  },
+];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,7 +10,8 @@ export type FieldType =
   | "checkbox"
   | "fieldArray"
   | "showHide"
-  | "file";
+  | "file"
+  | "heading";
 
 // Date-specific validation rules (only applicable when type === "date")
 export type DateValidationRule =
@@ -51,6 +52,9 @@ export type ConditionalRule = {
   value: string; // The value that triggers this field to show
 };
 
+/** Single rule or array of rules (OR logic - any matching rule shows the element) */
+export type ConditionalOn = ConditionalRule | ConditionalRule[];
+
 export type NestedFormField = {
   name: string;
   label: string;
@@ -61,7 +65,7 @@ export type NestedFormField = {
   validation: NonDateFieldValidation | DateFieldValidation;
   options?: SelectOption[];
   rows?: number;
-  conditionalOn?: ConditionalRule; // For conditional fields within field arrays
+  conditionalOn?: ConditionalOn; // For conditional fields within field arrays
   width?: "short" | "medium" | "full"; // Field width (defaults to "full")
 };
 
@@ -93,12 +97,13 @@ export type BaseFormField = {
   validation: ValidationRule;
   options?: SelectOption[]; // For select and radio fields
   rows?: number; // For textarea
-  conditionalOn?: ConditionalRule; // For conditional fields
+  conditionalOn?: ConditionalOn; // For conditional fields
   fieldArray?: FieldArrayConfig; // For fieldArray type
   showHide?: ShowHideConfig; // For showHide type (collapsible disclosure)
   /** Field name of ShowHide state - when this state is "open", validation is skipped for this field */
   skipValidationWhenShowHideOpen?: string;
   width?: "short" | "medium" | "full"; // Field width (defaults to "full")
+  inputClassName?: string;
 };
 
 type DateFormField = BaseFormField & {
@@ -149,6 +154,17 @@ type FileFormField = BaseFormField & {
   multiple?: boolean;
 };
 
+type HeadingFormField = {
+  type: "heading";
+  name: string; // Unique identifier
+  label: string; // The heading text
+  hint?: string; // Optional description below the heading
+  conditionalOn?: ConditionalOn; // Headings can be conditional too
+  width?: "short" | "medium" | "full"; // Field width (defaults to "full")
+  /** Heading level. Defaults to "h2" */
+  as?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+};
+
 export type FormField =
   | DateFormField
   | OptionFormField
@@ -157,7 +173,8 @@ export type FormField =
   | FieldArrayFormField
   | TextFormField
   | ShowHideFormField
-  | FileFormField;
+  | FileFormField
+  | HeadingFormField;
 
 export type ValidationRule = NonDateFieldValidation | DateFieldValidation;
 
@@ -197,7 +214,7 @@ export type FormStep = {
   title: string;
   description?: string;
   fields: FormField[];
-  conditionalOn?: ConditionalRule; // For conditional steps
+  conditionalOn?: ConditionalOn; // For conditional steps
   /** Markdown content for confirmation page body (replaces steps array) */
   bodyContent?: string;
   contactDetails?: ContactDetails; // For confirmation pages
@@ -225,6 +242,11 @@ export type ApiResponse = {
     amount?: number;
     description?: string;
     numberOfCopies?: number;
+    integrations?: {
+      opencrvs?: {
+        trackingId?: string;
+      };
+    };
   };
   errors?: { field: string; message: string; code: string }[];
   message?: string;

--- a/tests/e2e/forms/register-a-birth.spec.ts
+++ b/tests/e2e/forms/register-a-birth.spec.ts
@@ -1,0 +1,703 @@
+import { faker } from "@faker-js/faker";
+import { expect, test } from "@playwright/test";
+import type { ApiResponse } from "@/types";
+
+const FORM_URL = "/family-birth-relationships/register-a-birth/form";
+const FORM_KEY = "register-birth";
+const API_SUBMIT_PATH = `/forms/${FORM_KEY}/submit`;
+
+/**
+ * Test data generators
+ */
+const generateParentData = () => ({
+  firstName: faker.person.firstName(),
+  middleName: faker.person.middleName(),
+  lastName: faker.person.lastName(),
+  // TODO: DDMMYY-XXXX, this test can fail
+  idNumber: `${faker.number.int({ min: 100_000, max: 999_999 })}-${faker.number.int({ min: 1000, max: 9999 })}`,
+  parish: faker.helpers.arrayElement([
+    "christ-church",
+    "st-andrew",
+    "st-george",
+    "st-james",
+    "st-john",
+    "st-joseph",
+    "st-lucy",
+    "st-michael",
+    "st-peter",
+    "st-philip",
+    "st-thomas",
+  ]),
+  streetAddress: faker.location.streetAddress(),
+  occupation: faker.person.jobTitle(),
+});
+
+const generateMotherData = () => ({
+  ...generateParentData(),
+  maidenName: faker.person.lastName(),
+  telephoneNumber: `1246${faker.string.numeric(7)}`,
+  emailAddress: "testing@govtech.bb",
+});
+
+const generateChildData = () => ({
+  firstName: faker.person.firstName(),
+  middleName: faker.person.middleName(),
+  lastName: faker.person.lastName(),
+  dateOfBirth: {
+    day: faker.number.int({ min: 1, max: 28 }).toString().padStart(2, "0"),
+    month: faker.number.int({ min: 1, max: 12 }).toString().padStart(2, "0"),
+    year: faker.number.int({ min: 2020, max: 2024 }).toString(),
+  },
+  sexAtBirth: faker.helpers.arrayElement(["male", "female"]),
+});
+
+/**
+ * Log the submitted form data from the request
+ */
+function logSubmittedData(request: { postDataJSON: () => unknown }) {
+  const submittedData = request.postDataJSON();
+  console.log("\n📋 SUBMITTED FORM DATA:");
+  console.log("─".repeat(50));
+  console.log(JSON.stringify(submittedData, null, 2));
+  console.log("─".repeat(50));
+}
+
+/**
+ * Verify the API response structure and success status
+ */
+function verifyApiResponse(response: ApiResponse, formId: string) {
+  expect(response.success).toBe(true);
+  expect(response.message).toBeTruthy();
+  expect(response.data).toBeTruthy();
+
+  if (!response.data) {
+    throw new Error("Response data is undefined");
+  }
+
+  expect(response.data.submissionId).toBeTruthy();
+  expect(response.data.formId).toBe(formId);
+  expect(response.data.status).toBeTruthy();
+  expect(response.data.processedAt).toBeTruthy();
+
+  console.log("✅ API Response verified:");
+  console.log(`   - Submission ID: ${response.data.submissionId}`);
+  console.log(`   - Status: ${response.data.status}`);
+  if (response.data.referenceNumber) {
+    console.log(`   - Reference Number: ${response.data.referenceNumber}`);
+  }
+}
+
+/**
+ * Helper to fill father details step
+ */
+async function fillFatherDetails(
+  page: import("@playwright/test").Page,
+  father: ReturnType<typeof generateParentData>
+) {
+  await page.locator('input[name="father.firstName"]').fill(father.firstName);
+  await page.locator('input[name="father.middleName"]').fill(father.middleName);
+  await page.locator('input[name="father.lastName"]').fill(father.lastName);
+  await page.locator('input[name="father.idNumber"]').fill(father.idNumber);
+  await page
+    .locator('select[name="father.parish"]')
+    .selectOption(father.parish);
+  await page
+    .locator('textarea[name="father.streetAddress"]')
+    .fill(father.streetAddress);
+  await page.locator('input[name="father.occupation"]').fill(father.occupation);
+}
+
+/**
+ * Helper to fill mother details step
+ */
+async function fillMotherDetails(
+  page: import("@playwright/test").Page,
+  mother: ReturnType<typeof generateMotherData>
+) {
+  await page.locator('input[name="mother.firstName"]').fill(mother.firstName);
+  await page.locator('input[name="mother.middleName"]').fill(mother.middleName);
+  await page.locator('input[name="mother.lastName"]').fill(mother.lastName);
+  await page.locator('input[name="mother.idNumber"]').fill(mother.idNumber);
+  await page
+    .locator('select[name="mother.parish"]')
+    .selectOption(mother.parish);
+  await page
+    .locator('textarea[name="mother.streetAddress"]')
+    .fill(mother.streetAddress);
+  await page
+    .locator('input[name="mother.telephoneNumber"]')
+    .fill(mother.telephoneNumber);
+  await page
+    .locator('input[name="mother.emailAddress"]')
+    .fill(mother.emailAddress);
+  await page.locator('input[name="mother.occupation"]').fill(mother.occupation);
+}
+
+/**
+ * Helper to fill birth details step (health facility)
+ */
+async function fillBirthDetailsHealthFacility(
+  page: import("@playwright/test").Page
+) {
+  // Select health facility option
+  await page.getByText("Health facility", { exact: true }).click();
+
+  // Wait for conditional field to appear and select hospital
+  await page
+    .locator('select[name="birth.healthFacility"]')
+    .selectOption("3d5cd721-df37-493c-86c0-41b8aa42e27d"); // Queen Elizabeth Hospital
+
+  // Select single birth
+  await page.getByText("Single", { exact: true }).click();
+}
+
+/**
+ * Helper to fill birth details step (residential)
+ */
+async function fillBirthDetailsResidential(
+  page: import("@playwright/test").Page,
+  parish: string,
+  address: string
+) {
+  // Select residential option
+  await page.getByText("Residential", { exact: true }).click();
+
+  // Wait for conditional fields to appear
+  await page.locator('select[name="birth.parish"]').selectOption(parish);
+  await page.locator('textarea[name="birth.streetAddress"]').fill(address);
+
+  // Select single birth
+  await page.getByText("Single", { exact: true }).click();
+}
+
+/**
+ * Helper to fill child details step
+ */
+async function fillChildDetails(
+  page: import("@playwright/test").Page,
+  child: ReturnType<typeof generateChildData>
+) {
+  await page.locator('input[name="child.firstName"]').fill(child.firstName);
+  await page.locator('input[name="child.middleName"]').fill(child.middleName);
+  await page.locator('input[name="child.lastName"]').fill(child.lastName);
+  await page
+    .locator("#child\\.dateOfBirth-month")
+    .fill(child.dateOfBirth.month);
+  await page.locator("#child\\.dateOfBirth-day").fill(child.dateOfBirth.day);
+  await page.locator("#child\\.dateOfBirth-year").fill(child.dateOfBirth.year);
+  await page
+    .locator('select[name="child.sexAtBirth"]')
+    .selectOption(child.sexAtBirth);
+}
+
+test.describe("Register a Birth Form", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(FORM_URL);
+    await expect(page.locator("form")).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("complete form - married parents", async ({ page }) => {
+    const father = generateParentData();
+    const mother = generateMotherData();
+    const child = generateChildData();
+    const numberOfCopies = faker.number.int({ min: 1, max: 3 });
+
+    // Step 1: Marriage Status
+    await expect(
+      page.getByRole("heading", { name: /were the mother and father married/i })
+    ).toBeVisible();
+
+    await page.getByText("Yes", { exact: true }).click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 2: Father Details (shown because married)
+    await expect(
+      page.getByRole("heading", { name: /tell us about the child's father/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    await fillFatherDetails(page, father);
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 3: Mother Details
+    await expect(
+      page.getByRole("heading", { name: /tell us about the child's mother/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    await fillMotherDetails(page, mother);
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 4: Birth Details
+    await expect(
+      page.getByRole("heading", { name: /tell us about the birth/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    await fillBirthDetailsHealthFacility(page);
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 5: Child Details
+    await expect(
+      page.getByRole("heading", { name: /tell us about the child$/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    await fillChildDetails(page, child);
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 6: Order Details
+    await expect(
+      page.getByRole("heading", { name: /order a birth certificate/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    await page
+      .locator('input[name="order.numberOfCopies"]')
+      .fill(numberOfCopies.toString());
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 7: Check Your Answers
+    await expect(
+      page.getByRole("heading", { name: /check your answers/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    // Verify some data appears on review page
+    await expect(page.getByText(father.firstName)).toBeVisible();
+    await expect(page.getByText(mother.firstName)).toBeVisible();
+    await expect(page.getByText(child.firstName)).toBeVisible();
+
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 8: Declaration
+    await expect(
+      page.getByRole("heading", { name: /declaration/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    // Check declaration checkbox
+    const checkbox = page.locator('button[role="checkbox"]');
+    await expect(checkbox).toBeVisible();
+    await checkbox.click();
+
+    // Set up API response interception before submitting
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes(API_SUBMIT_PATH) &&
+        response.request().method() === "POST",
+      { timeout: 30_000 }
+    );
+
+    // Submit
+    await page.getByRole("button", { name: /submit/i }).click();
+
+    // Wait for and verify API response
+    const response = await responsePromise;
+    expect(response.status()).toBe(200);
+
+    logSubmittedData(response.request());
+
+    const responseBody = (await response.json()) as ApiResponse;
+    verifyApiResponse(responseBody, FORM_KEY);
+
+    // Verify UI navigated to confirmation
+    await expect(
+      page.getByRole("heading", { name: /thank you|confirmation/i })
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("complete form - unmarried parents, include father", async ({
+    page,
+  }) => {
+    const father = generateParentData();
+    const mother = generateMotherData();
+    const child = generateChildData();
+    const numberOfCopies = faker.number.int({ min: 1, max: 3 });
+
+    // Step 1: Marriage Status - No
+    await page.getByText("No", { exact: true }).click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 2: Include Father Details - Yes
+    await expect(
+      page.getByRole("heading", {
+        name: /do you want to include the father's details/i,
+      })
+    ).toBeVisible({ timeout: 5000 });
+
+    await page.getByText("Yes, include the father's details").click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 3: Father Details
+    await expect(
+      page.getByRole("heading", { name: /tell us about the child's father/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    await fillFatherDetails(page, father);
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 4: Mother Details
+    await expect(
+      page.getByRole("heading", { name: /tell us about the child's mother/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    await fillMotherDetails(page, mother);
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 5: Birth Details
+    await fillBirthDetailsHealthFacility(page);
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 6: Child Details
+    await fillChildDetails(page, child);
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 7: Order Details
+    await page
+      .locator('input[name="order.numberOfCopies"]')
+      .fill(numberOfCopies.toString());
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 8: Check Your Answers
+    await expect(
+      page.getByRole("heading", { name: /check your answers/i })
+    ).toBeVisible({ timeout: 5000 });
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 9: Declaration
+    const checkbox = page.locator('button[role="checkbox"]');
+    await checkbox.click();
+
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes(API_SUBMIT_PATH) &&
+        response.request().method() === "POST",
+      { timeout: 30_000 }
+    );
+
+    await page.getByRole("button", { name: /submit/i }).click();
+
+    const response = await responsePromise;
+    expect(response.status()).toBe(200);
+
+    logSubmittedData(response.request());
+
+    const responseBody = (await response.json()) as ApiResponse;
+    verifyApiResponse(responseBody, FORM_KEY);
+
+    await expect(
+      page.getByRole("heading", { name: /thank you|confirmation/i })
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("complete form - unmarried parents, exclude father (shortest path)", async ({
+    page,
+  }) => {
+    const mother = generateMotherData();
+    const child = generateChildData();
+    const numberOfCopies = faker.number.int({ min: 1, max: 3 });
+
+    // Step 1: Marriage Status - No
+    await page.getByText("No", { exact: true }).click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 2: Include Father Details - No
+    await expect(
+      page.getByRole("heading", {
+        name: /do you want to include the father's details/i,
+      })
+    ).toBeVisible({ timeout: 5000 });
+
+    await page.getByText("No, do not include the father's details").click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 3: Mother Details (father details step is skipped)
+    await expect(
+      page.getByRole("heading", { name: /tell us about the child's mother/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    await fillMotherDetails(page, mother);
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 4: Birth Details
+    await fillBirthDetailsHealthFacility(page);
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 5: Child Details
+    await fillChildDetails(page, child);
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 6: Order Details
+    await page
+      .locator('input[name="order.numberOfCopies"]')
+      .fill(numberOfCopies.toString());
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 7: Check Your Answers
+    await expect(
+      page.getByRole("heading", { name: /check your answers/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    // Verify father details are NOT shown (since excluded)
+    await expect(page.getByText(/father's first name/i)).not.toBeVisible();
+
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step 8: Declaration
+    const checkbox = page.locator('button[role="checkbox"]');
+    await checkbox.click();
+
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes(API_SUBMIT_PATH) &&
+        response.request().method() === "POST",
+      { timeout: 30_000 }
+    );
+
+    await page.getByRole("button", { name: /submit/i }).click();
+
+    const response = await responsePromise;
+    expect(response.status()).toBe(200);
+
+    logSubmittedData(response.request());
+
+    const responseBody = (await response.json()) as ApiResponse;
+    verifyApiResponse(responseBody, FORM_KEY);
+
+    await expect(
+      page.getByRole("heading", { name: /thank you|confirmation/i })
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("birth at residential location shows address fields", async ({
+    page,
+  }) => {
+    const mother = generateMotherData();
+    const child = generateChildData();
+
+    // Navigate to birth details step (shortest path)
+    await page.getByText("No", { exact: true }).click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    await page.getByText("No, do not include the father's details").click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    await fillMotherDetails(page, mother);
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Step: Birth Details - select Residential
+    await expect(
+      page.getByRole("heading", { name: /tell us about the birth/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    // Verify conditional fields are NOT visible initially
+    await expect(
+      page.locator('select[name="birth.healthFacility"]')
+    ).not.toBeVisible();
+    await expect(page.locator('select[name="birth.parish"]')).not.toBeVisible();
+
+    // Select residential
+    await page.getByText("Residential", { exact: true }).click();
+
+    // Verify conditional fields ARE now visible
+    await expect(page.locator('select[name="birth.parish"]')).toBeVisible({
+      timeout: 3000,
+    });
+    await expect(
+      page.locator('textarea[name="birth.streetAddress"]')
+    ).toBeVisible();
+
+    // Fill the conditional fields
+    await fillBirthDetailsResidential(page, "st-michael", "123 Test Street");
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Should proceed to child details
+    await expect(
+      page.getByRole("heading", { name: /tell us about the child$/i })
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test("validates required fields on marriage status step", async ({
+    page,
+  }) => {
+    // Try to continue without selecting anything
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Should show validation error
+    await expect(page.getByText(/select your preference/i).first()).toBeVisible(
+      {
+        timeout: 3000,
+      }
+    );
+  });
+
+  test("validates ID number format", async ({ page }) => {
+    const mother = generateMotherData();
+
+    // Navigate to mother details step (shortest path)
+    await page.getByText("No", { exact: true }).click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    await page.getByText("No, do not include the father's details").click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Fill mother details with invalid ID
+    await page.locator('input[name="mother.firstName"]').fill(mother.firstName);
+    await page.locator('input[name="mother.lastName"]').fill(mother.lastName);
+    await page.locator('input[name="mother.idNumber"]').fill("invalid-id");
+    await page
+      .locator('select[name="mother.parish"]')
+      .selectOption(mother.parish);
+    await page
+      .locator('textarea[name="mother.streetAddress"]')
+      .fill(mother.streetAddress);
+    await page
+      .locator('input[name="mother.telephoneNumber"]')
+      .fill(mother.telephoneNumber);
+    await page
+      .locator('input[name="mother.emailAddress"]')
+      .fill(mother.emailAddress);
+    await page
+      .locator('input[name="mother.occupation"]')
+      .fill(mother.occupation);
+
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Should show ID format error
+    await expect(page.getByText(/valid ID number/i).first()).toBeVisible({
+      timeout: 3000,
+    });
+  });
+
+  test("can use passport instead of ID number", async ({ page }) => {
+    const mother = generateMotherData();
+
+    // Navigate to mother details step (shortest path)
+    await page.getByText("No", { exact: true }).click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    await page.getByText("No, do not include the father's details").click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Fill mother details
+    await page.locator('input[name="mother.firstName"]').fill(mother.firstName);
+    await page.locator('input[name="mother.lastName"]').fill(mother.lastName);
+
+    // Click to expand passport option instead of filling ID
+    const passportToggle = page.getByText(/use passport number instead/i);
+    if (await passportToggle.isVisible()) {
+      await passportToggle.click();
+
+      // Fill passport details
+      await page
+        .locator('input[name="mother.passportNumber"]')
+        .fill("AB1234567");
+      await page.locator('input[name="mother.age"]').fill("30");
+    }
+
+    await page
+      .locator('select[name="mother.parish"]')
+      .selectOption(mother.parish);
+    await page
+      .locator('textarea[name="mother.streetAddress"]')
+      .fill(mother.streetAddress);
+    await page
+      .locator('input[name="mother.telephoneNumber"]')
+      .fill(mother.telephoneNumber);
+    await page
+      .locator('input[name="mother.emailAddress"]')
+      .fill(mother.emailAddress);
+    await page
+      .locator('input[name="mother.occupation"]')
+      .fill(mother.occupation);
+
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Should proceed to birth details step
+    await expect(
+      page.getByRole("heading", { name: /tell us about the birth/i })
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test("declaration step requires checkbox to be checked", async ({ page }) => {
+    const mother = generateMotherData();
+    const child = generateChildData();
+    const numberOfCopies = 1;
+
+    // Navigate through form (shortest path)
+    await page.getByText("No", { exact: true }).click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    await page.getByText("No, do not include the father's details").click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    await fillMotherDetails(page, mother);
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    await fillBirthDetailsHealthFacility(page);
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    await fillChildDetails(page, child);
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    await page
+      .locator('input[name="order.numberOfCopies"]')
+      .fill(numberOfCopies.toString());
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Check Your Answers
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Declaration - verify checkbox is required
+    await expect(
+      page.getByRole("heading", { name: /declaration/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    // Verify checkbox is initially unchecked
+    const checkbox = page.locator('button[role="checkbox"]');
+    await expect(checkbox).toHaveAttribute("aria-checked", "false");
+
+    // Try to submit without checking the checkbox
+    await page.getByRole("button", { name: /submit/i }).click();
+
+    // Should show validation error for checkbox
+    await expect(page.getByText(/there is a problem/i)).toBeVisible({
+      timeout: 3000,
+    });
+  });
+
+  test("validates child date of birth must be in the past", async ({
+    page,
+  }) => {
+    const mother = generateMotherData();
+
+    // Navigate to child details (shortest path)
+    await page.getByText("No", { exact: true }).click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    await page.getByText("No, do not include the father's details").click();
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    await fillMotherDetails(page, mother);
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    await fillBirthDetailsHealthFacility(page);
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Child Details - enter future date
+    await expect(
+      page.getByRole("heading", { name: /tell us about the child$/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    await page.locator('input[name="child.firstName"]').fill("TestChild");
+    await page.locator('input[name="child.lastName"]').fill("TestLastName");
+
+    // Enter a future date
+    await page.locator("#child\\.dateOfBirth-month").fill("12");
+    await page.locator("#child\\.dateOfBirth-day").fill("31");
+    await page.locator("#child\\.dateOfBirth-year").fill("2030");
+
+    await page.locator('select[name="child.sexAtBirth"]').selectOption("male");
+
+    await page.getByRole("button", { name: /continue/i }).click();
+
+    // Should show date validation error
+    await expect(page.getByText(/must be in the past/i).first()).toBeVisible({
+      timeout: 3000,
+    });
+  });
+});


### PR DESCRIPTION
## Description

**New Changes**
- Register a birth – age validationAdded min/max validation for father and mother age fields in the schema and form so values outside the allowed range (e.g. 12–120) are rejected and the user cannot proceed with invalid ages.
- ShowHide number fields – min/maxEnforced min/max validation for number fields inside ShowHide (e.g. passport age) in the multi-step form so out-of-range values are blocked and show the correct error messages.

**Previous Work**
Contains the stable version of refactor/birth-register-form branch.

## Type of Change
- [ X ] Bug fix
- [ X ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made
Have updated the age validations in register-a-birth form schema, in addition to it have handled the validations on show hide number fields.

In addition, it contains all the previous stable code of refactor/birth-register-form branch.

### Notes
Once merged it will update main with all the stable code of refactor/birth-register-form branch along with new changes.

## Testing
- [ ] Visual regression tests added for all device sizes
- [x] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Checklist
- [ X ] Code follows project style guidelines
- [ X ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
