### PR TITLE
RELEASE 2026-05-13 part 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /coverage
 /test-results/
 /playwright-report/
+/.playwright-mcp/
 /performance-report/
 /perf-artifacts/
 /perf-archive/

--- a/src/app/(content)/[...slug]/page.tsx
+++ b/src/app/(content)/[...slug]/page.tsx
@@ -7,6 +7,7 @@ import { YouthOpportunityForm } from "@/app/youth/opportunities/[id]/form/_compo
 import { ClearFormStorage } from "@/components/clear-form-storage";
 import { DynamicFormLoader } from "@/components/dynamic-form-loader";
 import { FormSkeleton } from "@/components/forms/form-skeleton";
+import { Breadcrumbs } from "@/components/layout/breadcrumbs";
 import { MarkdownContent } from "@/components/markdown-content";
 import { OpportunityDetail } from "@/components/opportunity-detail";
 import { PageViewTracker } from "@/components/page-view-tracker";
@@ -26,9 +27,9 @@ import { findSubPageTitleFromPath } from "@/lib/utils";
 
 const opportunities = opportunitiesData as Opportunity[];
 
-type ContentPageProps = {
+interface ContentPageProps {
   params: Promise<{ slug: string[] }>;
-};
+}
 
 export default async function Page({ params }: ContentPageProps) {
   const { slug } = await params;
@@ -255,27 +256,30 @@ export default async function Page({ params }: ContentPageProps) {
       notFound();
     }
 
-    const opportunity = opportunities.find(
-      (opp) => opp.id === opportunitySlug
-    );
+    const opportunity = opportunities.find((opp) => opp.id === opportunitySlug);
     if (!opportunity) {
       notFound();
     }
 
     return (
-      <Suspense
-        fallback={
-          <div className="container py-8 lg:py-16">
-            <FormSkeleton />
-          </div>
-        }
-      >
-        <YouthOpportunityForm
-          notificationEmail={opportunity.contact?.email ?? null}
-          opportunityId={opportunity.id}
-          opportunityTitle={opportunity.title}
-        />
-      </Suspense>
+      <>
+        <div className="container py-4 lg:py-6">
+          <Breadcrumbs />
+        </div>
+        <Suspense
+          fallback={
+            <div className="container py-8 lg:py-16">
+              <FormSkeleton />
+            </div>
+          }
+        >
+          <YouthOpportunityForm
+            notificationEmail={opportunity.contact?.email ?? null}
+            opportunityId={opportunity.id}
+            opportunityTitle={opportunity.title}
+          />
+        </Suspense>
+      </>
     );
   }
 
@@ -288,9 +292,7 @@ export async function generateMetadata({ params }: ContentPageProps) {
   // Opportunity application form (4 slugs)
   if (slug.length === 4 && slug[3] === "form") {
     const [, , opportunitySlug] = slug;
-    const opportunity = opportunities.find(
-      (opp) => opp.id === opportunitySlug
-    );
+    const opportunity = opportunities.find((opp) => opp.id === opportunitySlug);
     if (opportunity) {
       const title = `Apply for ${opportunity.title}`;
       const description = `Apply for ${opportunity.title}. ${opportunity.description}`;
@@ -372,7 +374,14 @@ export async function generateMetadata({ params }: ContentPageProps) {
         openGraph: {
           title: subPageTitle,
           url: `${SITE_URL}/${slug.join("/")}`,
-          images: [{ url: `${SITE_URL}/og-image.png`, width: 1200, height: 630, alt: "Government of Barbados" }],
+          images: [
+            {
+              url: `${SITE_URL}/og-image.png`,
+              width: 1200,
+              height: 630,
+              alt: "Government of Barbados",
+            },
+          ],
         },
         twitter: { title: subPageTitle, images: [`${SITE_URL}/og-image.png`] },
       };
@@ -388,7 +397,14 @@ export async function generateMetadata({ params }: ContentPageProps) {
           title: result.frontmatter.title,
           description: result.frontmatter.description,
           url: `${SITE_URL}/${slug.join("/")}`,
-          images: [{ url: `${SITE_URL}/og-image.png`, width: 1200, height: 630, alt: "Government of Barbados" }],
+          images: [
+            {
+              url: `${SITE_URL}/og-image.png`,
+              width: 1200,
+              height: 630,
+              alt: "Government of Barbados",
+            },
+          ],
         },
         twitter: {
           title: result.frontmatter.title,
@@ -448,7 +464,14 @@ export async function generateMetadata({ params }: ContentPageProps) {
           title: result.frontmatter.title,
           description: result.frontmatter.description,
           url: `${SITE_URL}/${slug.join("/")}`,
-          images: [{ url: `${SITE_URL}/og-image.png`, width: 1200, height: 630, alt: "Government of Barbados" }],
+          images: [
+            {
+              url: `${SITE_URL}/og-image.png`,
+              width: 1200,
+              height: 630,
+              alt: "Government of Barbados",
+            },
+          ],
         },
         twitter: {
           title: result.frontmatter.title,
@@ -473,7 +496,14 @@ export async function generateMetadata({ params }: ContentPageProps) {
           title: category.title,
           description: category.description || "",
           url: `${SITE_URL}/${slug.join("/")}`,
-          images: [{ url: `${SITE_URL}/og-image.png`, width: 1200, height: 630, alt: "Government of Barbados" }],
+          images: [
+            {
+              url: `${SITE_URL}/og-image.png`,
+              width: 1200,
+              height: 630,
+              alt: "Government of Barbados",
+            },
+          ],
         },
         twitter: {
           title: category.title,

--- a/src/app/(content)/[...slug]/page.tsx
+++ b/src/app/(content)/[...slug]/page.tsx
@@ -1,11 +1,17 @@
 import { Heading, Link, Text } from "@govtech-bb/react";
 import NextLink from "next/link";
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
+import type { Opportunity } from "@/app/youth/opportunities/_components/opportunities-list";
+import { YouthOpportunityForm } from "@/app/youth/opportunities/[id]/form/_components/youth-opportunity-form";
 import { ClearFormStorage } from "@/components/clear-form-storage";
 import { DynamicFormLoader } from "@/components/dynamic-form-loader";
+import { FormSkeleton } from "@/components/forms/form-skeleton";
 import { MarkdownContent } from "@/components/markdown-content";
+import { OpportunityDetail } from "@/components/opportunity-detail";
 import { PageViewTracker } from "@/components/page-view-tracker";
 import { INFORMATION_ARCHITECTURE } from "@/data/content-directory";
+import opportunitiesData from "@/data/opportunities.json";
 import { getFormStorageKey } from "@/lib/form-registry";
 import { getMarkdownContent } from "@/lib/markdown";
 import { hasResearchAccess } from "@/lib/research-access";
@@ -17,6 +23,8 @@ import {
 } from "@/lib/service-access-api";
 import { SITE_URL } from "@/lib/site-url";
 import { findSubPageTitleFromPath } from "@/lib/utils";
+
+const opportunities = opportunitiesData as Opportunity[];
 
 type ContentPageProps = {
   params: Promise<{ slug: string[] }>;
@@ -70,7 +78,7 @@ export default async function Page({ params }: ContentPageProps) {
     );
   }
 
-  // Two slugs: Main service page
+  // Two slugs: Main service page OR subcategory index
   if (slug.length === 2) {
     const [categorySlug, pageSlug] = slug;
 
@@ -84,6 +92,32 @@ export default async function Page({ params }: ContentPageProps) {
     const page = category.pages.find((p) => p.slug === pageSlug);
     if (!page) {
       notFound();
+    }
+
+    // Subcategory index: render the nested pages as clickable tiles
+    if (page.pages && page.pages.length > 0) {
+      return (
+        <>
+          <Heading as="h1">{page.title}</Heading>
+          {page.description && <Text as="p">{page.description}</Text>}
+          <div className="flex flex-col divide-y-2 divide-grey-00 last:border-grey-00 last:border-b-2">
+            {page.pages.map((child) => (
+              <div
+                className="py-4 first:pt-4 lg:py-8 first:lg:pt-8"
+                key={child.slug}
+              >
+                <Link
+                  as={NextLink}
+                  className="cursor-pointer text-[20px] leading-normal lg:text-3xl"
+                  href={`/${categorySlug}/${pageSlug}/${child.slug}`}
+                >
+                  {child.title}
+                </Link>
+              </div>
+            ))}
+          </div>
+        </>
+      );
     }
 
     const serviceConfig = await fetchServiceConfig(pageSlug);
@@ -115,7 +149,7 @@ export default async function Page({ params }: ContentPageProps) {
     );
   }
 
-  // Three slugs: Sub-pages (start, form, etc.)
+  // Three slugs: Sub-pages (start, form, etc.) OR opportunity detail under a subcategory
   if (slug.length === 3) {
     const [categorySlug, pageSlug, subPageSlug] = slug;
 
@@ -129,6 +163,24 @@ export default async function Page({ params }: ContentPageProps) {
     const page = category.pages.find((p) => p.slug === pageSlug);
     if (!page) {
       notFound();
+    }
+
+    // Opportunity detail under a subcategory: third slug is the opportunity id
+    if (page.pages && page.pages.length > 0) {
+      const childPage = page.pages.find((p) => p.slug === subPageSlug);
+      if (!childPage) {
+        notFound();
+      }
+      const opportunity = opportunities.find((opp) => opp.id === subPageSlug);
+      if (!opportunity) {
+        notFound();
+      }
+      return (
+        <OpportunityDetail
+          applyHref={`/${categorySlug}/${pageSlug}/${subPageSlug}/form`}
+          opportunity={opportunity}
+        />
+      );
     }
 
     const serviceConfig = await fetchServiceConfig(pageSlug);
@@ -179,11 +231,79 @@ export default async function Page({ params }: ContentPageProps) {
     );
   }
 
+  // Four slugs: Opportunity application form under a subcategory
+  if (slug.length === 4) {
+    const [categorySlug, pageSlug, opportunitySlug, leafSlug] = slug;
+    if (leafSlug !== "form") {
+      notFound();
+    }
+
+    const category = INFORMATION_ARCHITECTURE.find(
+      (cat) => cat.slug === categorySlug
+    );
+    if (!category) {
+      notFound();
+    }
+
+    const page = category.pages.find((p) => p.slug === pageSlug);
+    if (!page?.pages || page.pages.length === 0) {
+      notFound();
+    }
+
+    const childPage = page.pages.find((p) => p.slug === opportunitySlug);
+    if (!childPage) {
+      notFound();
+    }
+
+    const opportunity = opportunities.find(
+      (opp) => opp.id === opportunitySlug
+    );
+    if (!opportunity) {
+      notFound();
+    }
+
+    return (
+      <Suspense
+        fallback={
+          <div className="container py-8 lg:py-16">
+            <FormSkeleton />
+          </div>
+        }
+      >
+        <YouthOpportunityForm
+          notificationEmail={opportunity.contact?.email ?? null}
+          opportunityId={opportunity.id}
+          opportunityTitle={opportunity.title}
+        />
+      </Suspense>
+    );
+  }
+
   return notFound();
 }
 
 export async function generateMetadata({ params }: ContentPageProps) {
   const { slug } = await params;
+
+  // Opportunity application form (4 slugs)
+  if (slug.length === 4 && slug[3] === "form") {
+    const [, , opportunitySlug] = slug;
+    const opportunity = opportunities.find(
+      (opp) => opp.id === opportunitySlug
+    );
+    if (opportunity) {
+      const title = `Apply for ${opportunity.title}`;
+      const description = `Apply for ${opportunity.title}. ${opportunity.description}`;
+      const canonical = `${SITE_URL}/${slug.join("/")}`;
+      return {
+        title,
+        description,
+        alternates: { canonical },
+        openGraph: { title, description, url: canonical },
+      };
+    }
+    return { title: "Apply" };
+  }
 
   // For sub-pages (3 slugs)
   if (slug.length === 3) {
@@ -193,6 +313,38 @@ export async function generateMetadata({ params }: ContentPageProps) {
       (cat) => cat.slug === categorySlug
     );
     const page = category?.pages.find((p) => p.slug === pageSlug);
+
+    // Opportunity detail under a subcategory
+    if (page?.pages && page.pages.length > 0) {
+      const opportunity = opportunities.find((opp) => opp.id === subPageSlug);
+      if (opportunity) {
+        const canonical = `${SITE_URL}/${slug.join("/")}`;
+        return {
+          title: opportunity.title,
+          description: opportunity.description,
+          alternates: { canonical },
+          openGraph: {
+            title: opportunity.title,
+            description: opportunity.description,
+            url: canonical,
+            images: [
+              {
+                url: `${SITE_URL}/og-image.png`,
+                width: 1200,
+                height: 630,
+                alt: "Government of Barbados",
+              },
+            ],
+          },
+          twitter: {
+            title: opportunity.title,
+            description: opportunity.description,
+            images: [`${SITE_URL}/og-image.png`],
+          },
+        };
+      }
+      return { title: "Page not found" };
+    }
 
     if (page) {
       const serviceConfig = await fetchServiceConfig(pageSlug);
@@ -249,6 +401,41 @@ export async function generateMetadata({ params }: ContentPageProps) {
 
   // For main pages (2 slugs)
   if (slug.length === 2) {
+    const [categorySlug, pageSlug] = slug;
+    const category = INFORMATION_ARCHITECTURE.find(
+      (cat) => cat.slug === categorySlug
+    );
+    const page = category?.pages.find((p) => p.slug === pageSlug);
+
+    // Subcategory index — no markdown, use the page's own metadata
+    if (page?.pages && page.pages.length > 0) {
+      const canonical = `${SITE_URL}/${slug.join("/")}`;
+      const description = page.description || "";
+      return {
+        title: page.title,
+        description,
+        alternates: { canonical },
+        openGraph: {
+          title: page.title,
+          description,
+          url: canonical,
+          images: [
+            {
+              url: `${SITE_URL}/og-image.png`,
+              width: 1200,
+              height: 630,
+              alt: "Government of Barbados",
+            },
+          ],
+        },
+        twitter: {
+          title: page.title,
+          description,
+          images: [`${SITE_URL}/og-image.png`],
+        },
+      };
+    }
+
     const contentSlug = [slug[1]];
     const result = await getMarkdownContent(contentSlug);
 

--- a/src/app/youth/opportunities/[id]/form/_components/youth-opportunity-form.tsx
+++ b/src/app/youth/opportunities/[id]/form/_components/youth-opportunity-form.tsx
@@ -20,6 +20,7 @@ export function YouthOpportunityForm({
     <DynamicMultiStepForm
       analyticsCategory="youth-opportunities"
       confirmationFormId={opportunityId}
+      continueOnEmailFailure
       formSteps={formSteps}
       ministryName="Ministry of Youth, Sports and Community Empowerment"
       notificationEmail={notificationEmail}

--- a/src/app/youth/opportunities/[id]/form/_components/youth-opportunity-form.tsx
+++ b/src/app/youth/opportunities/[id]/form/_components/youth-opportunity-form.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import DynamicMultiStepForm from "@/components/forms/builder/multi-step-form";
+import { buildYouthOpportunityFormSteps } from "@/schema/youth-opportunity-default";
+
+interface Props {
+  opportunityId: string;
+  opportunityTitle: string;
+  notificationEmail: string | null;
+}
+
+export function YouthOpportunityForm({
+  opportunityId,
+  opportunityTitle,
+  notificationEmail,
+}: Props) {
+  const formSteps = buildYouthOpportunityFormSteps(opportunityTitle);
+
+  return (
+    <DynamicMultiStepForm
+      analyticsCategory="youth-opportunities"
+      confirmationFormId={opportunityId}
+      formSteps={formSteps}
+      ministryName="Ministry of Youth, Sports and Community Empowerment"
+      notificationEmail={notificationEmail}
+      serviceTitle={`Apply for ${opportunityTitle}`}
+      storageKey={`youth-opportunity-${opportunityId}`}
+      submissionMode="serverActionOnly"
+    />
+  );
+}

--- a/src/app/youth/opportunities/[id]/form/page.tsx
+++ b/src/app/youth/opportunities/[id]/form/page.tsx
@@ -1,0 +1,65 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import opportunitiesData from "@/data/opportunities.json";
+import { SITE_URL } from "@/lib/site-url";
+import type { Opportunity } from "../../_components/opportunities-list";
+import { YouthOpportunityForm } from "./_components/youth-opportunity-form";
+
+const opportunities = opportunitiesData as Opportunity[];
+
+function findOpportunity(id: string): Opportunity | undefined {
+  return opportunities.find((opp) => opp.id === id);
+}
+
+export function generateStaticParams() {
+  return opportunities.map((opp) => ({ id: opp.id }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const opportunity = findOpportunity(id);
+
+  if (!opportunity) {
+    return { title: "Apply" };
+  }
+
+  const title = `Apply for ${opportunity.title}`;
+  const canonical = `${SITE_URL}/youth/opportunities/${opportunity.id}/form`;
+  const description = `Apply for ${opportunity.title}. ${opportunity.description}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+    },
+  };
+}
+
+export default async function YouthOpportunityFormPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const opportunity = findOpportunity(id);
+
+  if (!opportunity) {
+    notFound();
+  }
+
+  return (
+    <YouthOpportunityForm
+      notificationEmail={opportunity.contact?.email ?? null}
+      opportunityId={opportunity.id}
+      opportunityTitle={opportunity.title}
+    />
+  );
+}

--- a/src/app/youth/opportunities/[id]/form/page.tsx
+++ b/src/app/youth/opportunities/[id]/form/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
+import { FormSkeleton } from "@/components/forms/form-skeleton";
 import opportunitiesData from "@/data/opportunities.json";
 import { SITE_URL } from "@/lib/site-url";
 import type { Opportunity } from "../../_components/opportunities-list";
@@ -56,10 +58,18 @@ export default async function YouthOpportunityFormPage({
   }
 
   return (
-    <YouthOpportunityForm
-      notificationEmail={opportunity.contact?.email ?? null}
-      opportunityId={opportunity.id}
-      opportunityTitle={opportunity.title}
-    />
+    <Suspense
+      fallback={
+        <div className="container py-8 lg:py-16">
+          <FormSkeleton />
+        </div>
+      }
+    >
+      <YouthOpportunityForm
+        notificationEmail={opportunity.contact?.email ?? null}
+        opportunityId={opportunity.id}
+        opportunityTitle={opportunity.title}
+      />
+    </Suspense>
   );
 }

--- a/src/app/youth/opportunities/[id]/page.tsx
+++ b/src/app/youth/opportunities/[id]/page.tsx
@@ -1,9 +1,8 @@
-import { Heading, Link, LinkButton, Text } from "@govtech-bb/react";
 import type { Metadata } from "next";
-import NextLink from "next/link";
 import { notFound } from "next/navigation";
 import { Breadcrumbs } from "@/components/layout/breadcrumbs";
 import { HelpfulBox } from "@/components/layout/helpful-box";
+import { OpportunityDetail } from "@/components/opportunity-detail";
 import { StageBanner } from "@/components/stage-banner";
 import opportunitiesData from "@/data/opportunities.json";
 import { SITE_URL } from "@/lib/site-url";
@@ -11,33 +10,8 @@ import type { Opportunity } from "../_components/opportunities-list";
 
 const opportunities = opportunitiesData as Opportunity[];
 
-const CATEGORY_LABEL: Record<Opportunity["category"], string> = {
-  program: "Programme",
-  initiative: "Initiative",
-  workshop: "Workshop",
-  volunteer: "Volunteering",
-  service: "Service",
-};
-
 function findOpportunity(id: string): Opportunity | undefined {
   return opportunities.find((opp) => opp.id === id);
-}
-
-function formatAgeRange(ageMin?: number, ageMax?: number): string | null {
-  if (ageMin != null && ageMax != null) return `Ages ${ageMin}–${ageMax}`;
-  if (ageMin != null) return `${ageMin}+ years`;
-  if (ageMax != null) return `Up to ${ageMax} years`;
-  return null;
-}
-
-function formatDeadline(deadline: string): string {
-  const parsed = new Date(`${deadline}T00:00:00`);
-  if (Number.isNaN(parsed.getTime())) return deadline;
-  return parsed.toLocaleDateString("en-GB", {
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  });
 }
 
 export function generateStaticParams() {
@@ -95,27 +69,6 @@ export default async function OpportunityDetailPage({
     notFound();
   }
 
-  const ageRange = formatAgeRange(
-    opportunity.eligibility?.ageMin,
-    opportunity.eligibility?.ageMax
-  );
-  const interests = opportunity.eligibility?.interests ?? [];
-  const eligibilityItems = [
-    ageRange,
-    interests.length > 0 ? `Interest in ${interests.join(", ")}` : null,
-  ].filter(Boolean) as string[];
-
-  const metaParts = [
-    CATEGORY_LABEL[opportunity.category],
-    opportunity.deadline
-      ? `Deadline: ${formatDeadline(opportunity.deadline)}`
-      : null,
-    opportunity.source,
-  ].filter(Boolean) as string[];
-
-  const applyHref = `/youth/opportunities/${opportunity.id}/form`;
-  const externalLink = opportunity.applyUrl ?? opportunity.url;
-
   return (
     <>
       <div className="bg-blue-10">
@@ -129,116 +82,10 @@ export default async function OpportunityDetailPage({
       </div>
 
       <div className="container pt-2 pb-8 lg:pb-12">
-        <article className="max-w-2xl space-y-m">
-          <header className="space-y-xs">
-            <Heading as="h1">{opportunity.title}</Heading>
-            <Text as="p" className="text-mid-grey-00">
-              {metaParts.join(" · ")}
-            </Text>
-          </header>
-
-          <section className="space-y-xs">
-            <Heading as="h2">Overview</Heading>
-            <Text as="p">{opportunity.description}</Text>
-            {opportunity.tags.length > 0 && (
-              <ul className="flex flex-wrap gap-2 pt-1">
-                {opportunity.tags.map((tag) => (
-                  <li
-                    className="rounded bg-yellow-40 px-3 py-1 text-base text-black-00"
-                    key={tag}
-                  >
-                    {tag}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </section>
-
-          {eligibilityItems.length > 0 && (
-            <section className="space-y-xs">
-              <Heading as="h2">Who can apply</Heading>
-              <ul className="list-disc space-y-xs ps-m">
-                {eligibilityItems.map((item) => (
-                  <li key={item}>
-                    <Text as="span">{item}</Text>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          )}
-
-          {opportunity.subProgrammes &&
-            opportunity.subProgrammes.length > 0 && (
-              <section className="space-y-xs">
-                <Heading as="h2">Sub-programmes</Heading>
-                <ul className="space-y-s">
-                  {opportunity.subProgrammes.map((sub) => (
-                    <li
-                      className="border-grey-00 border-l-4 bg-blue-10 p-s"
-                      key={sub.name}
-                    >
-                      <Heading as="h3">{sub.name}</Heading>
-                      <Text as="p">{sub.description}</Text>
-                    </li>
-                  ))}
-                </ul>
-              </section>
-            )}
-
-          <section className="space-y-xs">
-            <Heading as="h2">How to apply</Heading>
-            <Text as="p">
-              Complete the short application form to register your interest.
-              Your progress is saved automatically.
-            </Text>
-            <div className="pt-2">
-              <LinkButton as={NextLink} href={applyHref} variant="primary">
-                Apply now
-              </LinkButton>
-            </div>
-          </section>
-
-          {externalLink && (
-            <section className="space-y-xs">
-              <Heading as="h2">More information</Heading>
-              <Text as="p">
-                <Link
-                  as={NextLink}
-                  href={externalLink}
-                  rel="noopener"
-                  target="_blank"
-                >
-                  View the official page
-                </Link>
-              </Text>
-            </section>
-          )}
-
-          {opportunity.contact && (
-            <section className="space-y-xs">
-              <Heading as="h2">Contact</Heading>
-              <ul className="space-y-xs">
-                {opportunity.contact.email && (
-                  <li>
-                    <Text as="span">Email: </Text>
-                    <Link
-                      as={NextLink}
-                      href={`mailto:${opportunity.contact.email}`}
-                    >
-                      {opportunity.contact.email}
-                    </Link>
-                  </li>
-                )}
-                {opportunity.contact.phone && (
-                  <li>
-                    <Text as="span">Phone: {opportunity.contact.phone}</Text>
-                  </li>
-                )}
-              </ul>
-            </section>
-          )}
-        </article>
-
+        <OpportunityDetail
+          applyHref={`/youth/opportunities/${opportunity.id}/form`}
+          opportunity={opportunity}
+        />
         <HelpfulBox className="mt-8 lg:mt-12" />
       </div>
     </>

--- a/src/app/youth/opportunities/[id]/page.tsx
+++ b/src/app/youth/opportunities/[id]/page.tsx
@@ -113,8 +113,8 @@ export default async function OpportunityDetailPage({
     opportunity.source,
   ].filter(Boolean) as string[];
 
-  const applyHref = opportunity.applyUrl ?? opportunity.url;
-  const applyLabel = opportunity.applyUrl ? "Apply now" : "Visit official page";
+  const applyHref = `/youth/opportunities/${opportunity.id}/form`;
+  const externalLink = opportunity.applyUrl ?? opportunity.url;
 
   return (
     <>
@@ -187,39 +187,24 @@ export default async function OpportunityDetailPage({
 
           <section className="space-y-xs">
             <Heading as="h2">How to apply</Heading>
-            {applyHref ? (
-              <>
-                <Text as="p">
-                  {opportunity.applyUrl
-                    ? "Complete the application on the official site to register your interest."
-                    : "Find full details and how to apply on the official site."}
-                </Text>
-                <div className="pt-2">
-                  <LinkButton
-                    as={NextLink}
-                    href={applyHref}
-                    rel="noopener"
-                    target="_blank"
-                    variant="primary"
-                  >
-                    {applyLabel}
-                  </LinkButton>
-                </div>
-              </>
-            ) : (
-              <Text as="p">
-                Contact the organisers directly for details on how to take part.
-              </Text>
-            )}
+            <Text as="p">
+              Complete the short application form to register your interest.
+              Your progress is saved automatically.
+            </Text>
+            <div className="pt-2">
+              <LinkButton as={NextLink} href={applyHref} variant="primary">
+                Apply now
+              </LinkButton>
+            </div>
           </section>
 
-          {opportunity.url && opportunity.url !== applyHref && (
+          {externalLink && (
             <section className="space-y-xs">
               <Heading as="h2">More information</Heading>
               <Text as="p">
                 <Link
                   as={NextLink}
-                  href={opportunity.url}
+                  href={externalLink}
                   rel="noopener"
                   target="_blank"
                 >
@@ -252,7 +237,6 @@ export default async function OpportunityDetailPage({
               </ul>
             </section>
           )}
-
         </article>
 
         <HelpfulBox className="mt-8 lg:mt-12" />

--- a/src/app/youth/opportunities/[id]/page.tsx
+++ b/src/app/youth/opportunities/[id]/page.tsx
@@ -1,0 +1,262 @@
+import { Heading, Link, LinkButton, Text } from "@govtech-bb/react";
+import type { Metadata } from "next";
+import NextLink from "next/link";
+import { notFound } from "next/navigation";
+import { Breadcrumbs } from "@/components/layout/breadcrumbs";
+import { HelpfulBox } from "@/components/layout/helpful-box";
+import { StageBanner } from "@/components/stage-banner";
+import opportunitiesData from "@/data/opportunities.json";
+import { SITE_URL } from "@/lib/site-url";
+import type { Opportunity } from "../_components/opportunities-list";
+
+const opportunities = opportunitiesData as Opportunity[];
+
+const CATEGORY_LABEL: Record<Opportunity["category"], string> = {
+  program: "Programme",
+  initiative: "Initiative",
+  workshop: "Workshop",
+  volunteer: "Volunteering",
+  service: "Service",
+};
+
+function findOpportunity(id: string): Opportunity | undefined {
+  return opportunities.find((opp) => opp.id === id);
+}
+
+function formatAgeRange(ageMin?: number, ageMax?: number): string | null {
+  if (ageMin != null && ageMax != null) return `Ages ${ageMin}–${ageMax}`;
+  if (ageMin != null) return `${ageMin}+ years`;
+  if (ageMax != null) return `Up to ${ageMax} years`;
+  return null;
+}
+
+function formatDeadline(deadline: string): string {
+  const parsed = new Date(`${deadline}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) return deadline;
+  return parsed.toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+export function generateStaticParams() {
+  return opportunities.map((opp) => ({ id: opp.id }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const opportunity = findOpportunity(id);
+
+  if (!opportunity) {
+    return { title: "Opportunity not found" };
+  }
+
+  const canonical = `${SITE_URL}/youth/opportunities/${opportunity.id}`;
+
+  return {
+    title: opportunity.title,
+    description: opportunity.description,
+    alternates: { canonical },
+    openGraph: {
+      title: opportunity.title,
+      description: opportunity.description,
+      url: canonical,
+      images: [
+        {
+          url: `${SITE_URL}/og-image.png`,
+          width: 1200,
+          height: 630,
+          alt: "Government of Barbados",
+        },
+      ],
+    },
+    twitter: {
+      title: opportunity.title,
+      description: opportunity.description,
+      images: [`${SITE_URL}/og-image.png`],
+    },
+  };
+}
+
+export default async function OpportunityDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const opportunity = findOpportunity(id);
+
+  if (!opportunity) {
+    notFound();
+  }
+
+  const ageRange = formatAgeRange(
+    opportunity.eligibility?.ageMin,
+    opportunity.eligibility?.ageMax
+  );
+  const interests = opportunity.eligibility?.interests ?? [];
+  const eligibilityItems = [
+    ageRange,
+    interests.length > 0 ? `Interest in ${interests.join(", ")}` : null,
+  ].filter(Boolean) as string[];
+
+  const metaParts = [
+    CATEGORY_LABEL[opportunity.category],
+    opportunity.deadline
+      ? `Deadline: ${formatDeadline(opportunity.deadline)}`
+      : null,
+    opportunity.source,
+  ].filter(Boolean) as string[];
+
+  const applyHref = opportunity.applyUrl ?? opportunity.url;
+  const applyLabel = opportunity.applyUrl ? "Apply now" : "Visit official page";
+
+  return (
+    <>
+      <div className="bg-blue-10">
+        <div className="container">
+          <StageBanner stage="alpha" />
+        </div>
+      </div>
+
+      <div className="container py-4 lg:py-6">
+        <Breadcrumbs />
+      </div>
+
+      <div className="container pt-2 pb-8 lg:pb-12">
+        <article className="max-w-2xl space-y-m">
+          <header className="space-y-xs">
+            <Heading as="h1">{opportunity.title}</Heading>
+            <Text as="p" className="text-mid-grey-00">
+              {metaParts.join(" · ")}
+            </Text>
+          </header>
+
+          <section className="space-y-xs">
+            <Heading as="h2">Overview</Heading>
+            <Text as="p">{opportunity.description}</Text>
+            {opportunity.tags.length > 0 && (
+              <ul className="flex flex-wrap gap-2 pt-1">
+                {opportunity.tags.map((tag) => (
+                  <li
+                    className="rounded bg-yellow-40 px-3 py-1 text-base text-black-00"
+                    key={tag}
+                  >
+                    {tag}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          {eligibilityItems.length > 0 && (
+            <section className="space-y-xs">
+              <Heading as="h2">Who can apply</Heading>
+              <ul className="list-disc space-y-xs ps-m">
+                {eligibilityItems.map((item) => (
+                  <li key={item}>
+                    <Text as="span">{item}</Text>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {opportunity.subProgrammes &&
+            opportunity.subProgrammes.length > 0 && (
+              <section className="space-y-xs">
+                <Heading as="h2">Sub-programmes</Heading>
+                <ul className="space-y-s">
+                  {opportunity.subProgrammes.map((sub) => (
+                    <li
+                      className="border-grey-00 border-l-4 bg-blue-10 p-s"
+                      key={sub.name}
+                    >
+                      <Heading as="h3">{sub.name}</Heading>
+                      <Text as="p">{sub.description}</Text>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
+
+          <section className="space-y-xs">
+            <Heading as="h2">How to apply</Heading>
+            {applyHref ? (
+              <>
+                <Text as="p">
+                  {opportunity.applyUrl
+                    ? "Complete the application on the official site to register your interest."
+                    : "Find full details and how to apply on the official site."}
+                </Text>
+                <div className="pt-2">
+                  <LinkButton
+                    as={NextLink}
+                    href={applyHref}
+                    rel="noopener"
+                    target="_blank"
+                    variant="primary"
+                  >
+                    {applyLabel}
+                  </LinkButton>
+                </div>
+              </>
+            ) : (
+              <Text as="p">
+                Contact the organisers directly for details on how to take part.
+              </Text>
+            )}
+          </section>
+
+          {opportunity.url && opportunity.url !== applyHref && (
+            <section className="space-y-xs">
+              <Heading as="h2">More information</Heading>
+              <Text as="p">
+                <Link
+                  as={NextLink}
+                  href={opportunity.url}
+                  rel="noopener"
+                  target="_blank"
+                >
+                  View the official page
+                </Link>
+              </Text>
+            </section>
+          )}
+
+          {opportunity.contact && (
+            <section className="space-y-xs">
+              <Heading as="h2">Contact</Heading>
+              <ul className="space-y-xs">
+                {opportunity.contact.email && (
+                  <li>
+                    <Text as="span">Email: </Text>
+                    <Link
+                      as={NextLink}
+                      href={`mailto:${opportunity.contact.email}`}
+                    >
+                      {opportunity.contact.email}
+                    </Link>
+                  </li>
+                )}
+                {opportunity.contact.phone && (
+                  <li>
+                    <Text as="span">Phone: {opportunity.contact.phone}</Text>
+                  </li>
+                )}
+              </ul>
+            </section>
+          )}
+
+        </article>
+
+        <HelpfulBox className="mt-8 lg:mt-12" />
+      </div>
+    </>
+  );
+}

--- a/src/app/youth/opportunities/_components/opportunities-list.tsx
+++ b/src/app/youth/opportunities/_components/opportunities-list.tsx
@@ -14,6 +14,11 @@ export type OpportunityCategory =
 export interface Opportunity {
   id: string;
   title: string;
+  /**
+   * Short, plain-language sentence shown directly under the title on the
+   * detail page. Acts as a lede / introductory summary.
+   */
+  summary?: string;
   category: OpportunityCategory;
   description: string;
   tags: string[];

--- a/src/app/youth/opportunities/_components/opportunities-list.tsx
+++ b/src/app/youth/opportunities/_components/opportunities-list.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { Heading, LinkButton, Text } from "@govtech-bb/react";
+import NextLink from "next/link";
+import { useId, useMemo, useState } from "react";
+
+export type OpportunityCategory =
+  | "program"
+  | "initiative"
+  | "workshop"
+  | "volunteer"
+  | "service";
+
+export interface Opportunity {
+  id: string;
+  title: string;
+  category: OpportunityCategory;
+  description: string;
+  tags: string[];
+  eligibility?: {
+    ageMin?: number;
+    ageMax?: number;
+    interests?: string[];
+  };
+  deadline?: string | null;
+  startDate?: string;
+  url: string;
+  applyUrl?: string;
+  source?: string;
+  subProgrammes?: { name: string; description: string }[];
+  contact?: { email?: string; phone?: string };
+}
+
+const CATEGORY_LABEL: Record<OpportunityCategory, string> = {
+  program: "Programme",
+  initiative: "Initiative",
+  workshop: "Workshop",
+  volunteer: "Volunteering",
+  service: "Service",
+};
+
+function formatAgeRange(ageMin?: number, ageMax?: number): string | null {
+  if (ageMin != null && ageMax != null) return `Ages ${ageMin}–${ageMax}`;
+  if (ageMin != null) return `${ageMin}+ years`;
+  if (ageMax != null) return `Up to ${ageMax} years`;
+  return null;
+}
+
+function sortOpportunities(items: Opportunity[]): Opportunity[] {
+  return [...items].sort((a, b) => {
+    if (a.deadline && b.deadline) return a.deadline.localeCompare(b.deadline);
+    if (a.deadline) return -1;
+    if (b.deadline) return 1;
+    return a.title.localeCompare(b.title);
+  });
+}
+
+function matchesQuery(opportunity: Opportunity, query: string): boolean {
+  if (!query) return true;
+  const haystack = [
+    opportunity.title,
+    opportunity.description,
+    CATEGORY_LABEL[opportunity.category],
+    opportunity.category,
+    opportunity.source ?? "",
+    ...opportunity.tags,
+    ...(opportunity.eligibility?.interests ?? []),
+  ]
+    .join(" ")
+    .toLowerCase();
+  return query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .every((term) => haystack.includes(term));
+}
+
+export function OpportunitiesList({
+  opportunities,
+}: {
+  opportunities: Opportunity[];
+}) {
+  const [query, setQuery] = useState("");
+  const searchId = useId();
+
+  const sorted = useMemo(
+    () => sortOpportunities(opportunities),
+    [opportunities]
+  );
+
+  const results = useMemo(
+    () => sorted.filter((opp) => matchesQuery(opp, query.trim())),
+    [sorted, query]
+  );
+
+  const total = sorted.length;
+
+  return (
+    <div className="space-y-s">
+      <Heading as="h1">All opportunities</Heading>
+      <Text as="p">
+        Browse every programme. Use the search to filter by name, tag, or
+        category.
+      </Text>
+
+      <search aria-label="Search opportunities">
+        <form
+          className="flex w-full"
+          onSubmit={(event) => event.preventDefault()}
+        >
+          <label className="sr-only" htmlFor={searchId}>
+            Search opportunities
+          </label>
+          <input
+            autoComplete="off"
+            className="h-15.5 w-full min-w-0 flex-1 rounded-sm bg-white-00 px-4 text-[20px] leading-normal outline outline-grey-00 transition-all focus-visible:z-10 focus-visible:ring-4 focus-visible:ring-teal-100"
+            id={searchId}
+            name="q"
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search by name, tag, or category"
+            type="search"
+            value={query}
+          />
+        </form>
+      </search>
+
+      <Text as="p" className="text-mid-grey-00">
+        {results.length} of {total} opportunities
+      </Text>
+
+      <div aria-live="polite">
+        {results.length === 0 ? (
+          <div className="border-grey-00 border-l-4 bg-blue-10 p-s">
+            <Text as="p">No matches. Try a different search.</Text>
+          </div>
+        ) : (
+          <ul className="flex flex-col">
+            {results.map((opp) => {
+              const ageRange = formatAgeRange(
+                opp.eligibility?.ageMin,
+                opp.eligibility?.ageMax
+              );
+              const meta = [
+                CATEGORY_LABEL[opp.category],
+                ageRange,
+                opp.deadline ? `Deadline: ${opp.deadline}` : null,
+                opp.source,
+              ].filter(Boolean) as string[];
+
+              return (
+                <li
+                  className="flex flex-col gap-xs border-grey-00 border-b-2 py-s first:pt-0"
+                  key={opp.id}
+                >
+                  <Heading as="h2" className="text-[20px] leading-tight">
+                    {opp.title}
+                  </Heading>
+
+                  <Text as="p" className="text-base text-mid-grey-00">
+                    {meta.join(" · ")}
+                  </Text>
+
+                  <Text as="p">{opp.description}</Text>
+
+                  {opp.tags.length > 0 && (
+                    <ul className="flex flex-wrap gap-2 pt-1">
+                      {opp.tags.map((tag) => (
+                        <li
+                          className="rounded bg-yellow-40 px-3 py-1 text-base text-black-00"
+                          key={tag}
+                        >
+                          {tag}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+
+                  <div className="pt-2">
+                    <LinkButton
+                      as={NextLink}
+                      href={`/youth/opportunities/${opp.id}`}
+                      variant="primary"
+                    >
+                      View &amp; apply
+                    </LinkButton>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/youth/opportunities/page.tsx
+++ b/src/app/youth/opportunities/page.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from "next";
+import { Breadcrumbs } from "@/components/layout/breadcrumbs";
+import { HelpfulBox } from "@/components/layout/helpful-box";
+import { StageBanner } from "@/components/stage-banner";
+import opportunities from "@/data/opportunities.json";
+import { SITE_URL } from "@/lib/site-url";
+import type { Opportunity } from "./_components/opportunities-list";
+import { OpportunitiesList } from "./_components/opportunities-list";
+
+const TITLE = "All opportunities";
+const DESCRIPTION =
+  "Browse every government youth programme, workshop, initiative and volunteer opportunity. Filter by name, tag or category.";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: `${SITE_URL}/youth/opportunities` },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: `${SITE_URL}/youth/opportunities`,
+    images: [
+      {
+        url: `${SITE_URL}/og-image.png`,
+        width: 1200,
+        height: 630,
+        alt: "Government of Barbados",
+      },
+    ],
+  },
+  twitter: {
+    title: TITLE,
+    description: DESCRIPTION,
+    images: [`${SITE_URL}/og-image.png`],
+  },
+};
+
+export default function YouthOpportunitiesPage() {
+  return (
+    <>
+      <div className="bg-blue-10">
+        <div className="container">
+          <StageBanner stage="alpha" />
+        </div>
+      </div>
+
+      <div className="container py-4 lg:py-6">
+        <Breadcrumbs />
+      </div>
+
+      <div className="container pt-2 pb-8 lg:pb-12">
+        <OpportunitiesList opportunities={opportunities as Opportunity[]} />
+        <HelpfulBox className="mt-8 lg:mt-12" />
+      </div>
+    </>
+  );
+}

--- a/src/components/forms/builder/multi-step-form.tsx
+++ b/src/components/forms/builder/multi-step-form.tsx
@@ -450,7 +450,7 @@ function expandFormSteps(
   return expanded;
 }
 
-type DynamicMultiStepFormProps = {
+interface DynamicMultiStepFormProps {
   formSteps: FormStep[];
   serviceTitle: string;
   storageKey?: string;
@@ -461,7 +461,13 @@ type DynamicMultiStepFormProps = {
   analyticsCategory?: string;
   /** Overrides pathname segment[1] for confirmation / exit-survey links (e.g. remote form slug). */
   confirmationFormId?: string;
-};
+  /**
+   * When true and submissionMode is "serverActionOnly", email send failures are
+   * logged but do not block the submission from completing. Matches the
+   * best-effort email behaviour already used by the "api" submission mode.
+   */
+  continueOnEmailFailure?: boolean;
+}
 
 export default function DynamicMultiStepForm({
   formSteps,
@@ -472,6 +478,7 @@ export default function DynamicMultiStepForm({
   submissionMode = "api",
   analyticsCategory,
   confirmationFormId,
+  continueOnEmailFailure = false,
 }: DynamicMultiStepFormProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -962,12 +969,14 @@ export default function DynamicMultiStepForm({
           }
         } catch (emailError) {
           console.error("Form submission email delivery failed", emailError);
-          setSubmissionError({
-            message:
-              "There was a problem sending your submission emails. Please try again.",
-          });
-          tracking.trackSubmitError("Remote form email submission failed");
-          return;
+          if (!continueOnEmailFailure) {
+            setSubmissionError({
+              message:
+                "There was a problem sending your submission emails. Please try again.",
+            });
+            tracking.trackSubmitError("Remote form email submission failed");
+            return;
+          }
         }
 
         markAsSubmitted(generatedReferenceNumber, customerName);

--- a/src/components/forms/calculate-severance-pay-form.tsx
+++ b/src/components/forms/calculate-severance-pay-form.tsx
@@ -498,7 +498,7 @@ export default function CalculateSeverancePayForm() {
             <ServiceTitle />
             <Heading as="h1">Your insurable earnings</Heading>
             <Text as="p" size="body">
-              Enter your usual basic pay. We'll use it as the average over the
+              Enter your usual gross pay. We'll use it as the average over the
               last 104 weeks (2 years).
             </Text>
 
@@ -514,7 +514,7 @@ export default function CalculateSeverancePayForm() {
 
             <div className="max-w-[16rem]">
               <Input
-                description="Your usual gross pay. Don't include overtime or bonuses."
+                description="Your usual gross pay. Include overtime or bonuses."
                 error={payError || undefined}
                 id="simple-avg"
                 inputMode="decimal"
@@ -697,15 +697,15 @@ export default function CalculateSeverancePayForm() {
                         </Text>
                         <ul className="list-disc space-y-2 pl-7">
                           <li>
-                            <strong>2.5 weeks</strong> of basic pay for each
+                            <strong>2.5 weeks</strong> of gross pay for each
                             year up to 10 years
                           </li>
                           <li>
-                            <strong>3 weeks</strong> of basic pay for each year
+                            <strong>3 weeks</strong> of gross pay for each year
                             between 11 and 20 years
                           </li>
                           <li>
-                            <strong>3.5 weeks</strong> of basic pay for each
+                            <strong>3.5 weeks</strong> of gross pay for each
                             year between 21 and 33 years
                           </li>
                         </ul>

--- a/src/components/layout/breadcrumbs.tsx
+++ b/src/components/layout/breadcrumbs.tsx
@@ -6,10 +6,10 @@ import { usePathname } from "next/navigation";
 import { INFORMATION_ARCHITECTURE } from "@/data/content-directory";
 import { cn } from "@/lib/utils";
 
-type BreadcrumbsProps = {
+interface BreadcrumbsProps {
   className?: string;
   collapseOnMobile?: boolean;
-};
+}
 
 function formatSlug(slug: string): string {
   const raw = slug.replace(/-/g, " ");
@@ -25,8 +25,12 @@ function getTitleForSegment(segments: string[], index: number): string {
   const page = category?.pages.find((p) => p.slug === segments[1]);
   if (index === 1) return page?.title ?? formatSlug(segments[1]);
 
-  const subPage = page?.subPages?.find((sp) => sp.slug === segments[2]);
-  if (index === 2) return subPage?.title ?? formatSlug(segments[2]);
+  if (index === 2) {
+    const nestedPage = page?.pages?.find((p) => p.slug === segments[2]);
+    if (nestedPage) return nestedPage.title;
+    const subPage = page?.subPages?.find((sp) => sp.slug === segments[2]);
+    return subPage?.title ?? formatSlug(segments[2]);
+  }
 
   return formatSlug(segments[index]);
 }

--- a/src/components/opportunity-detail.tsx
+++ b/src/components/opportunity-detail.tsx
@@ -2,29 +2,11 @@ import { Heading, Link, LinkButton, Text } from "@govtech-bb/react";
 import NextLink from "next/link";
 import type { Opportunity } from "@/app/youth/opportunities/_components/opportunities-list";
 
-const CATEGORY_LABEL: Record<Opportunity["category"], string> = {
-  program: "Programme",
-  initiative: "Initiative",
-  workshop: "Workshop",
-  volunteer: "Volunteering",
-  service: "Service",
-};
-
 function formatAgeRange(ageMin?: number, ageMax?: number): string | null {
   if (ageMin != null && ageMax != null) return `Ages ${ageMin}–${ageMax}`;
   if (ageMin != null) return `${ageMin}+ years`;
   if (ageMax != null) return `Up to ${ageMax} years`;
   return null;
-}
-
-function formatDeadline(deadline: string): string {
-  const parsed = new Date(`${deadline}T00:00:00`);
-  if (Number.isNaN(parsed.getTime())) return deadline;
-  return parsed.toLocaleDateString("en-GB", {
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  });
 }
 
 export function OpportunityDetail({
@@ -44,40 +26,18 @@ export function OpportunityDetail({
     interests.length > 0 ? `Interest in ${interests.join(", ")}` : null,
   ].filter(Boolean) as string[];
 
-  const metaParts = [
-    CATEGORY_LABEL[opportunity.category],
-    opportunity.deadline
-      ? `Deadline: ${formatDeadline(opportunity.deadline)}`
-      : null,
-    opportunity.source,
-  ].filter(Boolean) as string[];
-
   const externalLink = opportunity.applyUrl ?? opportunity.url;
 
   return (
     <article className="max-w-2xl space-y-m">
       <header className="space-y-xs">
         <Heading as="h1">{opportunity.title}</Heading>
-        <Text as="p" className="text-mid-grey-00">
-          {metaParts.join(" · ")}
-        </Text>
+        {opportunity.summary && <Text as="p">{opportunity.summary}</Text>}
       </header>
 
       <section className="space-y-xs">
         <Heading as="h2">Overview</Heading>
         <Text as="p">{opportunity.description}</Text>
-        {opportunity.tags.length > 0 && (
-          <ul className="flex flex-wrap gap-2 pt-1">
-            {opportunity.tags.map((tag) => (
-              <li
-                className="rounded bg-yellow-40 px-3 py-1 text-base text-black-00"
-                key={tag}
-              >
-                {tag}
-              </li>
-            ))}
-          </ul>
-        )}
       </section>
 
       {eligibilityItems.length > 0 && (
@@ -124,7 +84,7 @@ export function OpportunityDetail({
       </section>
 
       {externalLink && (
-        <section className="space-y-xs">
+        <section className="space-y-xs pb-m">
           <Heading as="h2">More information</Heading>
           <Text as="p">
             <Link
@@ -133,7 +93,7 @@ export function OpportunityDetail({
               rel="noopener"
               target="_blank"
             >
-              View the official page
+              {`Go to the official site for ${opportunity.title}`}
             </Link>
           </Text>
         </section>

--- a/src/components/opportunity-detail.tsx
+++ b/src/components/opportunity-detail.tsx
@@ -1,0 +1,167 @@
+import { Heading, Link, LinkButton, Text } from "@govtech-bb/react";
+import NextLink from "next/link";
+import type { Opportunity } from "@/app/youth/opportunities/_components/opportunities-list";
+
+const CATEGORY_LABEL: Record<Opportunity["category"], string> = {
+  program: "Programme",
+  initiative: "Initiative",
+  workshop: "Workshop",
+  volunteer: "Volunteering",
+  service: "Service",
+};
+
+function formatAgeRange(ageMin?: number, ageMax?: number): string | null {
+  if (ageMin != null && ageMax != null) return `Ages ${ageMin}–${ageMax}`;
+  if (ageMin != null) return `${ageMin}+ years`;
+  if (ageMax != null) return `Up to ${ageMax} years`;
+  return null;
+}
+
+function formatDeadline(deadline: string): string {
+  const parsed = new Date(`${deadline}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) return deadline;
+  return parsed.toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+export function OpportunityDetail({
+  opportunity,
+  applyHref,
+}: {
+  opportunity: Opportunity;
+  applyHref: string;
+}) {
+  const ageRange = formatAgeRange(
+    opportunity.eligibility?.ageMin,
+    opportunity.eligibility?.ageMax
+  );
+  const interests = opportunity.eligibility?.interests ?? [];
+  const eligibilityItems = [
+    ageRange,
+    interests.length > 0 ? `Interest in ${interests.join(", ")}` : null,
+  ].filter(Boolean) as string[];
+
+  const metaParts = [
+    CATEGORY_LABEL[opportunity.category],
+    opportunity.deadline
+      ? `Deadline: ${formatDeadline(opportunity.deadline)}`
+      : null,
+    opportunity.source,
+  ].filter(Boolean) as string[];
+
+  const externalLink = opportunity.applyUrl ?? opportunity.url;
+
+  return (
+    <article className="max-w-2xl space-y-m">
+      <header className="space-y-xs">
+        <Heading as="h1">{opportunity.title}</Heading>
+        <Text as="p" className="text-mid-grey-00">
+          {metaParts.join(" · ")}
+        </Text>
+      </header>
+
+      <section className="space-y-xs">
+        <Heading as="h2">Overview</Heading>
+        <Text as="p">{opportunity.description}</Text>
+        {opportunity.tags.length > 0 && (
+          <ul className="flex flex-wrap gap-2 pt-1">
+            {opportunity.tags.map((tag) => (
+              <li
+                className="rounded bg-yellow-40 px-3 py-1 text-base text-black-00"
+                key={tag}
+              >
+                {tag}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {eligibilityItems.length > 0 && (
+        <section className="space-y-xs">
+          <Heading as="h2">Who can apply</Heading>
+          <ul className="list-disc space-y-xs ps-m">
+            {eligibilityItems.map((item) => (
+              <li key={item}>
+                <Text as="span">{item}</Text>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {opportunity.subProgrammes && opportunity.subProgrammes.length > 0 && (
+        <section className="space-y-xs">
+          <Heading as="h2">Sub-programmes</Heading>
+          <ul className="space-y-s">
+            {opportunity.subProgrammes.map((sub) => (
+              <li
+                className="border-grey-00 border-l-4 bg-blue-10 p-s"
+                key={sub.name}
+              >
+                <Heading as="h3">{sub.name}</Heading>
+                <Text as="p">{sub.description}</Text>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <section className="space-y-xs">
+        <Heading as="h2">How to apply</Heading>
+        <Text as="p">
+          Complete the short application form to register your interest. Your
+          progress is saved automatically.
+        </Text>
+        <div className="pt-2">
+          <LinkButton as={NextLink} href={applyHref} variant="primary">
+            Apply now
+          </LinkButton>
+        </div>
+      </section>
+
+      {externalLink && (
+        <section className="space-y-xs">
+          <Heading as="h2">More information</Heading>
+          <Text as="p">
+            <Link
+              as={NextLink}
+              href={externalLink}
+              rel="noopener"
+              target="_blank"
+            >
+              View the official page
+            </Link>
+          </Text>
+        </section>
+      )}
+
+      {opportunity.contact && (
+        <section className="space-y-xs">
+          <Heading as="h2">Contact</Heading>
+          <ul className="space-y-xs">
+            {opportunity.contact.email && (
+              <li>
+                <Text as="span">Email: </Text>
+                <Link
+                  as={NextLink}
+                  href={`mailto:${opportunity.contact.email}`}
+                >
+                  {opportunity.contact.email}
+                </Link>
+              </li>
+            )}
+            {opportunity.contact.phone && (
+              <li>
+                <Text as="span">Phone: {opportunity.contact.phone}</Text>
+              </li>
+            )}
+          </ul>
+        </section>
+      )}
+    </article>
+  );
+}

--- a/src/content/calculate-severance-pay/index.md
+++ b/src/content/calculate-severance-pay/index.md
@@ -18,7 +18,7 @@ You can use this tool if:
 
 ### Use the online calculator
 
-You will answer a short set of questions about why you were sent home, when you worked for the employer, and your usual basic pay. We then estimate how much you may be owed.
+You will answer a short set of questions about why you were sent home, when you worked for the employer, and your usual gross pay. We then estimate how much you may be owed.
 
 <a data-start-link href="/money-financial-support/calculate-severance-pay/start">Start your estimate now</a>
 

--- a/src/content/calculate-severance-pay/start.md
+++ b/src/content/calculate-severance-pay/start.md
@@ -18,6 +18,6 @@ Have these ready before you start:
 
 - why you were sent home (redundancy, disaster, lay-off or short time, or death of employer)
 - your start date and your last day at work
-- your usual basic pay (weekly or monthly) — do not include overtime or bonuses
+- your usual gross pay (weekly or monthly) — include overtime or bonuses
 
 <a data-start-link href="/money-financial-support/calculate-severance-pay/form">Start your estimate now</a>

--- a/src/data/content-directory.ts
+++ b/src/data/content-directory.ts
@@ -233,12 +233,20 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
       },
     ],
   },
-  // {
-  //   title: "Education, youth and learning",
-  //   slug: "education-youth-learning",
-  //   description: "Apply for or manage education and youth opportunities",
-  //   pages: [],
-  // },
+  {
+    title: "Youth",
+    slug: "youth",
+    description:
+      "Programmes, training, workshops and volunteering opportunities for young people in Barbados",
+    pages: [
+      {
+        title: "All opportunities",
+        slug: "opportunities",
+        description:
+          "Browse every government youth programme, workshop, initiative and volunteer opportunity. Filter by name, tag or category.",
+      },
+    ],
+  },
   {
     title: "Travel, ID and citizenship",
     slug: "travel-id-citizenship",

--- a/src/data/content-directory.ts
+++ b/src/data/content-directory.ts
@@ -234,16 +234,201 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
     ],
   },
   {
-    title: "Youth",
-    slug: "youth",
+    title: "Youth and Community Programmes",
+    slug: "youth-and-community",
     description:
       "Programmes, training, workshops and volunteering opportunities for young people in Barbados",
     pages: [
       {
-        title: "All opportunities",
-        slug: "opportunities",
+        title: "Youth development and leadership",
+        slug: "youth-development-leadership",
         description:
-          "Browse every government youth programme, workshop, initiative and volunteer opportunity. Filter by name, tag or category.",
+          "Long-term training, mentorship and leadership pathways for young people.",
+        pages: [
+          {
+            title: "Apply to the Barbados Youth Advance Corps",
+            slug: "byac",
+            source_url:
+              "https://youthaffairs.gov.bb/programme-channels/barbados-youthadvance-corps-2/",
+            description:
+              "Two-year developmental training. Year 1: 10 weeks residential technical/vocational training. Year 2: job attachments, apprenticeships, internships, community service.",
+          },
+          {
+            title: "Join the Youth Development Programme",
+            slug: "ydp",
+            source_url:
+              "https://youthaffairs.gov.bb/programme-channels/youth-development-programme/",
+            description:
+              "Programming channel of the Division of Youth Affairs to engage and empower youth across communities through initiatives like Bridge to the Future, YAR, Web Design for Entrepreneurs, Cyber Security Training, and Bright Sparks.",
+          },
+          {
+            title: "Apply for the Pathways Employability Programme",
+            slug: "pathways",
+            source_url:
+              "https://youthaffairs.gov.bb/programme-channels/pathways/",
+            description:
+              "Job attachment and mentorship programme for unemployed youth not in full-time education. Life and job skills, work ethic, and psycho-social support from social workers and counsellors.",
+          },
+          {
+            title: "Join Bright Sparks Educational Project 2.0",
+            slug: "bright-sparks-2",
+            source_url:
+              "https://youthaffairs.gov.bb/programme-channels/youth-development-programme/",
+            description:
+              "Educational project under the Youth Development Programme.",
+          },
+          {
+            title: "Register for the Bridge to the Future Workshop",
+            slug: "bridge-to-future-2025",
+            source_url:
+              "https://youthaffairs.gov.bb/programme-channels/youth-development-programme/",
+            description:
+              "Career and skills workshop under the Youth Development Programme.",
+          },
+        ],
+      },
+      {
+        title: "Skills, trades and vocational training",
+        slug: "skills-trades-vocational-training",
+        description:
+          "Practical courses and workshops in trades, technology and creative skills.",
+        pages: [
+          {
+            title: "Register for the Community Impact Programme (CIP)",
+            slug: "cip",
+            source_url: "https://comdev.gov.bb/programmes/cip/",
+            description:
+              "Practical demand-driven skill training in 25+ courses across trades, creative services, and wellness. Two sessions/week at community and resource centres island-wide.",
+          },
+          {
+            title: "Apply for the Block Transformation Unit (Project Dawn)",
+            slug: "btu",
+            source_url:
+              "https://youthaffairs.gov.bb/about/about-the-block-transformation-unit/",
+            description:
+              "Free vocational training in 20+ courses including Motor Vehicle Engineering, Professional Housekeeping, Basic Trade Cookery, Bar Operations, hospitality, beauty, construction and healthcare.",
+          },
+          {
+            title: "Join the Cyber Security Training Workshop",
+            slug: "cyber-security-training",
+            source_url:
+              "https://youthaffairs.gov.bb/programme-channels/youth-development-programme/",
+            description:
+              "Cyber security training under the Youth Development Programme.",
+          },
+          {
+            title: "Join Web Page Design and Maintenance for Entrepreneurs",
+            slug: "web-design-entrepreneurs",
+            source_url:
+              "https://youthaffairs.gov.bb/programme-channels/youth-development-programme/",
+            description:
+              "Workshop teaching young entrepreneurs to design and maintain their own websites.",
+          },
+          {
+            title: "Apply for the Community Arts Programme (CAP)",
+            slug: "cap",
+            source_url: "https://comdev.gov.bb/programmes/cap/",
+            description:
+              "Structured instruction in airbrushing, animation, automotive painting, basic bodywork, computer graphics, drawing & illustration, painting & colour theory, sign making and technical drawing.",
+          },
+        ],
+      },
+      {
+        title: "Entrepreneurship and business",
+        slug: "entrepreneurship-business",
+        description:
+          "Support for young people starting and growing their own ventures.",
+        pages: [
+          {
+            title:
+              "Make first contact with the Youth Entrepreneurship Scheme (YES)",
+            slug: "yes",
+            source_url: "https://youthaffairs.gov.bb/programme-channels/yes-2/",
+            description:
+              "From idea to enterprise. Direct technical assistance from Youth Enterprise Officers and consultants, plus access to financial assistance via partnerships.",
+          },
+        ],
+      },
+      {
+        title: "Arts and culture",
+        slug: "arts-culture",
+        description:
+          "Creative programmes, performances and content celebrating Barbadian culture.",
+        pages: [
+          {
+            title: "Register for Youth Achieving Results (YAR)",
+            slug: "yar",
+            source_url:
+              "https://youthaffairs.gov.bb/programme-channels/youth-development-programme/",
+            description:
+              "Arts-focused initiative under the Youth Development Programme.",
+          },
+          {
+            title: "Watch Community Canvas episodes",
+            slug: "community-canvas",
+            source_url: "https://comdev.gov.bb/canvas/",
+            description:
+              "Video/TV series on YouTube featuring activities and programs at Resource Centres island-wide. 10 episodes covering balloon artistry, senior fitness, vocational training and more.",
+          },
+        ],
+      },
+      {
+        title: "Children, families and the wider community",
+        slug: "children-families-community",
+        description:
+          "Programmes, volunteering opportunities and services for children, families and neighbourhoods.",
+        pages: [
+          {
+            title: "Register a child for the National Summer Camp Programme",
+            slug: "national-summer-camp",
+            source_url:
+              "https://youthaffairs.gov.bb/programme-channels/national-summer-camp-2/",
+            description:
+              "Summer camps across 46 locations island-wide. Hosted by the Ministry of Youth, Sports and Community Empowerment.",
+          },
+          {
+            title:
+              "Register for the Community Engagement and Educational Programme (CEEP)",
+            slug: "ceep",
+            source_url: "https://comdev.gov.bb/programmes/ceep/",
+            description:
+              "Education and assistance with tax, NIS/social security, and financial services. Partners: Barbados Revenue Authority, NISSS, Sagicor, BPWCCUL.",
+          },
+          {
+            title: "Join Mission Barbados",
+            slug: "mission-barbados",
+            source_url: "https://comdev.gov.bb/programmes/mission-barbados/",
+            description:
+              "National initiative around six 2030 missions: sustainability, social cohesion, food/water security, public health & safety, worker empowerment and digital transformation. Open to individuals and organisations.",
+          },
+          {
+            title: "Donate books to Barbados is Blooming (Little Libraries)",
+            slug: "barbados-blooming-libraries",
+            source_url: "https://comdev.gov.bb/programmes/libraries/",
+            description:
+              "Free little libraries placed across the island. Donate new or lightly used children's books at Massy Stores (Sunset Crest, Holetown, Warrens) and Farm and Garden in Salters, St. George.",
+          },
+          {
+            title: "Volunteer for a Centre Management Committee (CMC)",
+            slug: "cmc",
+            source_url: "https://comdev.gov.bb/programmes/cmc/",
+            description:
+              "Volunteer to review requests for use of community centres, review programme proposals and facilitate extended centre access.",
+          },
+          {
+            title: "Find a Spreading Joy at Christmas motorcade near you",
+            slug: "spreading-joy-2025",
+            source_url: "https://comdev.gov.bb/programmes/spreading-joy/",
+            description:
+              "Festive motorcades visit communities with staff, cultural characters and gift distribution to vulnerable children in designated parishes.",
+          },
+          {
+            title: "Book a community centre for an event",
+            slug: "centre-access",
+            source_url: "https://comdev.gov.bb/programmes/centre-access/",
+            description: "Access community centres for events and activities.",
+          },
+        ],
       },
     ],
   },

--- a/src/data/opportunities.json
+++ b/src/data/opportunities.json
@@ -1,0 +1,301 @@
+[
+  {
+    "id": "cip",
+    "title": "Community Impact Programme (CIP)",
+    "category": "program",
+    "description": "Practical demand-driven skill training in 25+ courses across trades, creative services, and wellness. Two sessions/week, 2-3 hours, morning/midday/afternoon/evening slots at community and resource centres island-wide.",
+    "tags": ["training", "skills", "trades", "wellness", "creative", "community"],
+    "eligibility": {
+      "ageMin": 16,
+      "interests": ["trades", "wellness", "creative", "community", "training"]
+    },
+    "deadline": null,
+    "url": "https://comdev.gov.bb/programmes/cip/",
+    "source": "comdev.gov.bb"
+  },
+  {
+    "id": "cap",
+    "title": "Community Arts Programme (CAP)",
+    "category": "program",
+    "description": "Structured instruction in airbrushing, animation, automotive painting, basic bodywork, computer graphics, drawing & illustration, painting & colour theory, sign making, technical drawing. Build a career in the creative sector.",
+    "tags": ["arts", "design", "animation", "creative"],
+    "eligibility": {
+      "ageMin": 14,
+      "interests": ["arts", "design", "animation", "creative"]
+    },
+    "deadline": null,
+    "url": "https://comdev.gov.bb/programmes/cap/",
+    "applyUrl": "https://comdev.gov.bb/registration-cap/",
+    "source": "comdev.gov.bb"
+  },
+  {
+    "id": "ceep",
+    "title": "Community Engagement and Educational Programme (CEEP)",
+    "category": "program",
+    "description": "Education and assistance with tax, NIS/social security, and financial services. Partners: Barbados Revenue Authority, NISSS, Sagicor, BPWCCUL.",
+    "tags": ["finance", "tax", "education", "adults"],
+    "eligibility": {
+      "ageMin": 18,
+      "interests": ["finance", "tax", "education"]
+    },
+    "deadline": "2025-08-24",
+    "url": "https://comdev.gov.bb/programmes/ceep/",
+    "applyUrl": "https://comdev.gov.bb/registration-ceep/",
+    "source": "comdev.gov.bb"
+  },
+  {
+    "id": "mission-barbados",
+    "title": "Mission Barbados",
+    "category": "initiative",
+    "description": "National initiative around six 2030 missions: sustainability, social cohesion, food/water security, public health & safety, worker empowerment, digital transformation. Open to individuals and organisations.",
+    "tags": ["sustainability", "community", "health", "digital", "national"],
+    "eligibility": {
+      "interests": ["sustainability", "community", "health", "digital"]
+    },
+    "deadline": null,
+    "url": "https://comdev.gov.bb/programmes/mission-barbados/",
+    "applyUrl": "https://control.missionbarbados.gov.bb/group-registrations/register",
+    "source": "comdev.gov.bb"
+  },
+  {
+    "id": "byac",
+    "title": "Barbados YouthADVANCE Corps (BYAC)",
+    "category": "program",
+    "description": "Two-year developmental training. Year 1: 10 weeks residential technical/vocational training. Year 2: job attachments, apprenticeships, internships, community service. Adventure, Discipline, Values, Acumen, New Skills, Charity, Empowerment.",
+    "tags": ["leadership", "training", "vocational", "youth"],
+    "eligibility": {
+      "ageMin": 16,
+      "ageMax": 20,
+      "interests": ["leadership", "training", "vocational", "employment"]
+    },
+    "deadline": null,
+    "url": "https://youthaffairs.gov.bb/programme-channels/barbados-youthadvance-corps-2/",
+    "source": "youthaffairs.gov.bb"
+  },
+  {
+    "id": "yes",
+    "title": "Youth Entrepreneurship Scheme (YES)",
+    "category": "program",
+    "description": "From idea to enterprise. Direct technical assistance from Youth Enterprise Officers and consultants, plus access to financial assistance via partnerships.",
+    "tags": ["business", "entrepreneurship", "youth"],
+    "eligibility": {
+      "interests": ["business", "entrepreneurship"]
+    },
+    "deadline": null,
+    "url": "https://youthaffairs.gov.bb/programme-channels/yes-2/",
+    "source": "youthaffairs.gov.bb"
+  },
+  {
+    "id": "ydp",
+    "title": "Youth Development Programme",
+    "category": "program",
+    "description": "Programming channel of the Division of Youth Affairs to engage and empower youth across communities. Hosts initiatives like Bridge to the Future, Youth Achieving Results, Web Design for Entrepreneurs, Cyber Security Training, and Bright Sparks Educational Project.",
+    "tags": ["youth", "community", "education", "skills"],
+    "eligibility": {
+      "ageMin": 9,
+      "ageMax": 29,
+      "interests": ["community", "education", "skills"]
+    },
+    "deadline": null,
+    "url": "https://youthaffairs.gov.bb/programme-channels/youth-development-programme/",
+    "applyUrl": "https://linktr.ee/myscebb",
+    "source": "youthaffairs.gov.bb"
+  },
+  {
+    "id": "pathways",
+    "title": "Pathways Employability Programme",
+    "category": "program",
+    "description": "Job attachment and mentorship programme. Life and job skills, work ethic, employment opportunities. Includes psycho-social support from social workers and counsellors. Targets unemployed youth not in full-time education.",
+    "tags": ["employment", "mentorship", "youth"],
+    "eligibility": {
+      "ageMin": 16,
+      "ageMax": 24,
+      "interests": ["employment", "mentorship", "career"]
+    },
+    "deadline": null,
+    "url": "https://youthaffairs.gov.bb/programme-channels/pathways/",
+    "source": "youthaffairs.gov.bb"
+  },
+  {
+    "id": "btu",
+    "title": "Block Transformation Unit (BTU)",
+    "category": "program",
+    "description": "Community development unit under the Division of Youth and Culture. Focused on transforming neighbourhood blocks through youth-led engagement.",
+    "tags": ["community", "youth", "development"],
+    "eligibility": {
+      "interests": ["community", "development"]
+    },
+    "deadline": null,
+    "url": "https://youthaffairs.gov.bb/about/about-the-block-transformation-unit/",
+    "source": "youthaffairs.gov.bb",
+    "subProgrammes": [
+      {
+        "name": "Project Dawn",
+        "description": "Free vocational training in 20+ courses: Motor Vehicle Engineering, Professional Housekeeping, Basic Trade Cookery, Bar Operations, hospitality, beauty, construction, healthcare."
+      }
+    ],
+    "contact": {
+      "email": "blocktransformation.MYSCE@barbados.gov.bb",
+      "phone": "(246) 535-3835 / (246) 832-7602 / (246) 832-9024 / (246) 832-9022"
+    }
+  },
+  {
+    "id": "national-summer-camp",
+    "title": "National Summer Camp Programme",
+    "category": "program",
+    "description": "Summer camps across 46 locations island-wide. Hosted by the Ministry of Youth, Sports and Community Empowerment.",
+    "tags": ["summer-camp", "children", "recreation"],
+    "eligibility": {
+      "ageMin": 5,
+      "ageMax": 16,
+      "interests": ["recreation", "summer-camp", "sports"]
+    },
+    "deadline": null,
+    "url": "https://youthaffairs.gov.bb/programme-channels/national-summer-camp-2/",
+    "applyUrl": "https://linktr.ee/myscebb",
+    "source": "youthaffairs.gov.bb"
+  },
+  {
+    "id": "yar",
+    "title": "Youth Achieving Results (YAR)",
+    "category": "program",
+    "description": "Arts-focused initiative under the Youth Development Programme.",
+    "tags": ["arts", "youth"],
+    "eligibility": {
+      "ageMin": 17,
+      "ageMax": 30,
+      "interests": ["arts", "creative"]
+    },
+    "deadline": null,
+    "url": "https://youthaffairs.gov.bb/programme-channels/youth-development-programme/",
+    "source": "youthaffairs.gov.bb"
+  },
+  {
+    "id": "cyber-security-training",
+    "title": "Cyber Security Training Workshop",
+    "category": "workshop",
+    "description": "Cyber security training under the Youth Development Programme.",
+    "tags": ["tech", "cybersecurity", "training"],
+    "eligibility": {
+      "ageMin": 9,
+      "ageMax": 29,
+      "interests": ["tech", "cybersecurity"]
+    },
+    "deadline": null,
+    "url": "https://youthaffairs.gov.bb/programme-channels/youth-development-programme/",
+    "source": "youthaffairs.gov.bb"
+  },
+  {
+    "id": "web-design-entrepreneurs",
+    "title": "Web Page Design and Maintenance for Entrepreneurs",
+    "category": "workshop",
+    "description": "Workshop teaching young entrepreneurs to design and maintain their own websites.",
+    "tags": ["tech", "design", "business"],
+    "eligibility": {
+      "ageMin": 9,
+      "ageMax": 29,
+      "interests": ["tech", "design", "business", "entrepreneurship"]
+    },
+    "deadline": null,
+    "url": "https://youthaffairs.gov.bb/programme-channels/youth-development-programme/",
+    "source": "youthaffairs.gov.bb"
+  },
+  {
+    "id": "bright-sparks-2",
+    "title": "Bright Sparks Educational Project 2.0",
+    "category": "program",
+    "description": "Educational project under the Youth Development Programme.",
+    "tags": ["education", "youth"],
+    "eligibility": {
+      "ageMin": 9,
+      "ageMax": 29,
+      "interests": ["education"]
+    },
+    "deadline": null,
+    "url": "https://youthaffairs.gov.bb/programme-channels/youth-development-programme/",
+    "source": "youthaffairs.gov.bb"
+  },
+  {
+    "id": "bridge-to-future-2025",
+    "title": "Bridge to the Future Workshop 2025",
+    "category": "workshop",
+    "description": "Career and skills workshop under the Youth Development Programme.",
+    "tags": ["career", "skills", "youth"],
+    "eligibility": {
+      "ageMin": 9,
+      "ageMax": 29,
+      "interests": ["career", "skills"]
+    },
+    "deadline": null,
+    "url": "https://youthaffairs.gov.bb/programme-channels/youth-development-programme/",
+    "source": "youthaffairs.gov.bb"
+  },
+  {
+    "id": "barbados-blooming-libraries",
+    "title": "Barbados is Blooming (Little Libraries)",
+    "category": "initiative",
+    "description": "Free little libraries placed across the island to revive reading post-COVID. Donate new or lightly used children's books at Massy Stores (Sunset Crest, Holetown, Warrens) and Farm and Garden in Salters, St. George. Partners: Prince Godwill D. Fomusoh Foundation, Massy Foundation, CDD.",
+    "tags": ["community", "reading", "education"],
+    "eligibility": {
+      "interests": ["community", "education", "reading"]
+    },
+    "deadline": null,
+    "url": "https://comdev.gov.bb/programmes/libraries/",
+    "source": "comdev.gov.bb"
+  },
+  {
+    "id": "community-canvas",
+    "title": "Community Canvas",
+    "category": "program",
+    "description": "Video/TV series on YouTube featuring activities and programs at Resource Centres island-wide. 10 episodes covering balloon artistry, senior fitness, vocational training, and more.",
+    "tags": ["arts", "community"],
+    "eligibility": {
+      "interests": ["arts", "community"]
+    },
+    "deadline": null,
+    "url": "https://comdev.gov.bb/canvas/",
+    "source": "comdev.gov.bb"
+  },
+  {
+    "id": "cmc",
+    "title": "Centre Management Committees (CMC)",
+    "category": "volunteer",
+    "description": "Volunteer to review requests for use of community centres, review programme proposals, and facilitate extended centre access. Must show desire for positive socio-economic change, deep understanding of the community, and credible knowledge of relevant skill sets.",
+    "tags": ["volunteer", "community", "leadership"],
+    "eligibility": {
+      "interests": ["volunteer", "community", "leadership"]
+    },
+    "deadline": null,
+    "url": "https://comdev.gov.bb/programmes/cmc/",
+    "applyUrl": "https://docs.google.com/forms/d/e/1FAIpQLSeWEt-xl67n-xNcPJs0PI2GzS06jWpzHIGzbp4_3UfwBC4ksA/viewform",
+    "source": "comdev.gov.bb"
+  },
+  {
+    "id": "spreading-joy-2025",
+    "title": "Spreading Joy at Christmas 2025",
+    "category": "initiative",
+    "description": "Festive motorcades visit communities with staff, cultural characters, and gift distribution to vulnerable children. No formal application — residents in designated parishes encounter motorcades on scheduled dates between 11:00 AM and 6:00 PM.",
+    "tags": ["children", "community", "christmas"],
+    "eligibility": {
+      "ageMax": 16,
+      "interests": ["community"]
+    },
+    "deadline": "2025-12-19",
+    "startDate": "2025-12-15",
+    "url": "https://comdev.gov.bb/programmes/spreading-joy/",
+    "source": "comdev.gov.bb"
+  },
+  {
+    "id": "centre-access",
+    "title": "Community Centre Access",
+    "category": "service",
+    "description": "Access community centres for events and activities.",
+    "tags": ["community", "facilities"],
+    "eligibility": {
+      "interests": ["community"]
+    },
+    "deadline": null,
+    "url": "https://comdev.gov.bb/programmes/centre-access/",
+    "source": "comdev.gov.bb"
+  }
+]

--- a/src/data/opportunities.json
+++ b/src/data/opportunities.json
@@ -2,10 +2,18 @@
   {
     "id": "cip",
     "title": "Community Impact Programme (CIP)",
+    "summary": "Short, hands-on training courses in trades, creative work and wellness, run two sessions a week at community centres across Barbados.",
     "category": "program",
     "subcategory": "skills-trades-vocational-training",
     "description": "Practical demand-driven skill training in 25+ courses across trades, creative services, and wellness. Two sessions/week, 2-3 hours, morning/midday/afternoon/evening slots at community and resource centres island-wide.",
-    "tags": ["training", "skills", "trades", "wellness", "creative", "community"],
+    "tags": [
+      "training",
+      "skills",
+      "trades",
+      "wellness",
+      "creative",
+      "community"
+    ],
     "eligibility": {
       "ageMin": 16,
       "interests": ["trades", "wellness", "creative", "community", "training"]
@@ -17,6 +25,7 @@
   {
     "id": "cap",
     "title": "Community Arts Programme (CAP)",
+    "summary": "Structured creative training to help you build a career in art, design and animation.",
     "category": "program",
     "subcategory": "skills-trades-vocational-training",
     "description": "Structured instruction in airbrushing, animation, automotive painting, basic bodywork, computer graphics, drawing & illustration, painting & colour theory, sign making, technical drawing. Build a career in the creative sector.",
@@ -33,6 +42,7 @@
   {
     "id": "ceep",
     "title": "Community Engagement and Educational Programme (CEEP)",
+    "summary": "Free workshops on taxes, social security and managing your money, delivered with partners like the BRA, NISSS, Sagicor and BPWCCUL.",
     "category": "program",
     "subcategory": "children-families-community",
     "description": "Education and assistance with tax, NIS/social security, and financial services. Partners: Barbados Revenue Authority, NISSS, Sagicor, BPWCCUL.",
@@ -49,6 +59,7 @@
   {
     "id": "mission-barbados",
     "title": "Mission Barbados",
+    "summary": "A national initiative inviting individuals and organisations to take part in six 2030 missions, from sustainability to digital transformation.",
     "category": "initiative",
     "subcategory": "children-families-community",
     "description": "National initiative around six 2030 missions: sustainability, social cohesion, food/water security, public health & safety, worker empowerment, digital transformation. Open to individuals and organisations.",
@@ -64,6 +75,7 @@
   {
     "id": "byac",
     "title": "Barbados YouthADVANCE Corps (BYAC)",
+    "summary": "A two-year programme for young people aged 16 to 20, combining residential vocational training with job attachments and community service.",
     "category": "program",
     "subcategory": "youth-development-leadership",
     "description": "Two-year developmental training. Year 1: 10 weeks residential technical/vocational training. Year 2: job attachments, apprenticeships, internships, community service. Adventure, Discipline, Values, Acumen, New Skills, Charity, Empowerment.",
@@ -80,6 +92,7 @@
   {
     "id": "yes",
     "title": "Youth Entrepreneurship Scheme (YES)",
+    "summary": "One-to-one support and access to funding to help young people turn a business idea into a working enterprise.",
     "category": "program",
     "subcategory": "entrepreneurship-business",
     "description": "From idea to enterprise. Direct technical assistance from Youth Enterprise Officers and consultants, plus access to financial assistance via partnerships.",
@@ -94,6 +107,7 @@
   {
     "id": "ydp",
     "title": "Youth Development Programme",
+    "summary": "An umbrella of workshops, projects and learning initiatives for young people aged 9 to 29 in communities across the island.",
     "category": "program",
     "subcategory": "youth-development-leadership",
     "description": "Programming channel of the Division of Youth Affairs to engage and empower youth across communities. Hosts initiatives like Bridge to the Future, Youth Achieving Results, Web Design for Entrepreneurs, Cyber Security Training, and Bright Sparks Educational Project.",
@@ -111,6 +125,7 @@
   {
     "id": "pathways",
     "title": "Pathways Employability Programme",
+    "summary": "A job-attachment and mentorship programme for unemployed young people aged 16 to 24, with support from social workers and counsellors.",
     "category": "program",
     "subcategory": "youth-development-leadership",
     "description": "Job attachment and mentorship programme. Life and job skills, work ethic, employment opportunities. Includes psycho-social support from social workers and counsellors. Targets unemployed youth not in full-time education.",
@@ -127,6 +142,7 @@
   {
     "id": "btu",
     "title": "Block Transformation Unit (BTU)",
+    "summary": "Free vocational training in over 20 trades — from motor vehicle engineering and cookery to construction and healthcare — through Project Dawn.",
     "category": "program",
     "subcategory": "skills-trades-vocational-training",
     "description": "Community development unit under the Division of Youth and Culture. Focused on transforming neighbourhood blocks through youth-led engagement.",
@@ -151,6 +167,7 @@
   {
     "id": "national-summer-camp",
     "title": "National Summer Camp Programme",
+    "summary": "Summer camps for children aged 5 to 16, hosted in 46 locations across Barbados.",
     "category": "program",
     "subcategory": "children-families-community",
     "description": "Summer camps across 46 locations island-wide. Hosted by the Ministry of Youth, Sports and Community Empowerment.",
@@ -168,6 +185,7 @@
   {
     "id": "yar",
     "title": "Youth Achieving Results (YAR)",
+    "summary": "An arts-focused initiative for young people aged 17 to 30, run under the Youth Development Programme.",
     "category": "program",
     "subcategory": "arts-culture",
     "description": "Arts-focused initiative under the Youth Development Programme.",
@@ -184,6 +202,7 @@
   {
     "id": "cyber-security-training",
     "title": "Cyber Security Training Workshop",
+    "summary": "A workshop teaching young people the fundamentals of staying safe online and the basics of cyber security.",
     "category": "workshop",
     "subcategory": "skills-trades-vocational-training",
     "description": "Cyber security training under the Youth Development Programme.",
@@ -200,6 +219,7 @@
   {
     "id": "web-design-entrepreneurs",
     "title": "Web Page Design and Maintenance for Entrepreneurs",
+    "summary": "A practical workshop where young entrepreneurs learn to design and maintain their own business websites.",
     "category": "workshop",
     "subcategory": "skills-trades-vocational-training",
     "description": "Workshop teaching young entrepreneurs to design and maintain their own websites.",
@@ -216,6 +236,7 @@
   {
     "id": "bright-sparks-2",
     "title": "Bright Sparks Educational Project 2.0",
+    "summary": "An educational project for young people aged 9 to 29, run under the Youth Development Programme.",
     "category": "program",
     "subcategory": "youth-development-leadership",
     "description": "Educational project under the Youth Development Programme.",
@@ -232,6 +253,7 @@
   {
     "id": "bridge-to-future-2025",
     "title": "Bridge to the Future Workshop 2025",
+    "summary": "A career and life-skills workshop helping young people aged 9 to 29 plan what comes next.",
     "category": "workshop",
     "subcategory": "youth-development-leadership",
     "description": "Career and skills workshop under the Youth Development Programme.",
@@ -248,6 +270,7 @@
   {
     "id": "barbados-blooming-libraries",
     "title": "Barbados is Blooming (Little Libraries)",
+    "summary": "Donate new or lightly used children's books at participating Massy Stores and Farm and Garden to stock free little libraries across the island.",
     "category": "initiative",
     "subcategory": "children-families-community",
     "description": "Free little libraries placed across the island to revive reading post-COVID. Donate new or lightly used children's books at Massy Stores (Sunset Crest, Holetown, Warrens) and Farm and Garden in Salters, St. George. Partners: Prince Godwill D. Fomusoh Foundation, Massy Foundation, CDD.",
@@ -262,6 +285,7 @@
   {
     "id": "community-canvas",
     "title": "Community Canvas",
+    "summary": "A 10-episode YouTube series showcasing the activities, classes and people at community Resource Centres across Barbados.",
     "category": "program",
     "subcategory": "arts-culture",
     "description": "Video/TV series on YouTube featuring activities and programs at Resource Centres island-wide. 10 episodes covering balloon artistry, senior fitness, vocational training, and more.",
@@ -276,6 +300,7 @@
   {
     "id": "cmc",
     "title": "Centre Management Committees (CMC)",
+    "summary": "Volunteer with a Centre Management Committee to help review programme proposals and run your local community centre.",
     "category": "volunteer",
     "subcategory": "children-families-community",
     "description": "Volunteer to review requests for use of community centres, review programme proposals, and facilitate extended centre access. Must show desire for positive socio-economic change, deep understanding of the community, and credible knowledge of relevant skill sets.",
@@ -291,6 +316,7 @@
   {
     "id": "spreading-joy-2025",
     "title": "Spreading Joy at Christmas 2025",
+    "summary": "Festive motorcades visiting communities between 15 and 19 December 2025, with gifts for children in designated parishes — no application needed.",
     "category": "initiative",
     "subcategory": "children-families-community",
     "description": "Festive motorcades visit communities with staff, cultural characters, and gift distribution to vulnerable children. No formal application — residents in designated parishes encounter motorcades on scheduled dates between 11:00 AM and 6:00 PM.",
@@ -307,6 +333,7 @@
   {
     "id": "centre-access",
     "title": "Community Centre Access",
+    "summary": "Book a community centre near you to host an event, class or community activity.",
     "category": "service",
     "subcategory": "children-families-community",
     "description": "Access community centres for events and activities.",

--- a/src/data/opportunities.json
+++ b/src/data/opportunities.json
@@ -3,6 +3,7 @@
     "id": "cip",
     "title": "Community Impact Programme (CIP)",
     "category": "program",
+    "subcategory": "skills-trades-vocational-training",
     "description": "Practical demand-driven skill training in 25+ courses across trades, creative services, and wellness. Two sessions/week, 2-3 hours, morning/midday/afternoon/evening slots at community and resource centres island-wide.",
     "tags": ["training", "skills", "trades", "wellness", "creative", "community"],
     "eligibility": {
@@ -17,6 +18,7 @@
     "id": "cap",
     "title": "Community Arts Programme (CAP)",
     "category": "program",
+    "subcategory": "skills-trades-vocational-training",
     "description": "Structured instruction in airbrushing, animation, automotive painting, basic bodywork, computer graphics, drawing & illustration, painting & colour theory, sign making, technical drawing. Build a career in the creative sector.",
     "tags": ["arts", "design", "animation", "creative"],
     "eligibility": {
@@ -32,6 +34,7 @@
     "id": "ceep",
     "title": "Community Engagement and Educational Programme (CEEP)",
     "category": "program",
+    "subcategory": "children-families-community",
     "description": "Education and assistance with tax, NIS/social security, and financial services. Partners: Barbados Revenue Authority, NISSS, Sagicor, BPWCCUL.",
     "tags": ["finance", "tax", "education", "adults"],
     "eligibility": {
@@ -47,6 +50,7 @@
     "id": "mission-barbados",
     "title": "Mission Barbados",
     "category": "initiative",
+    "subcategory": "children-families-community",
     "description": "National initiative around six 2030 missions: sustainability, social cohesion, food/water security, public health & safety, worker empowerment, digital transformation. Open to individuals and organisations.",
     "tags": ["sustainability", "community", "health", "digital", "national"],
     "eligibility": {
@@ -61,6 +65,7 @@
     "id": "byac",
     "title": "Barbados YouthADVANCE Corps (BYAC)",
     "category": "program",
+    "subcategory": "youth-development-leadership",
     "description": "Two-year developmental training. Year 1: 10 weeks residential technical/vocational training. Year 2: job attachments, apprenticeships, internships, community service. Adventure, Discipline, Values, Acumen, New Skills, Charity, Empowerment.",
     "tags": ["leadership", "training", "vocational", "youth"],
     "eligibility": {
@@ -76,6 +81,7 @@
     "id": "yes",
     "title": "Youth Entrepreneurship Scheme (YES)",
     "category": "program",
+    "subcategory": "entrepreneurship-business",
     "description": "From idea to enterprise. Direct technical assistance from Youth Enterprise Officers and consultants, plus access to financial assistance via partnerships.",
     "tags": ["business", "entrepreneurship", "youth"],
     "eligibility": {
@@ -89,6 +95,7 @@
     "id": "ydp",
     "title": "Youth Development Programme",
     "category": "program",
+    "subcategory": "youth-development-leadership",
     "description": "Programming channel of the Division of Youth Affairs to engage and empower youth across communities. Hosts initiatives like Bridge to the Future, Youth Achieving Results, Web Design for Entrepreneurs, Cyber Security Training, and Bright Sparks Educational Project.",
     "tags": ["youth", "community", "education", "skills"],
     "eligibility": {
@@ -105,6 +112,7 @@
     "id": "pathways",
     "title": "Pathways Employability Programme",
     "category": "program",
+    "subcategory": "youth-development-leadership",
     "description": "Job attachment and mentorship programme. Life and job skills, work ethic, employment opportunities. Includes psycho-social support from social workers and counsellors. Targets unemployed youth not in full-time education.",
     "tags": ["employment", "mentorship", "youth"],
     "eligibility": {
@@ -120,6 +128,7 @@
     "id": "btu",
     "title": "Block Transformation Unit (BTU)",
     "category": "program",
+    "subcategory": "skills-trades-vocational-training",
     "description": "Community development unit under the Division of Youth and Culture. Focused on transforming neighbourhood blocks through youth-led engagement.",
     "tags": ["community", "youth", "development"],
     "eligibility": {
@@ -143,6 +152,7 @@
     "id": "national-summer-camp",
     "title": "National Summer Camp Programme",
     "category": "program",
+    "subcategory": "children-families-community",
     "description": "Summer camps across 46 locations island-wide. Hosted by the Ministry of Youth, Sports and Community Empowerment.",
     "tags": ["summer-camp", "children", "recreation"],
     "eligibility": {
@@ -159,6 +169,7 @@
     "id": "yar",
     "title": "Youth Achieving Results (YAR)",
     "category": "program",
+    "subcategory": "arts-culture",
     "description": "Arts-focused initiative under the Youth Development Programme.",
     "tags": ["arts", "youth"],
     "eligibility": {
@@ -174,6 +185,7 @@
     "id": "cyber-security-training",
     "title": "Cyber Security Training Workshop",
     "category": "workshop",
+    "subcategory": "skills-trades-vocational-training",
     "description": "Cyber security training under the Youth Development Programme.",
     "tags": ["tech", "cybersecurity", "training"],
     "eligibility": {
@@ -189,6 +201,7 @@
     "id": "web-design-entrepreneurs",
     "title": "Web Page Design and Maintenance for Entrepreneurs",
     "category": "workshop",
+    "subcategory": "skills-trades-vocational-training",
     "description": "Workshop teaching young entrepreneurs to design and maintain their own websites.",
     "tags": ["tech", "design", "business"],
     "eligibility": {
@@ -204,6 +217,7 @@
     "id": "bright-sparks-2",
     "title": "Bright Sparks Educational Project 2.0",
     "category": "program",
+    "subcategory": "youth-development-leadership",
     "description": "Educational project under the Youth Development Programme.",
     "tags": ["education", "youth"],
     "eligibility": {
@@ -219,6 +233,7 @@
     "id": "bridge-to-future-2025",
     "title": "Bridge to the Future Workshop 2025",
     "category": "workshop",
+    "subcategory": "youth-development-leadership",
     "description": "Career and skills workshop under the Youth Development Programme.",
     "tags": ["career", "skills", "youth"],
     "eligibility": {
@@ -234,6 +249,7 @@
     "id": "barbados-blooming-libraries",
     "title": "Barbados is Blooming (Little Libraries)",
     "category": "initiative",
+    "subcategory": "children-families-community",
     "description": "Free little libraries placed across the island to revive reading post-COVID. Donate new or lightly used children's books at Massy Stores (Sunset Crest, Holetown, Warrens) and Farm and Garden in Salters, St. George. Partners: Prince Godwill D. Fomusoh Foundation, Massy Foundation, CDD.",
     "tags": ["community", "reading", "education"],
     "eligibility": {
@@ -247,6 +263,7 @@
     "id": "community-canvas",
     "title": "Community Canvas",
     "category": "program",
+    "subcategory": "arts-culture",
     "description": "Video/TV series on YouTube featuring activities and programs at Resource Centres island-wide. 10 episodes covering balloon artistry, senior fitness, vocational training, and more.",
     "tags": ["arts", "community"],
     "eligibility": {
@@ -260,6 +277,7 @@
     "id": "cmc",
     "title": "Centre Management Committees (CMC)",
     "category": "volunteer",
+    "subcategory": "children-families-community",
     "description": "Volunteer to review requests for use of community centres, review programme proposals, and facilitate extended centre access. Must show desire for positive socio-economic change, deep understanding of the community, and credible knowledge of relevant skill sets.",
     "tags": ["volunteer", "community", "leadership"],
     "eligibility": {
@@ -274,6 +292,7 @@
     "id": "spreading-joy-2025",
     "title": "Spreading Joy at Christmas 2025",
     "category": "initiative",
+    "subcategory": "children-families-community",
     "description": "Festive motorcades visit communities with staff, cultural characters, and gift distribution to vulnerable children. No formal application — residents in designated parishes encounter motorcades on scheduled dates between 11:00 AM and 6:00 PM.",
     "tags": ["children", "community", "christmas"],
     "eligibility": {
@@ -289,6 +308,7 @@
     "id": "centre-access",
     "title": "Community Centre Access",
     "category": "service",
+    "subcategory": "children-families-community",
     "description": "Access community centres for events and activities.",
     "tags": ["community", "facilities"],
     "eligibility": {

--- a/src/schema/youth-opportunity-default.ts
+++ b/src/schema/youth-opportunity-default.ts
@@ -163,7 +163,7 @@ export function buildYouthOpportunityFormSteps(
 - If we need anything else from you, we will reach out by email or phone.
 
 Thank you for your interest.`,
-      enableFeedback: true,
+      enableFeedback: false,
     },
   ];
 }

--- a/src/schema/youth-opportunity-default.ts
+++ b/src/schema/youth-opportunity-default.ts
@@ -1,0 +1,169 @@
+import { barbadosParishes, NAME_REGEX, PHONE_REGEX } from "@/data/constants";
+import type { FormStep } from "@/types";
+
+/**
+ * Default form schema used for every youth opportunity application.
+ * Per-opportunity overrides can be added later by branching on the
+ * opportunity id when building the steps.
+ */
+export function buildYouthOpportunityFormSteps(
+  opportunityTitle: string
+): FormStep[] {
+  return [
+    {
+      id: "applicant-details",
+      title: "About you",
+      description: "Tell us who you are so we know how to get in touch.",
+      fields: [
+        {
+          name: "applicant.firstName",
+          label: "First name",
+          type: "text",
+          validation: {
+            required: "First name is required",
+            minLength: {
+              value: 2,
+              message: "First name must be at least 2 characters",
+            },
+            pattern: {
+              value: NAME_REGEX,
+              message:
+                "First name must contain only letters, hyphens, or apostrophes",
+            },
+          },
+        },
+        {
+          name: "applicant.lastName",
+          label: "Last name",
+          type: "text",
+          validation: {
+            required: "Last name is required",
+            minLength: {
+              value: 2,
+              message: "Last name must be at least 2 characters",
+            },
+            pattern: {
+              value: NAME_REGEX,
+              message:
+                "Last name must contain only letters, hyphens, or apostrophes",
+            },
+          },
+        },
+        {
+          name: "applicant.dateOfBirth",
+          label: "Date of birth",
+          hint: "Used to confirm you meet the age requirements for this opportunity.",
+          type: "date",
+          validation: {
+            required: "Date of birth is required",
+            date: { type: "past" },
+          },
+        },
+        {
+          name: "applicant.email",
+          label: "Email address",
+          type: "email",
+          validation: {
+            required: "Email address is required",
+          },
+        },
+        {
+          name: "applicant.phone",
+          label: "Phone number",
+          hint: "A local Barbados number, for example 246-555-1234.",
+          type: "tel",
+          validation: {
+            required: "Phone number is required",
+            pattern: {
+              value: PHONE_REGEX,
+              message: "Enter a valid Barbados phone number",
+            },
+          },
+        },
+        {
+          name: "applicant.parish",
+          label: "Parish",
+          type: "select",
+          options: barbadosParishes,
+          validation: { required: "Select your parish" },
+        },
+        {
+          name: "applicant.citizenship",
+          label: "Citizenship status",
+          type: "radio",
+          options: [
+            { label: "Barbadian citizen", value: "citizen" },
+            { label: "Permanent resident", value: "resident" },
+            { label: "Other", value: "other" },
+          ],
+          validation: { required: "Select your citizenship status" },
+        },
+      ],
+    },
+    {
+      id: "your-interest",
+      title: "About your interest",
+      description: `A short paragraph about why ${opportunityTitle} is right for you.`,
+      fields: [
+        {
+          name: "interest.motivation",
+          label: "Why are you applying?",
+          hint: "Tell us a bit about what you hope to get out of taking part.",
+          type: "textarea",
+          rows: 5,
+          validation: {
+            required: "Tell us why you're applying",
+            minLength: {
+              value: 20,
+              message: "Please write at least 20 characters",
+            },
+          },
+        },
+      ],
+    },
+    {
+      id: "check-your-answers",
+      title: "Check your answers",
+      fields: [],
+    },
+    {
+      id: "declaration",
+      title: "Declaration",
+      fields: [
+        {
+          name: "declaration.confirmed",
+          label:
+            "I confirm that my information is correct and I am happy for it to be verified. I understand that false details may lead to my application being rejected, and that the Government of Barbados will keep my information confidential.",
+          type: "checkbox",
+          validation: {
+            required: "You must confirm the declaration to continue",
+          },
+        },
+        {
+          name: "declaration.dateOfDeclaration",
+          label: "Date of declaration",
+          hidden: true,
+          type: "date",
+          validation: {
+            required: "Date is required",
+            date: { type: "pastOrToday" },
+          },
+        },
+      ],
+    },
+    {
+      id: "confirmation",
+      title: "Application received",
+      description: `Thank you for applying to ${opportunityTitle}.`,
+      fields: [],
+      bodyContent: `## What happens next
+
+- The team running this opportunity will review your application.
+- If you meet the eligibility criteria, they will get in touch using the contact details you provided.
+- If we need anything else from you, we will reach out by email or phone.
+
+Thank you for your interest.`,
+      enableFeedback: true,
+    },
+  ];
+}

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -1,4 +1,4 @@
-export type PageType = {
+export interface PageType {
   title: string;
   filename?: string;
   stage?: string;
@@ -10,11 +10,17 @@ export type PageType = {
     title?: string;
     type: "markdown" | "component";
   }[];
-};
+  /**
+   * Nested child pages, used to express a subcategory whose children are
+   * individual services / opportunities. Rendered as a second-level index
+   * when the user lands on the parent URL.
+   */
+  pages?: PageType[];
+}
 
-export type InformationContent = {
+export interface InformationContent {
   title: string;
   description?: string;
   slug: string;
   pages: PageType[];
-};
+}


### PR DESCRIPTION
This PR is to merge the current branch into 'prod' branch

## Description
Adds a new **Youth Opportunities** section (listing, detail, and internal application form) and ships small fixes to the severance pay calculator wording and the feedback link visibility on confirmation pages.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Changes made

### Youth Opportunities (new feature)
- New listing page at `/youth/opportunities` powered by `src/data/opportunities.json` (348 lines of seed data covering CIP, CAP, CEEP and other programmes).
- Detail pages nested under subcategory routes: `/youth/opportunities/[id]` with summaries, eligibility, deadlines and apply links.
- Internal application form per opportunity at `/youth/opportunities/[id]/form`, wrapped in `<Suspense>` for static prerender.
- Form submission is resilient to email-service failures so users aren't blocked by transient backend errors.
- Opportunity summaries and breadcrumbs surfaced on the form pages for context.
- Shared default schema added at `src/schema/youth-opportunity-default.ts` and reusable `OpportunityDetail` component.
- Content directory and content types extended to register the new section.

### Severance Pay Calculator
- Updated wording from prior phrasing to **"gross pay"** in `src/components/forms/calculate-severance-pay-form.tsx` and the related `src/content/calculate-severance-pay/*.md` files for consistency with how NIS communicates the figure.

### Feedback link
- Hidden on the youth opportunity confirmation pages (via `multi-step-form.tsx`) since the global feedback widget isn't appropriate after a successful submission on these flows.

### Notes
- New file `src/data/opportunities.json` is the single source of truth for opportunities — edits to copy/eligibility/links should happen there.
- `src/app/(content)/[...slug]/page.tsx` picked up the bulk of the content-routing changes to support nesting opportunities under subcategory slugs.

## Testing

1. `npm run dev` and visit `/youth/opportunities` — confirm the list renders and each card links to the correct detail page.
2. Open at least 2 opportunity detail pages (one with `applyUrl`, one without) and verify the apply CTA behaves correctly.
3. From a detail page, click **Apply** to reach `/youth/opportunities/[id]/form` — confirm the opportunity summary and breadcrumbs render above the form.
4. Submit the form with a valid payload and verify the confirmation page shows **without** the feedback link.
5. Simulate an email-service failure (or rely on the resilient code path) and confirm the user still reaches the confirmation page.
6. Visit the severance pay calculator — confirm all visible copy now says **"gross pay"** where applicable.
7. Run `npx ultracite check` and `npm run build` — both should pass with no new errors.

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->
- Related PRs already merged into `main`: #558 (youth opportunities), #564 (severance gross-pay wording)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
