### PR TITLE
fix: resolve mobile overflow issues on confirmation step

### DIFF
--- a/src/components/forms/builder/confirmation-step.tsx
+++ b/src/components/forms/builder/confirmation-step.tsx
@@ -88,13 +88,13 @@ export function ConfirmationPage({
 
       {/* Main content */}
 
-      <div className="container space-y-6 py-4 lg:grid lg:grid-cols-3 lg:space-y-8 lg:py-8">
+      <div className="container space-y-6 overflow-hidden py-4 lg:grid lg:grid-cols-3 lg:space-y-8 lg:py-8">
         <div className="col-span-2 space-y-6 lg:space-y-8">
           {/* Reference number banner - shown by default unless explicitly set to false */}
           {referenceNumber &&
             confirmationStep.showReferenceNumber !== false && (
-              <div className="w-fit rounded-sm bg-blue-10 px-6 py-4">
-                <Heading as="h2" className="whitespace-nowrap text-black">
+              <div className="rounded-sm bg-blue-10 px-6 py-4 lg:w-fit">
+                <Heading as="h2" className="text-black-00 lg:whitespace-nowrap">
                   {confirmationStep.referenceNumberLabel ??
                     "Your reference number is"}{" "}
                   {referenceNumber}


### PR DESCRIPTION
## Description
<!-- Summarize the changes based on added/changed functionality --><!-- Summarize the changes based on added/changed functionality -->
  - Allow reference number text to wrap on mobile (lg:whitespace-nowrap)
  - Make reference number banner full-width on mobile (lg:w-fit)
  - Add overflow-hidden to main content container
  
Cherry-picked from #389

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->


## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
