### PR TITLE
fix: use test email in dev environment

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -2,7 +2,12 @@ import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  // SENTRY_ENABLED must be explicitly set to "true" in the deployment
+  // environment. Omitting it (e.g. on localhost) keeps Sentry disabled.
   enabled: process.env.SENTRY_ENABLED === "true",
+  // Set SENTRY_ENVIRONMENT to "development" or "production" in each Amplify
+  // environment so issues are filterable by environment in Sentry.
+  environment: process.env.SENTRY_ENVIRONMENT,
   tracesSampleRate: 0.1,
   enableLogs: true,
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -5,6 +5,9 @@ Sentry.init({
   // SENTRY_ENABLED must be explicitly set to "true" in the deployment
   // environment. Omitting it (e.g. on localhost) keeps Sentry disabled.
   enabled: process.env.SENTRY_ENABLED === "true",
+  // Set SENTRY_ENVIRONMENT to "development" or "production" in each Amplify
+  // environment so issues are filterable by environment in Sentry.
+  environment: process.env.SENTRY_ENVIRONMENT,
   tracesSampleRate: 0.1,
   enableLogs: true,
 });

--- a/src/app/actions/send-form-submission-emails.tsx
+++ b/src/app/actions/send-form-submission-emails.tsx
@@ -297,8 +297,8 @@ export async function sendFormSubmissionEmails(
     configurationSet: configurationSet ?? "(none)",
     hasTagKey: Boolean(tagKey),
     hasTagValue: Boolean(tagValue),
-    isDevMode: process.env.AWS_PROFILE === "dev",
-    hasDevNotificationOverride: Boolean(process.env.SES_DEV_NOTIFICATION_EMAIL),
+    sentryEnvironment: process.env.SENTRY_ENVIRONMENT ?? "(not set)",
+    emailOverrideActive: Boolean(process.env.SES_DEV_NOTIFICATION_EMAIL),
   });
 
   if (!mailFrom) {
@@ -358,27 +358,24 @@ export async function sendFormSubmissionEmails(
     notificationHtmlBytes: notificationHtml.length,
   });
 
-  // ── 5. Resolve notification recipient ─────────────────────────────────────
+  // ── 5. Resolve recipients ─────────────────────────────────────────────────
+  //
+  // When SES_DEV_NOTIFICATION_EMAIL is set, all emails are redirected to that
+  // address regardless of environment. Unset it in production so emails reach
+  // real recipients. This keeps the gate independent of Sentry config.
 
-  const isDevMode = process.env.AWS_PROFILE === "dev";
+  const safeTestEmail = process.env.SES_DEV_NOTIFICATION_EMAIL?.trim();
 
-  if (isDevMode && !process.env.SES_DEV_NOTIFICATION_EMAIL) {
-    throw new Error(
-      "SES_DEV_NOTIFICATION_EMAIL must be set when AWS_PROFILE=dev. " +
-        "Add it to your .env.local to redirect notification emails to a safe test address."
-    );
-  }
+  const resolvedApplicantEmail = safeTestEmail ?? applicantEmail;
+  const resolvedNotificationEmail = safeTestEmail ?? notificationEmail;
 
-  const resolvedNotificationEmail = isDevMode
-    ? (process.env.SES_DEV_NOTIFICATION_EMAIL as string)
-    : notificationEmail;
-
-  if (isDevMode) {
-    log("WARN", "sendFormSubmissionEmails.dev_email_override", {
+  if (safeTestEmail) {
+    log("WARN", "sendFormSubmissionEmails.email_override_active", {
       referenceNumber,
-      originalRecipient: maskEmail(notificationEmail),
-      overriddenTo: maskEmail(resolvedNotificationEmail),
-      hint: "Notification email is being redirected because AWS_PROFILE=dev",
+      originalApplicantRecipient: maskEmail(applicantEmail),
+      originalNotificationRecipient: maskEmail(notificationEmail),
+      overriddenTo: maskEmail(safeTestEmail),
+      hint: "SES_DEV_NOTIFICATION_EMAIL is set — all emails are redirected. Remove it in production to send to real recipients.",
     });
   }
 
@@ -386,15 +383,15 @@ export async function sendFormSubmissionEmails(
 
   const sendTasks: { label: string; promise: Promise<void> }[] = [];
 
-  if (applicantEmail) {
+  if (resolvedApplicantEmail) {
     log("INFO", "sendFormSubmissionEmails.queuing_confirmation", {
       referenceNumber,
-      recipient: maskEmail(applicantEmail),
+      recipient: maskEmail(resolvedApplicantEmail),
     });
     sendTasks.push({
-      label: `confirmation to ${applicantEmail}`,
+      label: `confirmation to ${resolvedApplicantEmail}`,
       promise: sendEmail({
-        to: applicantEmail,
+        to: resolvedApplicantEmail,
         subject: `${formName} application received (${referenceNumber})`,
         html: confirmationHtml,
         referenceNumber,

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -2,7 +2,12 @@ import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  // NEXT_PUBLIC_SENTRY_ENABLED must be explicitly set to "true" in the
+  // deployment environment. Omitting it (e.g. on localhost) keeps Sentry disabled.
   enabled: process.env.NEXT_PUBLIC_SENTRY_ENABLED === "true",
+  // Set NEXT_PUBLIC_SENTRY_ENVIRONMENT to "development" or "production" in
+  // each Amplify environment so issues are filterable by environment in Sentry.
+  environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
   tracesSampleRate: 0.1,
   enableLogs: true,
 });


### PR DESCRIPTION
## Description

Adds Sentry environment tagging across all three Sentry configs (client, server, edge) so issues are filterable by environment in the Sentry dashboard. 

Also decouples the email redirect gate from `AWS_PROFILE`, replacing it with a simpler `SES_DEV_NOTIFICATION_EMAIL`-only check that redirects **both** confirmation and notification emails when set.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Changes made

### `sentry.server.config.ts` / `sentry.edge.config.ts` / `src/instrumentation-client.ts`

- Added `environment` to each `Sentry.init()` call, reading from `SENTRY_ENVIRONMENT` (server/edge) and `NEXT_PUBLIC_SENTRY_ENVIRONMENT` (client). Set this to `"development"` or `"production"` in each Amplify environment to make issues filterable by environment in Sentry.

### `src/app/actions/send-form-submission-emails.tsx`

- **Removed `AWS_PROFILE === "dev"` gate** — the email redirect is now driven solely by `SES_DEV_NOTIFICATION_EMAIL` being set, making the behaviour consistent across all environments and independent of Sentry config.
- **Confirmation emails are now also redirected** — when `SES_DEV_NOTIFICATION_EMAIL` is set, both the applicant confirmation and the staff notification are redirected to the safe test address (`resolvedApplicantEmail` and `resolvedNotificationEmail`). Previously only the notification email was redirected.
- **Removed the hard throw** — the guard that threw an error when `AWS_PROFILE=dev` and `SES_DEV_NOTIFICATION_EMAIL` was missing is removed; failing silently or redirecting is now the responsibility of the override variable alone.
- **Improved config-check log fields** — replaced `isDevMode` / `hasDevNotificationOverride` with `sentryEnvironment` and `emailOverrideActive` to better reflect what is actually being logged.
- **Improved override warning log** — `sendFormSubmissionEmails.email_override_active` now logs both original recipients (applicant and notification) alongside the address they were redirected to.

### Notes

The following environment variables need to be set per Amplify environment for this to work correctly:

| Variable | Where | Value |
|---|---|---|
| `SENTRY_ENVIRONMENT` | Server / Edge | `"development"` or `"production"` |
| `NEXT_PUBLIC_SENTRY_ENVIRONMENT` | Client (build-time) | `"development"` or `"production"` |
| `SES_DEV_NOTIFICATION_EMAIL` | Non-production only | A safe test email address |

Unset `SES_DEV_NOTIFICATION_EMAIL` in production — its presence is the only gate that triggers the redirect.

## Testing

1. **Sentry environment tagging** — trigger a test error in both a development and production Amplify environment. Confirm the resulting Sentry issues show the correct `environment` tag and are filterable in the Sentry dashboard.
2. **Email redirect (override active)** — set `SES_DEV_NOTIFICATION_EMAIL` to a test address and submit a form with a valid applicant email. Confirm both the confirmation *and* the notification email arrive at the test address, and the `sendFormSubmissionEmails.email_override_active` log entry shows both original recipients.
3. **Email redirect (override inactive)** — unset `SES_DEV_NOTIFICATION_EMAIL` and submit a form. Confirm emails go to the real applicant and notification addresses with no warning log.
4. **CloudWatch / Sentry Logs** — verify the config-check log now includes `sentryEnvironment` and `emailOverrideActive` fields rather than the old `isDevMode` / `hasDevNotificationOverride` fields.

## Related Github Issue(s)/Trello Ticket(s)

<!-- Link any related issues: Fixes #123 -->

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated