### PR TITLE
feat: open alpha.gov.bb to search engine indexing

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"b39a917f-96fb-4bc3-87fe-d2bfe54d95fa","pid":21826,"procStart":"Tue May  5 18:14:06 2026","acquiredAt":1778005821083}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"b39a917f-96fb-4bc3-87fe-d2bfe54d95fa","pid":21826,"procStart":"Tue May  5 18:14:06 2026","acquiredAt":1778005821083}

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ next-env.d.ts
 
 # Sentry Config File
 .env.sentry-build-plugin
+
+# Claude Code local state
+.claude/scheduled_tasks.lock

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
-Disallow: /
+Allow: /
+
+Sitemap: https://alpha.gov.bb/sitemap.xml

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,17 +13,8 @@ export const metadata: Metadata = {
   },
   description: "The best place to access official government services",
   robots: {
-    index: false,
-    follow: false,
-    nocache: true,
-    googleBot: {
-      index: false,
-      follow: false,
-      noimageindex: true,
-      "max-video-preview": -1,
-      "max-image-preview": "none",
-      "max-snippet": -1,
-    },
+    index: true,
+    follow: true,
   },
 };
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,35 @@
+import type { MetadataRoute } from "next";
+import { INFORMATION_ARCHITECTURE } from "@/data/content-directory";
+
+const BASE_URL = "https://alpha.gov.bb";
+
+const STATIC_PATHS = [
+  "/",
+  "/services",
+  "/feedback",
+  "/what-we-mean-by-alpha",
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+  const paths: string[] = [...STATIC_PATHS];
+
+  for (const category of INFORMATION_ARCHITECTURE) {
+    paths.push(`/${category.slug}`);
+
+    for (const page of category.pages) {
+      paths.push(`/${category.slug}/${page.slug}`);
+
+      for (const subPage of page.subPages ?? []) {
+        if (subPage.type === "markdown") {
+          paths.push(`/${category.slug}/${page.slug}/${subPage.slug}`);
+        }
+      }
+    }
+  }
+
+  return paths.map((path) => ({
+    url: `${BASE_URL}${path}`,
+    lastModified,
+  }));
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,12 +3,7 @@ import { INFORMATION_ARCHITECTURE } from "@/data/content-directory";
 
 const BASE_URL = "https://alpha.gov.bb";
 
-const STATIC_PATHS = [
-  "/",
-  "/services",
-  "/feedback",
-  "/what-we-mean-by-alpha",
-];
+const STATIC_PATHS = ["/", "/services", "/feedback", "/what-we-mean-by-alpha"];
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const lastModified = new Date();


### PR DESCRIPTION
## Description
Removes the site-wide `noindex/nofollow` block so the alpha subdomain can be discovered by search engines alongside `gov.bb`, per the GovTech SEO meeting (30 Apr 2026).

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- `src/app/layout.tsx` — replaces the global `robots: { index: false, follow: false, ... }` block with explicit `index: true, follow: true`.
- `public/robots.txt` — switches from `Disallow: /` to `Allow: /` and points to the new sitemap.
- `src/app/sitemap.ts` — new App Router sitemap, enumerates routes from `INFORMATION_ARCHITECTURE` (homepage, `/services`, `/feedback`, `/what-we-mean-by-alpha`, every category, service, and markdown subpage). Uses category-prefixed canonical URLs to avoid same-domain duplicates with the fallback `/<slug>` resolution.

### Notes
Google Search Console verification is intentionally **not** in this PR — handled in a follow-up once GSC issues a token. Recommended approach: add `verification: { google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION }` to the metadata export and set the env var in Amplify.

## Related Github Issue(s)/Trello Ticket(s)
N/A — driven by GovTech SEO meeting 30 Apr 2026.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added/updated (visual regression snapshots) — N/A, no UI changes
- [ ] Documentation updated — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)