### PR TITLE
fix: use "gross pay" wording in severance pay calculator (#561)

### DIFF
--- a/src/components/forms/calculate-severance-pay-form.tsx
+++ b/src/components/forms/calculate-severance-pay-form.tsx
@@ -498,7 +498,7 @@ export default function CalculateSeverancePayForm() {
             <ServiceTitle />
             <Heading as="h1">Your insurable earnings</Heading>
             <Text as="p" size="body">
-              Enter your usual basic pay. We'll use it as the average over the
+              Enter your usual gross pay. We'll use it as the average over the
               last 104 weeks (2 years).
             </Text>
 
@@ -514,7 +514,7 @@ export default function CalculateSeverancePayForm() {
 
             <div className="max-w-[16rem]">
               <Input
-                description="Your usual gross pay. Don't include overtime or bonuses."
+                description="Your usual gross pay. Include overtime or bonuses."
                 error={payError || undefined}
                 id="simple-avg"
                 inputMode="decimal"
@@ -697,15 +697,15 @@ export default function CalculateSeverancePayForm() {
                         </Text>
                         <ul className="list-disc space-y-2 pl-7">
                           <li>
-                            <strong>2.5 weeks</strong> of basic pay for each
+                            <strong>2.5 weeks</strong> of gross pay for each
                             year up to 10 years
                           </li>
                           <li>
-                            <strong>3 weeks</strong> of basic pay for each year
+                            <strong>3 weeks</strong> of gross pay for each year
                             between 11 and 20 years
                           </li>
                           <li>
-                            <strong>3.5 weeks</strong> of basic pay for each
+                            <strong>3.5 weeks</strong> of gross pay for each
                             year between 21 and 33 years
                           </li>
                         </ul>

--- a/src/content/calculate-severance-pay/index.md
+++ b/src/content/calculate-severance-pay/index.md
@@ -18,7 +18,7 @@ You can use this tool if:
 
 ### Use the online calculator
 
-You will answer a short set of questions about why you were sent home, when you worked for the employer, and your usual basic pay. We then estimate how much you may be owed.
+You will answer a short set of questions about why you were sent home, when you worked for the employer, and your usual gross pay. We then estimate how much you may be owed.
 
 <a data-start-link href="/money-financial-support/calculate-severance-pay/start">Start your estimate now</a>
 

--- a/src/content/calculate-severance-pay/start.md
+++ b/src/content/calculate-severance-pay/start.md
@@ -18,6 +18,6 @@ Have these ready before you start:
 
 - why you were sent home (redundancy, disaster, lay-off or short time, or death of employer)
 - your start date and your last day at work
-- your usual basic pay (weekly or monthly) — do not include overtime or bonuses
+- your usual gross pay (weekly or monthly) — include overtime or bonuses
 
 <a data-start-link href="/money-financial-support/calculate-severance-pay/form">Start your estimate now</a>


### PR DESCRIPTION
## Description
Updates copy on the severance pay calculator to say "gross pay" instead of "basic pay", and flips the field-level guidance to tell users to *include* overtime or bonuses — matching how gross/insurable earnings actually work.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Changes Made
- `src/components/forms/calculate-severance-pay-form.tsx` — intro paragraph, input description, and the three results-page bullets (2.5 / 3 / 3.5 weeks) now say "gross pay"; field description flipped to "Include overtime or bonuses."
- `src/content/calculate-severance-pay/start.md` — list item changed to "your usual gross pay (weekly or monthly) — include overtime or bonuses".
- `src/content/calculate-severance-pay/index.md` — landing copy updated to "your usual gross pay".

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
Fixes #561

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [x] Documentation updated