### PR TITLE
Fix: Allow Today's Date in Birth Registration Form Validation

### DIFF
--- a/src/schema/register-a-birth.ts
+++ b/src/schema/register-a-birth.ts
@@ -609,7 +609,7 @@ export const formSteps: FormStep[] = [
         validation: {
           required: "Date of birth is required",
           date: {
-            type: "past",
+            type: "pastOrToday",
           },
         },
       },


### PR DESCRIPTION
## Description
Allow today’s date to be used in the birth registration form. Previously, only past dates were allowed.

## Type of Change
- [ X ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

Simply updated the schema and replaced data type "past" with "pastOrToday".


## Checklist
- [ X ] Code follows project style guidelines
- [ X ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
