### PR TITLE
Added Labels To Mother Field

### DIFF
--- a/src/schema/get-birth-certificate.ts
+++ b/src/schema/get-birth-certificate.ts
@@ -506,7 +506,7 @@ export const formSteps: FormStep[] = [
       },
       {
         name: "parents.mother.otherNames",
-        label: "",
+        label: "Mother's other names",
         type: "text",
         validation: {
           required: false,
@@ -536,7 +536,7 @@ export const formSteps: FormStep[] = [
       },
       {
         name: "parents.mother.maidenName",
-        label: "",
+        label: "Mother's maiden name",
         type: "text",
         validation: {
           required: false,


### PR DESCRIPTION
## Description
Added missing labels in the get-birth-certificate mother's fields page.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
https://trello.com/c/ii7N94Z8/20-get-a-birth-certificate-2-fields-for-mothers-last-name


## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
