### PR TITLE
fix: show message when JavaScript is disabled on form pages

### DIFF
--- a/src/components/dynamic-form-loader.tsx
+++ b/src/components/dynamic-form-loader.tsx
@@ -15,8 +15,21 @@ export function DynamicFormLoader({ formSlug }: DynamicFormLoaderProps) {
   }
 
   return (
-    <Suspense fallback={<div className="container">Loading form...</div>}>
-      <FormComponent />
-    </Suspense>
+    <>
+      <noscript>
+        <div className="container">
+          <p>
+            This form requires JavaScript to work. Please enable JavaScript in
+            your browser settings and reload the page to continue.
+          </p>
+        </div>
+        <style>{".js-only{display:none!important}"}</style>
+      </noscript>
+      <div className="js-only">
+        <Suspense fallback={<div className="container">Loading form...</div>}>
+          <FormComponent />
+        </Suspense>
+      </div>
+    </>
   );
 }

--- a/src/components/dynamic-form-loader.tsx
+++ b/src/components/dynamic-form-loader.tsx
@@ -2,10 +2,11 @@
 
 import { Suspense } from "react";
 import { FORM_COMPONENTS, type FormSlug } from "@/lib/form-registry";
+import { NoScriptMessage } from "./no-script-message";
 
-type DynamicFormLoaderProps = {
+interface DynamicFormLoaderProps {
   formSlug: string;
-};
+}
 
 export function DynamicFormLoader({ formSlug }: DynamicFormLoaderProps) {
   const FormComponent = FORM_COMPONENTS[formSlug as FormSlug];
@@ -17,12 +18,7 @@ export function DynamicFormLoader({ formSlug }: DynamicFormLoaderProps) {
   return (
     <>
       <noscript>
-        <div className="container">
-          <p>
-            This form requires JavaScript to work. Please enable JavaScript in
-            your browser settings and reload the page to continue.
-          </p>
-        </div>
+        <NoScriptMessage />
         <style>{".js-only{display:none!important}"}</style>
       </noscript>
       <div className="js-only">

--- a/src/components/no-script-message.tsx
+++ b/src/components/no-script-message.tsx
@@ -1,0 +1,46 @@
+import { Heading, LinkButton } from "@govtech-bb/react";
+
+export function NoScriptMessage() {
+  return (
+    <div className="container">
+      <div className="w-full space-y-m bg-white-00 py-m md:max-w-2/3 md:py-l">
+        <div className="space-y-m">
+          <Heading as="h1">This page needs JavaScript to work properly</Heading>
+          <p>
+            JavaScript is currently turned off in your browser, or your browser
+            doesn't support it.
+          </p>
+        </div>
+
+        <div className="space-y-s">
+          <Heading as="h3">Suggestions:</Heading>
+          <ul className="list-disc space-y-s pl-7.5">
+            <li>
+              Turn on JavaScript in your browser settings. The steps differ by
+              browser, but you'll usually find the option under Settings →
+              Privacy and Security, or Site Settings. Once it's on, refresh this
+              page.
+            </li>
+            <li>
+              Try a different browser. Most up-to-date browsers (Chrome, Safari,
+              Firefox, Edge) support JavaScript by default.
+            </li>
+            <li>
+              Update your browser. If you're using an older version, updating
+              may resolve the issue.
+            </li>
+          </ul>
+        </div>
+
+        <div className="flex flex-col gap-xm md:flex-row">
+          {/* <LinkButton href="#" variant="secondary">
+            Contact us
+          </LinkButton> */}
+          <LinkButton href="/" variant="primary">
+            Return to homepage
+          </LinkButton>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
<!-- Summarize the changes based on added/changed functionality --><!-- Summarize the changes based on added/changed functionality -->
Forms without JavaScript hung on an infinite "Loading form..." spinner. Added a <noscript> fallback so users see a clear message telling them to enable JavaScript and reload.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->
https://trello.com/c/eCbOtgbi

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
