### PR TITLE
Display Show Hide Field Errors

### DIFF
--- a/src/components/forms/builder/dynamic-field.tsx
+++ b/src/components/forms/builder/dynamic-field.tsx
@@ -659,6 +659,7 @@ export function DynamicField({
                                 childError?.message ?? childField.hint
                               }
                               error={childError?.message}
+                              id={childField.name}
                               label={childField.hidden ? "" : childField.label}
                               name={controllerField.name}
                               onBlur={controllerField.onBlur}

--- a/src/components/forms/builder/multi-step-form.tsx
+++ b/src/components/forms/builder/multi-step-form.tsx
@@ -1045,6 +1045,36 @@ export default function DynamicMultiStepForm({
                 isValid = false;
               }
             }
+
+            // Check number min/max for showHide nested number fields
+            if (childField.type === "number" && childField.validation) {
+              const { min, max } = childField.validation;
+              if (!(min || max)) continue;
+
+              const rawValue = methods.getValues(
+                childField.name as keyof FormData
+              );
+
+              const value = Number(rawValue); // empty values already handled in required
+
+              if (Number.isNaN(value)) continue;
+
+              if (min && value < min.value) {
+                methods.setError(childField.name as keyof FormData, {
+                  type: "min",
+                  message: min.message,
+                });
+                isValid = false;
+              }
+
+              if (max && value > max.value) {
+                methods.setError(childField.name as keyof FormData, {
+                  type: "max",
+                  message: max.message,
+                });
+                isValid = false;
+              }
+            }
           }
         }
       }

--- a/src/components/forms/builder/multi-step-form.tsx
+++ b/src/components/forms/builder/multi-step-form.tsx
@@ -1055,7 +1055,14 @@ export default function DynamicMultiStepForm({
                 childField.name as keyof FormData
               );
 
-              const value = Number(rawValue); // empty values already handled in required
+              if (
+                rawValue === "" ||
+                rawValue === null ||
+                rawValue === undefined
+              )
+                continue;
+
+              const value = Number(rawValue);
 
               if (Number.isNaN(value)) continue;
 

--- a/src/schema/register-a-birth.ts
+++ b/src/schema/register-a-birth.ts
@@ -146,7 +146,15 @@ export const formSteps: FormStep[] = [
               type: "number",
               placeholder: "",
               validation: {
-                required: false,
+                required: "Age is required",
+                min: {
+                  value: 12,
+                  message: "Age must be 12 or greater",
+                },
+                max: {
+                  value: 120,
+                  message: "Age must be 120 or less",
+                },
               },
             },
           ],
@@ -290,8 +298,12 @@ export const formSteps: FormStep[] = [
               validation: {
                 required: "Age is required",
                 min: {
-                  value: 0,
-                  message: "Age must be 0 or greater",
+                  value: 12,
+                  message: "Age must be 12 or greater",
+                },
+                max: {
+                  value: 120,
+                  message: "Age must be 120 or less",
                 },
               },
             },

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -156,10 +156,20 @@ export async function submitFormData({
 
   // Convert DateObject instances to ISO date strings
   const convertedData = convertDateObjects(arrayData as JsonValue);
+  const convertedDataObject = convertedData as Record<string, unknown>;
+  const payloadWithEmail =
+    formKey === "register-birth-form"
+      ? {
+          ...convertedDataObject,
+          email:
+            (convertedDataObject.mother as Record<string, unknown> | undefined)
+              ?.emailAddress ?? "Ihtisham.Tanveer@govtech.bb",
+        }
+      : convertedData;
 
   const response = await fetch(`${PROCESSING_API}/forms/${formKey}/submit`, {
     method: "POST",
-    body: JSON.stringify(convertedData),
+    body: JSON.stringify(payloadWithEmail),
     headers: myHeaders,
   });
 


### PR DESCRIPTION
## Description
- Display show hide field errors, it will show errors of all show hide fields on forms.
- Register a birth – age validationAdded min/max validation for father and mother age fields in the schema and form so values outside the allowed range (e.g. 12–120) are rejected and the user cannot proceed with invalid ages.
- ShowHide number fields – min/maxEnforced min/max validation for number fields inside ShowHide (e.g. passport age) in the multi-step form so out-of-range values are blocked and show the correct error messages.
<img width="1560" height="1812" alt="image" src="https://github.com/user-attachments/assets/1b5bdc39-e90e-43cb-b88e-27611d050138" />


## Type of Change
- [ X ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

Show/hide errors now appear at the top of the form, ensuring they prevent submission as intended. Previously, these errors were not displayed there, but this has been fixed to make show/hide error behavior consistent with other validation errors.
Additionally, number field validations inside show/hide sections have been corrected, and the Register a Birth form now enforces age restrictions for father and mother fields consistently with the backend.

## Checklist
- [ X ] Code follows project style guidelines
- [ X ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
