### PR TITLE
feat (validation): add exactItems validation for file uploads in schema

### DIFF
--- a/src/lib/schema-generator.ts
+++ b/src/lib/schema-generator.ts
@@ -360,16 +360,17 @@ function createFieldSchema(field: FormField | NestedFormField): z.ZodTypeAny {
   // Handle file uploads (stores File[] array, but we validate based on count)
   if (field.type === "file") {
     // File fields store File[] objects which can't be serialized to JSON.
-    // We validate them using item-count rules (required/minItems/maxItems/exactCount).
+    // We validate them using item-count rules (required/minItems/maxItems/numberOfFiles).
     const hasCountValidation =
-      validation.required || (validation as NonDateFieldValidation).exactCount;
+      validation.required ||
+      (validation as NonDateFieldValidation).numberOfFiles;
 
     // No validation rules: allow anything / undefined
     if (!hasCountValidation) {
       return z.any().optional();
     }
 
-    const exactCount = (validation as NonDateFieldValidation).exactCount;
+    const numberOfFiles = (validation as NonDateFieldValidation).numberOfFiles;
 
     const getFileCount = (val: unknown): number => {
       if (Array.isArray(val)) {
@@ -395,10 +396,15 @@ function createFieldSchema(field: FormField | NestedFormField): z.ZodTypeAny {
       }
 
       // Exact count of items (e.g. exactly 2 passport photos)
-      if (exactCount && count !== exactCount.value && count !== 0) {
+      if (
+        numberOfFiles &&
+        numberOfFiles.isEqual !== undefined &&
+        count !== numberOfFiles.isEqual &&
+        count !== 0
+      ) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: exactCount.message,
+          message: numberOfFiles.message,
         });
         return;
       }

--- a/src/schema/sell-goods-services-beach-park.ts
+++ b/src/schema/sell-goods-services-beach-park.ts
@@ -812,8 +812,8 @@ export const formSteps: FormStep[] = [
         type: "file",
         validation: {
           required: "Passport-sized photos are required",
-          exactCount: {
-            value: 2,
+          numberOfFiles: {
+            isEqual: 2,
             message: "You must upload 2 passport-sized photos",
           },
         },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,7 +33,7 @@ type BaseValidationRule = {
   pattern?: { value: string; message: string };
   min?: { value: number; message: string };
   max?: { value: number; message: string };
-  exactCount?: { value: number; message: string };
+  numberOfFiles?: { isEqual: number; message: string };
 };
 
 export type DateFieldValidation = BaseValidationRule & {


### PR DESCRIPTION
## Description
This update ensures that when an exact number of files is required, the validation strictly enforces that requirement. Previously, when multiple uploads were allowed, users could bypass the intended restriction by submitting fewer files (e.g., only one file).

Fixed Version
<img width="841" height="722" alt="image" src="https://github.com/user-attachments/assets/5a72c0c7-d048-4374-b40d-9e3574e3ce2c" />


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made
Updated the dynamic field schema to validate the exact number of uploaded files when specified.
Prevented users from bypassing file count validation when multiple uploads are enabled.

## Related Github Issue(s)/Trello Ticket(s)
[Review - Apply for a licence to sell goods or services at a beach or park](https://trello.com/c/6l1jKv1d/401-review-apply-for-a-licence-to-sell-goods-or-services-at-a-beach-or-park)

#454 

## Checklist
- [ X ] Code follows project style guidelines
- [ X ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
