### PR TITLE
Fix: Updated form application description based on the available number of ways to apply

### DIFF
--- a/src/lib/rehype-hide-start-links.ts
+++ b/src/lib/rehype-hide-start-links.ts
@@ -4,8 +4,23 @@ type Options = {
   hasResearchAccess?: boolean;
 };
 
+const WAYS_TO_APPLY_REGEX = /are (\d+) ways|are ([a-zA-Z]+) ways/i;
+const WORD_TO_NUMBER: Record<string, number> = {
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10,
+} as const;
+
 function rehypeHideStartLinks(options: Options = {}) {
   const { hasResearchAccess = false } = options;
+  let removedLinksCount = 0; // Tracks the number of links removed to adjust the description text accordingly
 
   return (tree: Root) => {
     // Recursively filter links based on access
@@ -16,12 +31,25 @@ function rehypeHideStartLinks(options: Options = {}) {
         .filter((node) => {
           if (node.type !== "element") return true;
           const element = node as Element;
+
           // Hide start links inside list items
           if (element.tagName === "li") {
-            return !containsStartLink(element, hasResearchAccess);
+            const containsStartLinkResult = containsStartLink(
+              element,
+              hasResearchAccess
+            );
+
+            if (containsStartLinkResult) {
+              removedLinksCount++;
+            }
+            return !containsStartLinkResult;
           }
+
           // Hide start links if they have a data-external-form attribute
-          if (shouldHideStartLink(element, hasResearchAccess)) return false;
+          if (shouldHideStartLink(element, hasResearchAccess)) {
+            removedLinksCount++;
+            return false;
+          }
           return true;
         })
         .map((node) => {
@@ -36,6 +64,15 @@ function rehypeHideStartLinks(options: Options = {}) {
         });
 
     tree.children = filterChildren(tree.children);
+
+    // After filtering links/methods, update the description text if necessary
+    if (removedLinksCount > 0) {
+      updateDescriptionText(
+        tree.children,
+        hasResearchAccess,
+        removedLinksCount
+      );
+    }
   };
 }
 
@@ -69,6 +106,77 @@ function shouldHideStartLink(
   // No cookie: hide /start links
   if (!hasResearchAccess && isStartLink) return true;
   return false;
+}
+
+function shouldReplaceDescriptionText(
+  element: Element,
+  hasResearchAccess: boolean
+): boolean {
+  if (element.tagName !== "p") return false;
+
+  const textContent = element.children
+    .filter((child) => child.type === "text")
+    .map((child) => child.value)
+    .join("");
+
+  return WAYS_TO_APPLY_REGEX.test(textContent) && !hasResearchAccess;
+}
+
+function updateDescriptionText(
+  children: Root["children"],
+  hasResearchAccess: boolean,
+  linksRemovedCount: number
+): void {
+  children.forEach((node) => {
+    if (node.type === "element") {
+      const element = node as Element;
+
+      if (shouldReplaceDescriptionText(element, hasResearchAccess)) {
+        const textContent = element.children
+          .filter((child) => child.type === "text")
+          .map((child) => child.value)
+          .join("");
+
+        const newTextContent = textContent.replace(
+          WAYS_TO_APPLY_REGEX,
+          (match, numberPattern, wordPattern) => {
+            let ways = Number.parseInt(numberPattern, 10);
+
+            // If numberPattern is not a number, try to convert wordPattern (word) to a number. E.g., "two" to 2
+            if (isNaN(ways) && wordPattern in WORD_TO_NUMBER) {
+              ways = WORD_TO_NUMBER[wordPattern as keyof typeof WORD_TO_NUMBER];
+            }
+
+            // If we still couldn't parse a number, return the original match
+            if (isNaN(ways)) {
+              return match;
+            }
+
+            const newWays = Math.max(0, ways - linksRemovedCount);
+            if (newWays === 1) {
+              return `is ${newWays} way`;
+            }
+            return `are ${newWays} ways`;
+          }
+        );
+
+        element.children = [
+          {
+            type: "text",
+            value: newTextContent,
+          },
+        ];
+      }
+
+      if (element.children) {
+        updateDescriptionText(
+          element.children,
+          hasResearchAccess,
+          linksRemovedCount
+        );
+      }
+    }
+  });
 }
 
 export default rehypeHideStartLinks;


### PR DESCRIPTION
## Description
Updated the script to hide start links to adapt "How to Apply" description to match the correct number of options listed.

|<img width="931" height="738" alt="image" src="https://github.com/user-attachments/assets/be2b92ea-f87f-4c8e-97dd-7cb355563462" />| <img width="906" height="560" alt="image" src="https://github.com/user-attachments/assets/1ace68f6-4c9e-4f80-9d48-89397b4a6832" />|
|---|---|

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->

- `src/lib/rehype-hide-start-links.ts` : 
  - Added removed-link counting (`removedLinksCount`) while filtering to keep track of application options removed.
  - Added/updated dynamic description rewriting with singular/plural handling. This keeps “number of ways to apply” text in sync with visible options. 
  - Added helper functions (`containsStartLink`, `shouldHideStartLink`, `shouldReplaceDescriptionText`) to isolate decision logic. 

### Notes
This fix works for the current content for forms but does not account for cases where wording is changed.

**Accounts for:**
- "There are 3 ways to apply"
- "There are two ways to apply"
- "There are 4 WAYS to apply"
- Handles capitalization

**Does NOT account for:**
- "There are 2 methods to apply"
- "There are 5 options for application"

## Testing
- [ ] Visual regression tests added for all device sizes
- [x] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [x] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
Fixes #475 
https://trello.com/c/ujCSEfP6/406-fix-feature-flag-intro-text-does-not-match-number-of-live-options

## Checklist
- [ ] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
