### PR TITLE
feat: add form analytics to performance report

### DIFF
--- a/.github/workflows/performance-report.yml
+++ b/.github/workflows/performance-report.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [prod]
   workflow_dispatch:
+  schedule:
+    # Weekly on Mondays at 12:15 UTC (08:15 AST). Off-the-hour to dodge the
+    # GitHub Actions cron contention window.
+    - cron: "15 12 * * 1"
 
 permissions:
   contents: read
@@ -56,6 +60,9 @@ jobs:
         env:
           BASE_URL: http://127.0.0.1:3000
           PERF_EXTERNAL_SERVER: "1"
+          UMAMI_API_KEY: ${{ secrets.UMAMI_API_KEY }}
+          NEXT_PUBLIC_UMAMI_SITE_ID: ${{ secrets.UMAMI_SITE_ID }}
+          UMAMI_REPORT_DAYS: "7"
         run: npm run perf:report
 
       - name: Stop Next.js server
@@ -73,7 +80,7 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/prod') || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/prod') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/scripts/perf/generate-performance-report.mjs
+++ b/scripts/perf/generate-performance-report.mjs
@@ -1,5 +1,5 @@
 /**
- * Runs Lighthouse against key URLs, then Playwright (axe + navigation timings),
+ * Runs Lighthouse against key URLs, then Playwright (axe accessibility audit),
  * and writes a static `performance-report/index.html` plus per-route Lighthouse HTML.
  *
  * Expects the production server to be listening unless you rely on `playwright.perf.config.ts`
@@ -16,9 +16,14 @@ import lighthouse, { generateReport } from "lighthouse";
 import desktopConfig from "lighthouse/core/config/desktop-config.js";
 import { chromium } from "playwright";
 import waitOn from "wait-on";
+import {
+  fetchFormFunnelMetrics,
+  fetchWebsiteStats,
+} from "./umami-form-metrics.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, "..", "..");
+const MS_PER_DAY = 86_400_000;
 
 const PAGES = [
   { slug: "home", path: "/", label: "Home" },
@@ -113,7 +118,374 @@ async function readJson(filePath) {
   }
 }
 
-function buildIndexHtml({ lighthouseRows, playwrightMetrics, meta }) {
+function formatPercent(rate) {
+  if (rate === null || rate === undefined || Number.isNaN(rate)) return "—";
+  return `${(rate * 100).toFixed(1)}%`;
+}
+
+function formatInteger(value) {
+  if (value === null || value === undefined || Number.isNaN(value)) return "—";
+  return Number(value).toLocaleString("en-US");
+}
+
+const DELTA_COLOR_GOOD = "#16a34a";
+const DELTA_COLOR_BAD = "#dc2626";
+const DELTA_COLOR_NEUTRAL = "#64748b";
+
+/**
+ * Computes a week-over-week delta between two scalar values.
+ *
+ * `mode` controls how the difference is expressed:
+ *  - "percent-points" — for rates that are already 0..1 fractions (e.g.,
+ *    completion rate). Diff is rendered as `±N.Npp`, which is more honest
+ *    than a relative % on a percentage.
+ *  - "relative" — for counts/durations. Diff is rendered as `±N.N%`. Falls
+ *    back to "new" when the prior window was zero so the badge stays useful.
+ *
+ * Returns `null` when a delta can't be computed so callers can hide the badge.
+ *
+ * @returns {{ display: string; arrow: string; color: string } | null}
+ */
+function buildDelta({ current, previous, higherIsBetter, mode }) {
+  if (current === null || current === undefined || Number.isNaN(current)) {
+    return null;
+  }
+  if (previous === null || previous === undefined || Number.isNaN(previous)) {
+    return null;
+  }
+
+  let direction;
+  let display;
+
+  if (mode === "percent-points") {
+    const diffPp = (current - previous) * 100;
+    direction = Math.sign(diffPp);
+    const sign = diffPp > 0 ? "+" : "";
+    display = `${sign}${diffPp.toFixed(1)}pp`;
+  } else if (previous === 0) {
+    if (current === 0) {
+      direction = 0;
+      display = "no change";
+    } else {
+      direction = Math.sign(current);
+      display = current > 0 ? "new" : "—";
+    }
+  } else {
+    const rel = ((current - previous) / previous) * 100;
+    direction = Math.sign(rel);
+    const sign = rel > 0 ? "+" : "";
+    display = `${sign}${rel.toFixed(1)}%`;
+  }
+
+  const arrow = direction > 0 ? "▲" : direction < 0 ? "▼" : "→";
+  let color = DELTA_COLOR_NEUTRAL;
+  if (direction !== 0) {
+    const isGood = higherIsBetter ? direction > 0 : direction < 0;
+    color = isGood ? DELTA_COLOR_GOOD : DELTA_COLOR_BAD;
+  }
+
+  return { display, arrow, color };
+}
+
+function renderDelta(delta, windowLabel) {
+  if (!delta) return "";
+  return `<div class="stat-delta" style="color:${delta.color}">${delta.arrow} ${escapeHtml(delta.display)}<span class="stat-delta-context"> vs ${escapeHtml(windowLabel)}</span></div>`;
+}
+
+function formatSeconds(value) {
+  if (value === null || value === undefined || Number.isNaN(value)) return "—";
+  if (value < 60) return `${value.toFixed(1)}s`;
+  const minutes = Math.floor(value / 60);
+  const seconds = Math.round(value % 60);
+  return `${minutes}m ${seconds}s`;
+}
+
+function formatWindow(formMetrics) {
+  if (!formMetrics) return "";
+  const start = new Date(formMetrics.startAt).toISOString().slice(0, 10);
+  const end = new Date(formMetrics.endAt).toISOString().slice(0, 10);
+  return `${start} → ${end} (${formMetrics.days} days)`;
+}
+
+const SPARKLINE_WIDTH = 140;
+const SPARKLINE_HEIGHT = 32;
+const SPARKLINE_STARTS_COLOR = "#94a3b8";
+const SPARKLINE_COMPLETIONS_COLOR = "#0d9488";
+
+function seriesToPolylinePoints(series, max, width, height) {
+  if (series.length === 0) return "";
+  if (series.length === 1) {
+    const y = (height - (series[0].count / max) * height).toFixed(2);
+    return `0,${y} ${width},${y}`;
+  }
+  const stepX = width / (series.length - 1);
+  return series
+    .map((point, idx) => {
+      const x = (idx * stepX).toFixed(2);
+      const y = (height - (point.count / max) * height).toFixed(2);
+      return `${x},${y}`;
+    })
+    .join(" ");
+}
+
+function renderTrendSparkline(series, label) {
+  const starts = series?.starts ?? [];
+  const completions = series?.completions ?? [];
+  if (starts.length === 0 && completions.length === 0) return "—";
+
+  const max = Math.max(
+    1,
+    ...starts.map((p) => p.count),
+    ...completions.map((p) => p.count)
+  );
+
+  const startsPoints = seriesToPolylinePoints(
+    starts,
+    max,
+    SPARKLINE_WIDTH,
+    SPARKLINE_HEIGHT
+  );
+  const completionsPoints = seriesToPolylinePoints(
+    completions,
+    max,
+    SPARKLINE_WIDTH,
+    SPARKLINE_HEIGHT
+  );
+
+  return `<svg width="${SPARKLINE_WIDTH}" height="${SPARKLINE_HEIGHT}" viewBox="0 0 ${SPARKLINE_WIDTH} ${SPARKLINE_HEIGHT}" role="img" aria-label="${escapeHtml(label)} daily trend">
+  ${startsPoints ? `<polyline fill="none" stroke="${SPARKLINE_STARTS_COLOR}" stroke-width="1.25" points="${startsPoints}" />` : ""}
+  ${completionsPoints ? `<polyline fill="none" stroke="${SPARKLINE_COMPLETIONS_COLOR}" stroke-width="1.5" points="${completionsPoints}" />` : ""}
+</svg>`;
+}
+
+function renderStepsTable(steps) {
+  if (steps.length === 0) {
+    return '<p class="meta">No <code>form-step-*</code> events recorded for this form.</p>';
+  }
+  const rows = steps
+    .map(
+      (step) => `<tr>
+  <td>Step ${escapeHtml(String(step.number))}</td>
+  <td>${escapeHtml(String(step.sessions))}</td>
+  <td>${escapeHtml(formatPercent(step.conversionFromStartRate))}</td>
+  <td>${escapeHtml(formatPercent(step.conversionFromPreviousRate))}</td>
+</tr>`
+    )
+    .join("\n");
+
+  return `<table>
+  <thead>
+    <tr>
+      <th>Step</th>
+      <th>Unique sessions</th>
+      <th>From start</th>
+      <th>From previous step</th>
+    </tr>
+  </thead>
+  <tbody>${rows}</tbody>
+</table>`;
+}
+
+function renderGeneralStatsSection({
+  formMetrics,
+  formMetricsPrior,
+  websiteStats,
+  reportDays,
+}) {
+  // Skip the section entirely when neither data source is available so we
+  // don't clutter the report with placeholder cards.
+  if (!(formMetrics || websiteStats)) {
+    return `
+  <section>
+    <h2>General stats</h2>
+    <p class="meta">Skipped — set <code>UMAMI_API_KEY</code> and <code>NEXT_PUBLIC_UMAMI_SITE_ID</code> to include site-wide aggregates.</p>
+  </section>`;
+  }
+
+  // Prefer the form metrics window since both helpers are called with the same
+  // `reportDays`; fall back to website stats, then the env-supplied default.
+  const window = formMetrics ?? websiteStats;
+  const windowText = window
+    ? formatWindow({
+        startAt: window.startAt,
+        endAt: window.endAt,
+        days: window.days,
+      })
+    : `last ${reportDays} days`;
+  const deltaWindowLabel = `prior ${reportDays} days`;
+
+  const aggregate = formMetrics?.aggregate;
+  const aggregatePrior = formMetricsPrior?.aggregate;
+
+  const cards = [
+    {
+      label: "Website visits",
+      value: websiteStats ? formatInteger(websiteStats.visits) : "—",
+      delta: websiteStats
+        ? buildDelta({
+            current: websiteStats.visits,
+            previous: websiteStats.previous.visits,
+            higherIsBetter: true,
+            mode: "relative",
+          })
+        : null,
+      sub: websiteStats
+        ? `${formatInteger(websiteStats.visitors)} unique visitors · ${formatInteger(websiteStats.pageviews)} page views`
+        : "Umami stats unavailable",
+    },
+    {
+      label: "Form completion rate",
+      value: aggregate ? formatPercent(aggregate.completionRate) : "—",
+      delta:
+        aggregate && aggregatePrior
+          ? buildDelta({
+              current: aggregate.completionRate,
+              previous: aggregatePrior.completionRate,
+              higherIsBetter: true,
+              mode: "percent-points",
+            })
+          : null,
+      sub: aggregate
+        ? `${formatInteger(aggregate.completions)} of ${formatInteger(aggregate.starts)} starts completed`
+        : "No form events recorded",
+    },
+    {
+      label: "Form abandonment rate",
+      value: aggregate ? formatPercent(aggregate.abandonmentRate) : "—",
+      delta:
+        aggregate && aggregatePrior
+          ? buildDelta({
+              current: aggregate.abandonmentRate,
+              previous: aggregatePrior.abandonmentRate,
+              higherIsBetter: false,
+              mode: "percent-points",
+            })
+          : null,
+      sub: aggregate
+        ? `${formatInteger(aggregate.starts - aggregate.completions)} starts abandoned`
+        : "No form events recorded",
+    },
+    {
+      label: "Avg time to complete a form",
+      value: aggregate ? formatSeconds(aggregate.avgCompletionSeconds) : "—",
+      delta:
+        aggregate && aggregatePrior
+          ? buildDelta({
+              current: aggregate.avgCompletionSeconds,
+              previous: aggregatePrior.avgCompletionSeconds,
+              higherIsBetter: false,
+              mode: "relative",
+            })
+          : null,
+      sub: aggregate
+        ? `Median ${formatSeconds(aggregate.medianCompletionSeconds)} · p90 ${formatSeconds(aggregate.p90CompletionSeconds)}`
+        : "No form-submit duration data",
+    },
+  ];
+
+  const cardMarkup = cards
+    .map(
+      (card) => `<div class="stat">
+  <div class="stat-label">${escapeHtml(card.label)}</div>
+  <div class="stat-value">${escapeHtml(card.value)}</div>
+  ${renderDelta(card.delta, deltaWindowLabel)}
+  <div class="stat-sub">${escapeHtml(card.sub)}</div>
+</div>`
+    )
+    .join("\n");
+
+  return `
+  <section>
+    <h2>General stats</h2>
+    <p class="meta">
+      Aggregated across all forms and the entire website for ${escapeHtml(windowText)}.
+      Each card compares to the immediately preceding ${escapeHtml(String(reportDays))}-day window.
+      Form rates roll up unique-session starts and completions; the average uses the merged <code>duration_seconds</code> distribution from <code>form-submit</code>.
+    </p>
+    <div class="stats-grid">${cardMarkup}</div>
+  </section>`;
+}
+
+function renderFormMetricsSection(formMetrics) {
+  if (!formMetrics) {
+    return `
+  <section>
+    <h2>Form completion analytics</h2>
+    <p class="meta">Skipped — set <code>UMAMI_API_KEY</code> and <code>NEXT_PUBLIC_UMAMI_SITE_ID</code> to include Umami funnel metrics.</p>
+  </section>`;
+  }
+
+  if (formMetrics.rows.length === 0) {
+    return `
+  <section>
+    <h2>Form completion analytics</h2>
+    <p class="meta">Window ${escapeHtml(formatWindow(formMetrics))}. No <code>form-start</code> / <code>form-submit</code> events recorded.</p>
+  </section>`;
+  }
+
+  const summaryRows = formMetrics.rows
+    .map(
+      (row) => `<tr>
+  <td>${escapeHtml(row.label)}<br /><code style="color:#64748b;font-size:0.75rem">${escapeHtml(row.form)}</code>${row.truncated ? ' <span title="Pagination cap reached; numbers may be a lower bound" style="color:#b45309">⚠</span>' : ""}</td>
+  <td>${escapeHtml(String(row.starts))}</td>
+  <td>${escapeHtml(String(row.completions))}</td>
+  <td>${escapeHtml(formatPercent(row.completionRate))}</td>
+  <td>${escapeHtml(formatPercent(row.abandonmentRate))}</td>
+  <td>${escapeHtml(formatSeconds(row.avgCompletionSeconds))}</td>
+  <td>${escapeHtml(formatSeconds(row.medianCompletionSeconds))}</td>
+  <td>${escapeHtml(formatSeconds(row.p90CompletionSeconds))}</td>
+  <td>${renderTrendSparkline(row.series, row.label)}</td>
+</tr>`
+    )
+    .join("\n");
+
+  const stepBlocks = formMetrics.rows
+    .map(
+      (row) => `<details>
+  <summary><strong>${escapeHtml(row.label)}</strong> — ${escapeHtml(String(row.steps.length))} step${row.steps.length === 1 ? "" : "s"}</summary>
+  ${renderStepsTable(row.steps)}
+</details>`
+    )
+    .join("\n");
+
+  return `
+  <section>
+    <h2>Form completion analytics</h2>
+    <p class="meta">
+      Umami funnel for ${escapeHtml(formatWindow(formMetrics))}. Counts are unique browser sessions (de-duplicated on <code>sessionId</code>). Average / median / p90 are derived from the <code>duration_seconds</code> property on <code>form-submit</code>. Trend sparklines show unique sessions per day:
+      <span style="display:inline-flex;align-items:center;gap:0.35rem;margin-left:0.25rem"><span style="display:inline-block;width:14px;height:2px;background:${SPARKLINE_STARTS_COLOR}"></span>starts</span>
+      <span style="display:inline-flex;align-items:center;gap:0.35rem;margin-left:0.5rem"><span style="display:inline-block;width:14px;height:2px;background:${SPARKLINE_COMPLETIONS_COLOR}"></span>completions</span>.
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Form</th>
+          <th>Starts</th>
+          <th>Completions</th>
+          <th>Completion rate</th>
+          <th>Abandonment rate</th>
+          <th>Avg</th>
+          <th>Median</th>
+          <th>p90</th>
+          <th>Trend</th>
+        </tr>
+      </thead>
+      <tbody>${summaryRows}</tbody>
+    </table>
+    <h3 style="font-size:1rem;margin-top:1.5rem;margin-bottom:0.5rem">Per-step drop-off</h3>
+    ${stepBlocks}
+  </section>`;
+}
+
+function buildIndexHtml({
+  lighthouseRows,
+  playwrightMetrics,
+  formMetrics,
+  formMetricsPrior,
+  websiteStats,
+  reportDays,
+  meta,
+}) {
   const axeRows = Object.entries(playwrightMetrics?.axe ?? {})
     .map(([key, v]) => {
       const violations = escapeHtml(
@@ -158,10 +530,13 @@ function buildIndexHtml({ lighthouseRows, playwrightMetrics, meta }) {
     th, td { text-align: left; padding: 0.65rem 0.85rem; border-bottom: 1px solid #e2e8f0; vertical-align: top; }
     th { background: #f1f5f9; font-weight: 600; font-size: 0.85rem; }
     tr:last-child td { border-bottom: none; }
-    .scores { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 0.75rem; margin-top: 0.75rem; }
-    .card { background: #fff; border-radius: 8px; padding: 0.85rem 1rem; box-shadow: 0 1px 3px rgb(15 23 42 / 0.08); }
-    .card .k { font-size: 0.75rem; color: #64748b; text-transform: uppercase; letter-spacing: 0.03em; }
-    .card .v { font-size: 1.5rem; font-weight: 700; margin-top: 0.15rem; }
+    .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.75rem; margin-top: 0.75rem; }
+    .stat { background: #fff; border-radius: 8px; padding: 1rem 1.1rem; box-shadow: 0 1px 3px rgb(15 23 42 / 0.08); }
+    .stat-label { font-size: 0.75rem; color: #64748b; text-transform: uppercase; letter-spacing: 0.03em; }
+    .stat-value { font-size: 1.75rem; font-weight: 700; margin-top: 0.25rem; color: #0f172a; }
+    .stat-delta { font-size: 0.8rem; font-weight: 600; margin-top: 0.25rem; }
+    .stat-delta-context { color: #64748b; font-weight: 400; margin-left: 0.25rem; }
+    .stat-sub { font-size: 0.8rem; color: #475569; margin-top: 0.35rem; }
     .pre-json { max-height: 200px; overflow: auto; font-size: 0.75rem; background: #f1f5f9; padding: 0.5rem; border-radius: 4px; white-space: pre-wrap; word-break: break-word; }
     a { color: #0d9488; }
   </style>
@@ -174,14 +549,7 @@ function buildIndexHtml({ lighthouseRows, playwrightMetrics, meta }) {
     Run: ${escapeHtml(meta.runUrl)}
   </p>
 
-  <section>
-    <h2>Playwright timings</h2>
-    <p>Measured in Chromium (desktop) against <code>${escapeHtml(meta.baseUrl)}</code>.</p>
-    <div class="scores">
-      <div class="card"><div class="k">Form page ready</div><div class="v">${escapeHtml(String(playwrightMetrics?.timings?.formPageReadyMs ?? "—"))}<span style="font-size:0.9rem;font-weight:400"> ms</span></div></div>
-      <div class="card"><div class="k">Home → search results</div><div class="v">${escapeHtml(String(playwrightMetrics?.timings?.searchToResultsMs ?? "—"))}<span style="font-size:0.9rem;font-weight:400"> ms</span></div></div>
-    </div>
-  </section>
+  ${renderGeneralStatsSection({ formMetrics, formMetricsPrior, websiteStats, reportDays })}
 
   <section>
     <h2>Lighthouse (desktop)</h2>
@@ -200,6 +568,8 @@ function buildIndexHtml({ lighthouseRows, playwrightMetrics, meta }) {
       <tbody>${lhTable}</tbody>
     </table>
   </section>
+
+  ${renderFormMetricsSection(formMetrics)}
 
   <section>
     <h2>axe (accessibility)</h2>
@@ -260,12 +630,66 @@ async function main() {
     console.log("[perf] Running Lighthouse…");
     const lhResults = await runLighthouseSuite(baseUrl, outDir, lhArtifactDir);
 
-    console.log("[perf] Running Playwright (axe + timings)…");
+    console.log("[perf] Running Playwright (axe)…");
     runPlaywrightMetrics(baseUrl);
 
     const playwrightMetrics = await readJson(
       path.join(perfArtifacts, "playwright-metrics.json")
     );
+
+    const reportDaysRaw = Number(process.env.UMAMI_REPORT_DAYS ?? 7);
+    const reportDays = Number.isFinite(reportDaysRaw) ? reportDaysRaw : 7;
+
+    let formMetrics = null;
+    let formMetricsPrior = null;
+    let websiteStats = null;
+
+    // Anchor the prior window to the start of the current window so the two
+    // funnels never overlap, regardless of when the job runs.
+    const endAt = Date.now();
+    const priorEndAt = endAt - reportDays * MS_PER_DAY;
+
+    console.log(
+      "[perf] Fetching Umami form funnel (current + prior) + website stats…"
+    );
+    const [formMetricsResult, formMetricsPriorResult, websiteStatsResult] =
+      await Promise.allSettled([
+        fetchFormFunnelMetrics({ days: reportDays, now: endAt }),
+        fetchFormFunnelMetrics({ days: reportDays, now: priorEndAt }),
+        fetchWebsiteStats({ days: reportDays, now: endAt }),
+      ]);
+
+    if (formMetricsResult.status === "fulfilled") {
+      formMetrics = formMetricsResult.value;
+      if (!formMetrics) {
+        console.log(
+          "[perf] Skipping form funnel section — UMAMI_API_KEY or NEXT_PUBLIC_UMAMI_SITE_ID not set."
+        );
+      }
+    } else {
+      const reason = formMetricsResult.reason;
+      console.warn(
+        `[perf] Form funnel fetch failed; continuing without it: ${reason instanceof Error ? reason.message : String(reason)}`
+      );
+    }
+
+    if (formMetricsPriorResult.status === "fulfilled") {
+      formMetricsPrior = formMetricsPriorResult.value;
+    } else {
+      const reason = formMetricsPriorResult.reason;
+      console.warn(
+        `[perf] Prior-window form funnel fetch failed; continuing without comparison: ${reason instanceof Error ? reason.message : String(reason)}`
+      );
+    }
+
+    if (websiteStatsResult.status === "fulfilled") {
+      websiteStats = websiteStatsResult.value;
+    } else {
+      const reason = websiteStatsResult.reason;
+      console.warn(
+        `[perf] Website stats fetch failed; continuing without it: ${reason instanceof Error ? reason.message : String(reason)}`
+      );
+    }
 
     const lighthouseRows = lhResults.map(({ page, lhr }) => {
       const c = lhr.categories ?? {};
@@ -292,8 +716,11 @@ async function main() {
     const html = buildIndexHtml({
       lighthouseRows,
       playwrightMetrics,
+      formMetrics,
+      formMetricsPrior,
+      websiteStats,
+      reportDays,
       meta: {
-        baseUrl,
         sha,
         ref,
         runUrl,

--- a/scripts/perf/umami-form-metrics.mjs
+++ b/scripts/perf/umami-form-metrics.mjs
@@ -1,0 +1,572 @@
+/**
+ * Aggregates Umami custom events emitted by `useFormTracking` into per-form
+ * funnel metrics: unique-session form starts, completions, completion /
+ * abandonment rate, completion-time mean / median / p90, and per-step drop-off.
+ *
+ * Counts are de-duplicated on Umami sessionId — one browser session counts
+ * once per event, even if the user reloads or the event fires repeatedly. We
+ * use sessionId because the app does not currently call `umami.identify`; if
+ * that changes, swap `record.sessionId` for `record.distinctId` below.
+ *
+ * Umami Cloud only — set UMAMI_API_KEY and NEXT_PUBLIC_UMAMI_SITE_ID. When
+ * either is missing, exported helpers return `null` so the perf report can
+ * silently omit the section in environments without analytics access (PR
+ * forks, local runs).
+ */
+
+const DEFAULT_UMAMI_BASE_URL = "https://api.umami.is/v1";
+const DEFAULT_DAYS = 7;
+const MS_PER_DAY = 86_400_000;
+const EVENTS_PAGE_SIZE = 1000;
+const MAX_EVENT_PAGES = 50;
+const DURATION_PROPERTY = "duration_seconds";
+
+const FORM_START_REGEX = /^(.+?):form-start$/;
+const FORM_SUBMIT_REGEX = /^(.+?):form-submit$/;
+const FORM_STEP_REGEX = /^(.+?):form-step-([a-z]+)$/;
+
+// Mirrors the `NUMBER_WORDS` table in `src/lib/analytics.ts` (1-based step
+// number ↔ word). Kept as a private copy so this script has zero coupling to
+// the Next.js source tree.
+const NUMBER_WORDS = [
+  "one",
+  "two",
+  "three",
+  "four",
+  "five",
+  "six",
+  "seven",
+  "eight",
+  "nine",
+  "ten",
+];
+
+/**
+ * @typedef {object} StepFunnel
+ * @property {number} number 1-based step index parsed from the event suffix.
+ * @property {string} eventName Full Umami event name (e.g. `slug:form-step-one`).
+ * @property {number} sessions Unique sessions that reached this step AND fired form-start.
+ * @property {number | null} conversionFromStartRate sessions / starts.
+ * @property {number | null} conversionFromPreviousRate sessions / previous step sessions (form-start for step 1).
+ */
+
+/**
+ * @typedef {object} DailyPoint
+ * @property {string} date ISO `YYYY-MM-DD` (UTC).
+ * @property {number} count Unique sessions that fired the event on that day.
+ */
+
+/**
+ * @typedef {object} FormFunnelRow
+ * @property {string} form Slug used as the Umami event prefix.
+ * @property {string} label Human-readable label derived from the slug.
+ * @property {number} starts Unique sessions that fired `{form}:form-start`.
+ * @property {number} completions Unique sessions that fired both start and submit.
+ * @property {number | null} completionRate completions / starts (capped at 1).
+ * @property {number | null} abandonmentRate 1 - completionRate.
+ * @property {number | null} avgCompletionSeconds Weighted mean of `duration_seconds` across completions.
+ * @property {number | null} medianCompletionSeconds 50th percentile of `duration_seconds`.
+ * @property {number | null} p90CompletionSeconds 90th percentile of `duration_seconds`.
+ * @property {StepFunnel[]} steps Per-step drop-off, ordered by step number.
+ * @property {{ starts: DailyPoint[]; completions: DailyPoint[] }} series Daily event counts for trend chart.
+ * @property {boolean} truncated True when an event hit the pagination cap.
+ */
+
+/**
+ * @typedef {object} FormAggregate
+ * @property {number} starts Total unique-session starts summed across forms.
+ * @property {number} completions Total unique-session completions summed across forms.
+ * @property {number | null} completionRate completions / starts (capped at 1).
+ * @property {number | null} abandonmentRate 1 - completionRate.
+ * @property {number | null} avgCompletionSeconds Weighted mean across the merged duration distribution of all forms.
+ * @property {number | null} medianCompletionSeconds 50th percentile of the merged distribution.
+ * @property {number | null} p90CompletionSeconds 90th percentile of the merged distribution.
+ */
+
+/**
+ * @typedef {object} FormMetricsResult
+ * @property {number} startAt Window start (ms epoch).
+ * @property {number} endAt Window end (ms epoch).
+ * @property {number} days Window size in days.
+ * @property {FormFunnelRow[]} rows Per-form funnel rows, sorted by starts desc.
+ * @property {FormAggregate} aggregate Cross-form roll-up for "general stats" headlines.
+ */
+
+/**
+ * @typedef {object} WebsiteStatsTotals
+ * @property {number} pageviews
+ * @property {number} visitors
+ * @property {number} visits
+ */
+
+/**
+ * @typedef {object} WebsiteStats
+ * @property {number} startAt Window start (ms epoch).
+ * @property {number} endAt Window end (ms epoch).
+ * @property {number} days Window size in days.
+ * @property {number} pageviews Total page views in the window.
+ * @property {number} visitors Unique visitors (distinct browsers/devices).
+ * @property {number} visits Sessions started in the window — used as the "website visits" headline.
+ * @property {WebsiteStatsTotals} previous Equivalent totals for the immediately preceding window of the same length, sourced from Umami's `prev` fields.
+ */
+
+function asArray(body) {
+  if (Array.isArray(body)) return body;
+  if (body && typeof body === "object" && Array.isArray(body.data)) {
+    return body.data;
+  }
+  return [];
+}
+
+function humanizeFormSlug(slug) {
+  if (!slug) return slug;
+  return slug
+    .split("-")
+    .map((part) => (part ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(" ");
+}
+
+function wordToStepNumber(word) {
+  const idx = NUMBER_WORDS.indexOf(word);
+  return idx >= 0 ? idx + 1 : null;
+}
+
+function setIntersection(a, b) {
+  const result = new Set();
+  // Iterate the smaller set for a tiny speedup on lopsided funnels
+  const [small, large] = a.size <= b.size ? [a, b] : [b, a];
+  for (const value of small) {
+    if (large.has(value)) result.add(value);
+  }
+  return result;
+}
+
+async function fetchUmamiJson({ baseUrl, apiKey, path, params }) {
+  const url = new URL(`${baseUrl}${path}`);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  const res = await fetch(url.toString(), {
+    headers: {
+      Accept: "application/json",
+      "x-umami-api-key": apiKey,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `Umami request failed (${res.status} ${res.statusText}): ${url.pathname}${url.search}`
+    );
+  }
+
+  return res.json();
+}
+
+/**
+ * Paginates `/events?event={eventName}` and returns:
+ *  - `sessions`: window-wide de-duplicated sessionIds (drives funnel headlines).
+ *  - `dailySessions`: per-UTC-day session sets (drives unique-session sparklines).
+ *
+ * Stops when the page is empty or pagination cap is hit.
+ *
+ * @returns {Promise<{ sessions: Set<string>; dailySessions: Map<string, Set<string>>; truncated: boolean }>}
+ */
+async function fetchEventSessions({
+  baseUrl,
+  apiKey,
+  websiteId,
+  startAt,
+  endAt,
+  eventName,
+}) {
+  const sessions = new Set();
+  /** @type {Map<string, Set<string>>} */
+  const dailySessions = new Map();
+  let truncated = false;
+
+  for (let page = 1; page <= MAX_EVENT_PAGES; page += 1) {
+    const body = await fetchUmamiJson({
+      baseUrl,
+      apiKey,
+      path: `/websites/${websiteId}/events`,
+      params: {
+        startAt,
+        endAt,
+        event: eventName,
+        page,
+        pageSize: EVENTS_PAGE_SIZE,
+      },
+    });
+
+    const records = Array.isArray(body?.data) ? body.data : [];
+    if (records.length === 0) break;
+
+    for (const record of records) {
+      const sessionId = record?.sessionId;
+      if (typeof sessionId !== "string" || !sessionId) continue;
+      sessions.add(sessionId);
+
+      const createdAt = record?.createdAt;
+      if (typeof createdAt !== "string") continue;
+      const dateKey = createdAt.slice(0, 10);
+      let bucket = dailySessions.get(dateKey);
+      if (!bucket) {
+        bucket = new Set();
+        dailySessions.set(dateKey, bucket);
+      }
+      bucket.add(sessionId);
+    }
+
+    const total = Number(body?.count ?? 0);
+    if (page * EVENTS_PAGE_SIZE >= total) break;
+
+    if (page === MAX_EVENT_PAGES) {
+      truncated = true;
+    }
+  }
+
+  return { sessions, dailySessions, truncated };
+}
+
+function dailySessionsToSeries(dailySessions, startAt, endAt) {
+  const buckets = buildDailyBuckets(startAt, endAt);
+  for (const point of buckets) {
+    const set = dailySessions.get(point.date);
+    point.count = set ? set.size : 0;
+  }
+  return buckets;
+}
+
+function utcDateKey(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function buildDailyBuckets(startAt, endAt) {
+  /** @type {DailyPoint[]} */
+  const days = [];
+  const cursor = new Date(startAt);
+  cursor.setUTCHours(0, 0, 0, 0);
+  const stop = new Date(endAt);
+  stop.setUTCHours(0, 0, 0, 0);
+  while (cursor.getTime() <= stop.getTime()) {
+    days.push({ date: utcDateKey(cursor), count: 0 });
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  return days;
+}
+
+function discoverForms(eventRows) {
+  /** @type {Map<string, { startEvent?: string; submitEvent?: string; steps: Map<number, { number: number; eventName: string }> }>} */
+  const catalog = new Map();
+
+  const ensureEntry = (slug) => {
+    let entry = catalog.get(slug);
+    if (!entry) {
+      entry = { steps: new Map() };
+      catalog.set(slug, entry);
+    }
+    return entry;
+  };
+
+  for (const row of eventRows) {
+    const name = row?.x;
+    if (typeof name !== "string") continue;
+
+    let match = FORM_START_REGEX.exec(name);
+    if (match) {
+      ensureEntry(match[1]).startEvent = name;
+      continue;
+    }
+
+    match = FORM_SUBMIT_REGEX.exec(name);
+    if (match) {
+      ensureEntry(match[1]).submitEvent = name;
+      continue;
+    }
+
+    match = FORM_STEP_REGEX.exec(name);
+    if (match) {
+      const stepNumber = wordToStepNumber(match[2]);
+      if (!stepNumber) continue;
+      const entry = ensureEntry(match[1]);
+      // Discovery yields each step once; first-write-wins is fine
+      if (!entry.steps.has(stepNumber)) {
+        entry.steps.set(stepNumber, { number: stepNumber, eventName: name });
+      }
+    }
+  }
+
+  return catalog;
+}
+
+/**
+ * Computes mean, median (p50), and p90 from a value-distribution as returned
+ * by `event-data/values`: `[{ value, total }]`.
+ */
+function summarizeDurationValues(rows) {
+  const items = rows
+    .map((row) => ({
+      value: Number(row?.value),
+      count: Number(row?.total ?? 0),
+    }))
+    .filter((item) => Number.isFinite(item.value) && item.count > 0)
+    .sort((a, b) => a.value - b.value);
+
+  let total = 0;
+  let sum = 0;
+  for (const item of items) {
+    total += item.count;
+    sum += item.value * item.count;
+  }
+  if (total === 0) return { mean: null, median: null, p90: null };
+
+  const percentile = (fraction) => {
+    const target = total * fraction;
+    let cumulative = 0;
+    for (const item of items) {
+      cumulative += item.count;
+      if (cumulative >= target) return item.value;
+    }
+    return items.at(-1)?.value ?? null;
+  };
+
+  return {
+    mean: sum / total,
+    median: percentile(0.5),
+    p90: percentile(0.9),
+  };
+}
+
+/**
+ * Fetches per-form funnel metrics from Umami Cloud for the given window.
+ *
+ * Returns `null` when required credentials are missing rather than throwing,
+ * so the perf report can degrade gracefully on PRs/forks.
+ *
+ * @param {{ days?: number; now?: number }} [options]
+ * @returns {Promise<FormMetricsResult | null>}
+ */
+export async function fetchFormFunnelMetrics(options = {}) {
+  const apiKey = process.env.UMAMI_API_KEY;
+  const websiteId = process.env.NEXT_PUBLIC_UMAMI_SITE_ID;
+  if (!(apiKey && websiteId)) return null;
+
+  const baseUrl = (
+    process.env.UMAMI_API_BASE_URL ?? DEFAULT_UMAMI_BASE_URL
+  ).replace(/\/$/, "");
+  const days = Math.max(1, Math.min(365, options.days ?? DEFAULT_DAYS));
+  const endAt = options.now ?? Date.now();
+  const startAt = endAt - days * MS_PER_DAY;
+  const ctx = { baseUrl, apiKey, websiteId, startAt, endAt };
+
+  const eventCatalogBody = await fetchUmamiJson({
+    baseUrl,
+    apiKey,
+    path: `/websites/${websiteId}/metrics`,
+    params: { startAt, endAt, type: "event", limit: 500 },
+  });
+  const catalog = discoverForms(asArray(eventCatalogBody));
+
+  /** @type {FormFunnelRow[]} */
+  const rows = [];
+
+  // Merged across forms so we can compute true weighted aggregates (rather than
+  // averaging per-form averages, which would mis-weight small/large forms).
+  /** @type {Array<{ value: number; total: number }>} */
+  const aggregateDurationRows = [];
+  let aggregateStarts = 0;
+  let aggregateCompletions = 0;
+
+  for (const [form, entry] of catalog.entries()) {
+    if (!entry.startEvent) {
+      // No form-start signal means we can't compute a meaningful funnel
+      continue;
+    }
+
+    const sortedSteps = [...entry.steps.values()].sort(
+      (a, b) => a.number - b.number
+    );
+
+    const [startResult, submitResult, durationValues, ...stepResults] =
+      await Promise.all([
+        fetchEventSessions({ ...ctx, eventName: entry.startEvent }),
+        entry.submitEvent
+          ? fetchEventSessions({ ...ctx, eventName: entry.submitEvent })
+          : Promise.resolve({
+              sessions: new Set(),
+              dailySessions: new Map(),
+              truncated: false,
+            }),
+        entry.submitEvent
+          ? fetchUmamiJson({
+              baseUrl,
+              apiKey,
+              path: `/websites/${websiteId}/event-data/values`,
+              params: {
+                startAt,
+                endAt,
+                event: entry.submitEvent,
+                propertyName: DURATION_PROPERTY,
+              },
+            }).then(asArray)
+          : Promise.resolve([]),
+        ...sortedSteps.map((step) =>
+          fetchEventSessions({ ...ctx, eventName: step.eventName })
+        ),
+      ]);
+
+    const startsSeries = dailySessionsToSeries(
+      startResult.dailySessions,
+      startAt,
+      endAt
+    );
+    const completionsSeries = dailySessionsToSeries(
+      submitResult.dailySessions,
+      startAt,
+      endAt
+    );
+
+    const startSessions = startResult.sessions;
+    const submitSessions = submitResult.sessions;
+    const completions = setIntersection(startSessions, submitSessions);
+
+    let previousSessions = startSessions;
+    /** @type {StepFunnel[]} */
+    const steps = sortedSteps.map((step, idx) => {
+      const reached = stepResults[idx]?.sessions ?? new Set();
+      const reachedFromStart = setIntersection(startSessions, reached);
+      const reachedFromPrevious = setIntersection(previousSessions, reached);
+
+      const stepRow = {
+        number: step.number,
+        eventName: step.eventName,
+        sessions: reachedFromStart.size,
+        conversionFromStartRate:
+          startSessions.size > 0
+            ? reachedFromStart.size / startSessions.size
+            : null,
+        conversionFromPreviousRate:
+          previousSessions.size > 0
+            ? reachedFromPrevious.size / previousSessions.size
+            : null,
+      };
+
+      previousSessions = reached;
+      return stepRow;
+    });
+
+    const completionRate =
+      startSessions.size > 0
+        ? Math.min(1, completions.size / startSessions.size)
+        : null;
+    const abandonmentRate =
+      completionRate === null ? null : Math.max(0, 1 - completionRate);
+
+    const { mean, median, p90 } = summarizeDurationValues(durationValues);
+
+    const truncated =
+      startResult.truncated ||
+      submitResult.truncated ||
+      stepResults.some((s) => s?.truncated);
+
+    rows.push({
+      form,
+      label: humanizeFormSlug(form),
+      starts: startSessions.size,
+      completions: completions.size,
+      completionRate,
+      abandonmentRate,
+      avgCompletionSeconds: mean,
+      medianCompletionSeconds: median,
+      p90CompletionSeconds: p90,
+      steps,
+      series: { starts: startsSeries, completions: completionsSeries },
+      truncated,
+    });
+
+    aggregateStarts += startSessions.size;
+    aggregateCompletions += completions.size;
+    aggregateDurationRows.push(...durationValues);
+  }
+
+  rows.sort((a, b) => b.starts - a.starts || b.completions - a.completions);
+
+  const aggregateCompletionRate =
+    aggregateStarts > 0
+      ? Math.min(1, aggregateCompletions / aggregateStarts)
+      : null;
+  const aggregateAbandonmentRate =
+    aggregateCompletionRate === null
+      ? null
+      : Math.max(0, 1 - aggregateCompletionRate);
+  const aggregateDuration = summarizeDurationValues(aggregateDurationRows);
+
+  /** @type {FormAggregate} */
+  const aggregate = {
+    starts: aggregateStarts,
+    completions: aggregateCompletions,
+    completionRate: aggregateCompletionRate,
+    abandonmentRate: aggregateAbandonmentRate,
+    avgCompletionSeconds: aggregateDuration.mean,
+    medianCompletionSeconds: aggregateDuration.median,
+    p90CompletionSeconds: aggregateDuration.p90,
+  };
+
+  return { startAt, endAt, days, rows, aggregate };
+}
+
+/**
+ * Fetches site-wide visit counts for the same reporting window used by the
+ * form funnel. Returns `null` when Umami credentials are missing so callers can
+ * skip the section silently in environments without analytics access.
+ *
+ * @param {{ days?: number; now?: number }} [options]
+ * @returns {Promise<WebsiteStats | null>}
+ */
+export async function fetchWebsiteStats(options = {}) {
+  const apiKey = process.env.UMAMI_API_KEY;
+  const websiteId = process.env.NEXT_PUBLIC_UMAMI_SITE_ID;
+  if (!(apiKey && websiteId)) return null;
+
+  const baseUrl = (
+    process.env.UMAMI_API_BASE_URL ?? DEFAULT_UMAMI_BASE_URL
+  ).replace(/\/$/, "");
+  const days = Math.max(1, Math.min(365, options.days ?? DEFAULT_DAYS));
+  const endAt = options.now ?? Date.now();
+  const startAt = endAt - days * MS_PER_DAY;
+
+  const body = await fetchUmamiJson({
+    baseUrl,
+    apiKey,
+    path: `/websites/${websiteId}/stats`,
+    params: { startAt, endAt },
+  });
+
+  // Umami Cloud returns metrics as flat numbers at the top level plus an
+  // equally-shaped `comparison` block for the immediately preceding window.
+  // (Self-hosted v1 used a `{ value, prev }` shape — we don't target that
+  // here.) Coerce defensively because zero-traffic windows can omit fields.
+  const readNumber = (value) => {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : 0;
+  };
+
+  const comparison = body?.comparison ?? {};
+
+  return {
+    days,
+    startAt,
+    endAt,
+    pageviews: readNumber(body?.pageviews),
+    visitors: readNumber(body?.visitors),
+    visits: readNumber(body?.visits),
+    previous: {
+      pageviews: readNumber(comparison.pageviews),
+      visitors: readNumber(comparison.visitors),
+      visits: readNumber(comparison.visits),
+    },
+  };
+}

--- a/tests/perf/metrics.spec.ts
+++ b/tests/perf/metrics.spec.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import AxeBuilder from "@axe-core/playwright";
-import { expect, test } from "@playwright/test";
+import { test } from "@playwright/test";
 
 const ARTIFACTS_DIR = path.join(process.cwd(), "perf-artifacts");
 
@@ -28,18 +28,12 @@ type AxeSummary = {
 
 type PlaywrightMetricsPayload = {
   axe: Record<AxeRouteKey, AxeSummary>;
-  timings: {
-    formPageReadyMs: number;
-    searchToResultsMs: number;
-  };
 };
 
 const store: {
   axe: Partial<Record<AxeRouteKey, AxeSummary>>;
-  timings: Partial<PlaywrightMetricsPayload["timings"]>;
 } = {
   axe: {},
-  timings: {},
 };
 
 function ensureArtifactsDir() {
@@ -62,13 +56,7 @@ function writeFinalPayload() {
       };
     }
   }
-  const payload: PlaywrightMetricsPayload = {
-    axe,
-    timings: {
-      formPageReadyMs: store.timings.formPageReadyMs ?? -1,
-      searchToResultsMs: store.timings.searchToResultsMs ?? -1,
-    },
-  };
+  const payload: PlaywrightMetricsPayload = { axe };
   const out = path.join(ARTIFACTS_DIR, "playwright-metrics.json");
   fs.writeFileSync(out, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
 }
@@ -95,28 +83,6 @@ test.describe("performance metrics", () => {
       };
     });
   }
-
-  test("timing: form page ready", async ({ page }) => {
-    const start = Date.now();
-    await page.goto(ROUTES.form, { waitUntil: "domcontentloaded" });
-    await expect(
-      page.getByRole("heading", { name: /tell us about yourself/i })
-    ).toBeVisible({ timeout: 60_000 });
-    store.timings.formPageReadyMs = Date.now() - start;
-  });
-
-  test("timing: search to results", async ({ page }) => {
-    const start = Date.now();
-    await page.goto(ROUTES.home, { waitUntil: "domcontentloaded" });
-    await page.locator("#service-search").fill("certificate");
-    await page.getByRole("button", { name: "Search" }).click();
-    await expect(
-      page.getByRole("heading", { name: "Search results" })
-    ).toBeVisible({
-      timeout: 60_000,
-    });
-    store.timings.searchToResultsMs = Date.now() - start;
-  });
 
   test.afterAll(() => {
     writeFinalPayload();


### PR DESCRIPTION
## Description
Replaces the brittle Playwright timing measurements in the weekly performance report with real product analytics pulled from Umami. 


The report now surfaces site-wide visits and per-form funnel health (starts, completions, abandonment, time-to-complete, per-step drop-off) with week-over-week deltas, and runs automatically every Monday so stakeholders always see fresh numbers.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes made

**`scripts/perf/umami-form-metrics.mjs` (new)**
- Adds a standalone Umami Cloud client that pages through `/events` and `/website/{id}/stats`, then aggregates `form-start`, `form-submit`, and `form-step-*` events into per-form funnels.
- De-duplicates on Umami `sessionId` so reloads and repeat fires don't inflate counts. Pulls `duration_seconds` off `form-submit` to compute mean / median / p90 completion time, and emits a daily series for sparklines.
- Returns `null` (instead of throwing) when `UMAMI_API_KEY` or `NEXT_PUBLIC_UMAMI_SITE_ID` is missing so PR forks and local runs degrade gracefully.

**`scripts/perf/generate-performance-report.mjs`**
- Fetches the current window, the immediately preceding window, and site-wide stats in parallel with `Promise.allSettled`, so a single failing call never blocks the report.
- Adds a **General stats** section with cards for Website visits, Form completion rate, Form abandonment rate, and Avg time to complete a form. Each card renders a week-over-week delta — percentage points for rates, relative % for counts/durations — colored green/red by whether the direction is good for that metric.
- Adds a **Form completion analytics** section with a per-form summary table (starts, completions, completion %, abandonment %, avg / median / p90, inline SVG trend sparkline for starts vs completions) and a collapsible per-step drop-off table per form.
- Removes the old Playwright timings card section; analytics now own that surface.

**`tests/perf/metrics.spec.ts`**
- Drops the two synthetic timing tests (`form page ready`, `search to results`) and the `timings` field from the emitted `playwright-metrics.json`. The spec now only persists axe results, which is all the report still consumes from Playwright.

**`.github/workflows/performance-report.yml`**
- Adds a weekly `schedule` trigger (`15 12 * * 1`, Mondays 12:15 UTC / 08:15 AST) — intentionally off-the-hour to dodge GitHub Actions cron contention.
- Wires `UMAMI_API_KEY`, `NEXT_PUBLIC_UMAMI_SITE_ID`, and `UMAMI_REPORT_DAYS=7` into the report step, and extends the deploy job's `if` so scheduled runs publish to GitHub Pages.

### Notes
- The script intentionally keeps a private copy of the 1-based `NUMBER_WORDS` table from `src/lib/analytics.ts` so it has zero coupling to the Next.js source tree and can run in any CI image with just Node.
- `MAX_EVENT_PAGES` is set to 50 (50k events). When that cap is hit a row is flagged with a warning glyph in the table so readers know the numbers are a lower bound.

## Testing

1. Set `UMAMI_API_KEY` and `NEXT_PUBLIC_UMAMI_SITE_ID` in `.env.local` (already configured locally).
2. Build the app and start it: `npm run build && npm start`.
3. From a second terminal: `BASE_URL=http://127.0.0.1:3000 PERF_EXTERNAL_SERVER=1 UMAMI_REPORT_DAYS=7 npm run perf:report`.
4. Open `performance-report/index.html` and verify:
   - **General stats** renders four cards with non-zero values and a delta badge under each.
   - **Form completion analytics** renders a row per active form, sparklines render, and the per-step `<details>` blocks expand to show drop-off.
   - The old "Playwright timings" section is gone; **axe** and **Lighthouse** sections still render.
5. To exercise the no-credentials path, unset `UMAMI_API_KEY`, rerun the script, and confirm both new sections show their "Skipped" placeholder instead of erroring.
6. Optional: trigger the workflow manually from the Actions tab (`workflow_dispatch`) to confirm the secrets are wired and the deploy job publishes.

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->


## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated