### PR TITLE
fix: widen pension form descriptions and restyle formula boxes (#566)

### DIFF
--- a/src/components/forms/calculate-your-pension-form.tsx
+++ b/src/components/forms/calculate-your-pension-form.tsx
@@ -181,7 +181,7 @@ export default function CalculateYourPensionForm() {
               calculate();
             }}
           >
-            <div className="max-w-[14rem]">
+            <div className="[&_input]:max-w-[14rem]">
               <Input
                 description="Enter the total number of complete months. No-pay leave does not count."
                 error={monthsError || undefined}
@@ -194,7 +194,7 @@ export default function CalculateYourPensionForm() {
               />
             </div>
 
-            <div className="max-w-[18rem]">
+            <div className="[&_input]:max-w-[18rem]">
               <Input
                 description="Enter your gross annual salary in Barbados dollars."
                 error={salaryError || undefined}
@@ -314,7 +314,7 @@ export default function CalculateYourPensionForm() {
                 A gratuity is paid as a lump sum. The annual pension is divided
                 by 12 and paid monthly.
               </Text>
-              <p className="mt-2 border-blue-40 border-l-4 bg-blue-10 px-4 py-2 font-mono text-sm">
+              <p className="mt-2 rounded-sm bg-blue-10 px-4 py-3">
                 Formula: (months of service ÷ 600) × last annual salary
               </p>
             </div>
@@ -326,14 +326,14 @@ export default function CalculateYourPensionForm() {
                 remaining 25% is multiplied by 12.5 to give your gratuity lump
                 sum.
               </Text>
-              <p className="mt-2 border-blue-40 border-l-4 bg-blue-10 px-4 py-2 font-mono text-sm">
+              <p className="mt-2 rounded-sm bg-blue-10 px-4 py-3">
                 Formula: full pension × 75%
               </p>
             </div>
 
             <div className="mt-4">
               <Heading as="h3">Gratuity</Heading>
-              <p className="mt-2 border-blue-40 border-l-4 bg-blue-10 px-4 py-2 font-mono text-sm">
+              <p className="mt-2 rounded-sm bg-blue-10 px-4 py-3">
                 Formula: (full pension ÷ 4) × 12.5
               </p>
             </div>


### PR DESCRIPTION
## Description

Visual fixes for the pension calculator flagged in #566. Stacked on #563 (the `feat/pension-calculator` branch where the calculator lives).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

`src/components/forms/calculate-your-pension-form.tsx`:
- Move the input width constraint off the wrapper (`max-w-[14rem]` / `max-w-[18rem]`) and onto the inner `<input>` via `[&_input]:max-w-…` so the field descriptions for "Months of pensionable service" and "Last annual salary (BDS$)" are no longer clipped.
- Restyle the three "Formula:" callouts under "How your pension is calculated" — drop the blue left-border + monospace treatment in favour of a soft rounded fill (`rounded-sm bg-blue-10 px-4 py-3`).

### Notes

Three non-annotated differences in the target mockup were left out pending confirmation: yellow banner instead of blue, extra "Do not include commas." copy + `0.00` placeholder on the salary field, and primary/secondary button order swap.

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)

Fixes #566. Stacked on #563.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated