### PR TITLE
refactor(feature-flag): add rehypeHideStartLinks to hide start links …

### DIFF
--- a/src/content/apply-to-jobstart-plus-programme/index.md
+++ b/src/content/apply-to-jobstart-plus-programme/index.md
@@ -46,7 +46,7 @@ There are 2 ways to register. You can:
 
    <a data-start-link href="/work-employment/apply-to-jobstart-plus-programme/start">Register now</a>
 
-2. #### Get a paper form from the Ministry of Labour, Social Security and Third Seectorr
+2. #### Get a paper form from the Ministry of Labour, Social Security and Third Sector
 
    You must complete it by hand and return it to the department.
 

--- a/src/lib/rehype-hide-start-links.ts
+++ b/src/lib/rehype-hide-start-links.ts
@@ -1,4 +1,4 @@
-import type { Element, Root } from "hast";
+import type { Element, ElementContent, Root } from "hast";
 
 type Options = {
   hasResearchAccess?: boolean;
@@ -14,21 +14,14 @@ function rehypeHideStartLinks(options: Options = {}) {
     const filterChildren = (children: Root["children"]): Root["children"] =>
       children
         .filter((node) => {
-          if (node.type === "element") {
-            const element = node as Element;
-            if (element.tagName === "a") {
-              const href = element.properties?.href;
-              const isExternalForm =
-                element.properties?.dataExternalForm !== undefined;
-              if (typeof href === "string") {
-                const isStartLink = href.endsWith("/start");
-                // Has cookie: hide external form links
-                if (hasResearchAccess && isExternalForm) return false;
-                // No cookie: hide /start links
-                if (!hasResearchAccess && isStartLink) return false;
-              }
-            }
+          if (node.type !== "element") return true;
+          const element = node as Element;
+          // Hide start links inside list items
+          if (element.tagName === "li") {
+            return !containsStartLink(element, hasResearchAccess);
           }
+          // Hide start links if they have a data-external-form attribute
+          if (shouldHideStartLink(element, hasResearchAccess)) return false;
           return true;
         })
         .map((node) => {
@@ -44,6 +37,36 @@ function rehypeHideStartLinks(options: Options = {}) {
 
     tree.children = filterChildren(tree.children);
   };
+}
+
+// Check if an element contains a start link
+function containsStartLink(
+  node: ElementContent,
+  hasResearchAccess: boolean
+): boolean {
+  if (node.type === "element") {
+    const element = node as Element;
+    if (shouldHideStartLink(element, hasResearchAccess)) return true;
+    return element.children.some((child) =>
+      containsStartLink(child, hasResearchAccess)
+    );
+  }
+  return false;
+}
+
+// Check if it anchor and if it has a data-start-link attribute
+function shouldHideStartLink(element: Element, hasResearchAccess: boolean): boolean {
+  if (element.tagName !== "a") return false;
+  const href = element.properties?.href;
+  const isExternalForm =
+    element.properties?.dataExternalForm !== undefined;
+  if (typeof href !== "string") return false;
+  const isStartLink = href.endsWith("/start");
+  // Has cookie: hide external form links
+  if (hasResearchAccess && isExternalForm) return true;
+  // No cookie: hide /start links
+  if (!hasResearchAccess && isStartLink) return true;
+  return false;
 }
 
 export default rehypeHideStartLinks;


### PR DESCRIPTION
## Description
<!-- Summarize the changes based on added/changed functionality --><!-- Summarize the changes based on added/changed functionality -->
Update `rehypeHideStartLinks` to hide entire list items (`<li>`) that contain start links, rather than only hiding the anchor element itself. This prevents orphaned list items from appearing when the start link within them is hidden by the feature flag. Also fixes a typo in the JobStart Plus content.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made
<!--List the files changed and why -->

- `src/lib/rehype-hide-start-links.ts` — Refactored the rehype plugin to recursively check list items for start links and hide the entire `<li>` when one is found.

- src/content/apply-to-jobstart-plus-programme/index.md — Fixed typo:
  "Third Seectorr" → "Third Sector"

### Notes
<!--Add notes for anything unrelated to the specified categories -->
  - The previous behavior only hid the <a> tag, we offer two ways to the service “There are 2 ways to apply…“ but the first option is a dead end, as we hide the “form“ button. The new behavior removes the entire list item from the rendered output.


## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [x] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->
https://trello.com/c/6GPVMeuk

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
