### PR TITLE
fix: improve form error tracking

### DIFF
--- a/src/app/actions/send-form-submission-emails.tsx
+++ b/src/app/actions/send-form-submission-emails.tsx
@@ -1,10 +1,6 @@
 "use server";
 
-import {
-  SESv2Client,
-  SESv2ServiceException,
-  SendEmailCommand,
-} from "@aws-sdk/client-sesv2";
+import { SESv2Client, SendEmailCommand } from "@aws-sdk/client-sesv2";
 import { render } from "@react-email/render";
 import * as Sentry from "@sentry/nextjs";
 import { z } from "zod";
@@ -388,21 +384,22 @@ export async function sendFormSubmissionEmails(
 
   // ── 6. Queue send tasks ───────────────────────────────────────────────────
 
-  const sendTasks: Promise<void>[] = [];
+  const sendTasks: { label: string; promise: Promise<void> }[] = [];
 
   if (applicantEmail) {
     log("INFO", "sendFormSubmissionEmails.queuing_confirmation", {
       referenceNumber,
       recipient: maskEmail(applicantEmail),
     });
-    sendTasks.push(
-      sendEmail({
+    sendTasks.push({
+      label: `confirmation to ${applicantEmail}`,
+      promise: sendEmail({
         to: applicantEmail,
         subject: `${formName} application received (${referenceNumber})`,
         html: confirmationHtml,
         referenceNumber,
-      })
-    );
+      }),
+    });
   } else {
     log("WARN", "sendFormSubmissionEmails.skipping_confirmation", {
       referenceNumber,
@@ -416,14 +413,15 @@ export async function sendFormSubmissionEmails(
       referenceNumber,
       recipient: maskEmail(resolvedNotificationEmail),
     });
-    sendTasks.push(
-      sendEmail({
+    sendTasks.push({
+      label: `staff notification to ${resolvedNotificationEmail}`,
+      promise: sendEmail({
         to: resolvedNotificationEmail,
         subject: `New submission: ${formName} (${referenceNumber})`,
         html: notificationHtml,
         referenceNumber,
-      })
-    );
+      }),
+    });
   } else {
     log("WARN", "sendFormSubmissionEmails.skipping_notification", {
       referenceNumber,
@@ -442,43 +440,48 @@ export async function sendFormSubmissionEmails(
 
   // ── 7. Dispatch ───────────────────────────────────────────────────────────
 
-  try {
-    await Promise.all(sendTasks);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    // SESv2ServiceException carries the service error code in `.name`
-    const code =
-      error instanceof SESv2ServiceException ? error.name : undefined;
-    const durationMs = Date.now() - actionStart;
+  const results = await Promise.allSettled(
+    sendTasks.map((task) => task.promise)
+  );
+
+  const failures = results
+    .map((result, index) => ({ result, task: sendTasks[index] }))
+    .filter(({ result }) => result.status === "rejected");
+
+  if (failures.length > 0) {
+    const failedLabels = failures.map(({ task }) => task?.label).join(", ");
+    const errors = failures.map(
+      ({ result }) => (result as PromiseRejectedResult).reason
+    );
 
     log("ERROR", "sendFormSubmissionEmails.ses_error", {
       referenceNumber,
-      errorMessage: message,
-      errorCode: code,
+      failedLabels,
       sesRegion,
       configurationSet: configurationSet ?? "(none)",
       hint: "Verify the SES sender identity, IAM permissions (ses:SendEmail), and that the region matches your verified domain",
-      durationMs,
+      durationMs: Date.now() - actionStart,
     });
 
-    // Capture with full context so the Sentry issue includes the SES
-    // request details alongside the stack trace.
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(message),
-      {
-        extra: {
-          referenceNumber,
-          errorCode: code,
-          sesRegion,
-          configurationSet: configurationSet ?? "(none)",
-          durationMs,
-        },
-      }
+    console.error(
+      `[send-form-submission-emails] Failed to send email(s) for "${formName}" (${referenceNumber}): ${failedLabels}`,
+      errors
     );
 
-    throw new Error(
-      "Email delivery failed. Please check your SES configuration and credentials."
-    );
+    for (const { result, task } of failures) {
+      Sentry.captureException((result as PromiseRejectedResult).reason, {
+        extra: {
+          formName,
+          referenceNumber,
+          emailType: task?.label,
+        },
+      });
+    }
+
+    return {
+      success: false as const,
+      error: `Failed to send email(s): ${failedLabels}. Please try again.`,
+    };
   }
 
   // ── 8. Done ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

Improves error tracking and resilience for form submission email delivery in `sendFormSubmissionEmails`.

Previously, email dispatch used `Promise.all` which would short-circuit on the first failure, meaning a failed confirmation email would prevent a notification email from being attempted (and vice versa). 

This change switches to `Promise.allSettled` so all emails are always attempted, with per-email failure reporting via Sentry.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes made

### `src/app/actions/send-form-submission-emails.tsx`

- **Labeled send tasks** — `sendTasks` is now typed as `{ label: string; promise: Promise<void> }[]` instead of `Promise<void>[]`. Each task carries a human-readable label (e.g. `"confirmation to user@example.com"`, `"staff notification to admin@example.com"`) used for structured error reporting.
- **`Promise.allSettled` instead of `Promise.all`** — all emails are now attempted regardless of individual failures. Previously a single SES error would abort any remaining sends.
- **Per-email Sentry capture** — each failed send is reported to Sentry individually with `formName`, `referenceNumber`, and `emailType` (the task label) attached as extras, making it easy to identify which email type failed and for which submission.
- **Structured error return instead of throw** — on failure the action now returns `{ success: false, error: "..." }` with the names of the failed tasks, consistent with the existing validation error return shape, rather than throwing an unhandled exception.
- **Removed unused import** — `SESv2ServiceException` is no longer referenced after removing the try/catch block and is cleaned up from the import.

### Notes

This change does not affect the email templates, SES configuration, or any other part of the form submission flow. The `sendEmail` helper function is unchanged.

## Testing

1. Trigger a form submission with a valid applicant email and a valid notification email — both emails should be sent and the action should return `{ success: true }`.
2. Simulate an SES failure for one email (e.g. temporarily use an invalid `MAIL_FROM` or a blocked recipient for one task) — verify the other email still sends, the action returns `{ success: false, error: "Failed to send email(s): ..." }`, and a Sentry issue is created with the correct `emailType` extra.
3. Confirm the Sentry issue includes `formName`, `referenceNumber`, and `emailType` in its extras.
4. Check CloudWatch/Sentry Logs for the `sendFormSubmissionEmails.ses_error` event with `failedLabels` populated correctly.

## Related Github Issue(s)/Trello Ticket(s)

<!-- Link any related issues: Fixes #123 -->

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated