### PR TITLE
feat: state-bodies migration + mobile hamburger nav

### DIFF
--- a/src/app/departments/[slug]/page.tsx
+++ b/src/app/departments/[slug]/page.tsx
@@ -55,7 +55,6 @@ export default async function DepartmentDetailPage({
     <MinistryPage
       body={body}
       contact={department.contact}
-      intro={department.intro}
       leadershipLabel="Director"
       minister={department.head}
       originalSource={department.originalSource}

--- a/src/app/government/organisations/page.tsx
+++ b/src/app/government/organisations/page.tsx
@@ -6,7 +6,8 @@ import { HelpfulBox } from "@/components/layout/helpful-box";
 import { SearchForm } from "@/components/search-form";
 import { StageBanner } from "@/components/stage-banner";
 import { DEPARTMENTS } from "@/data/departments";
-import { getMinistriesByCategory } from "@/data/ministries";
+import { MINISTRIES } from "@/data/ministries";
+import { STATE_BODIES } from "@/data/state-bodies";
 import { filterByQuery } from "@/lib/search-filter";
 
 export const metadata: Metadata = {
@@ -22,24 +23,25 @@ interface Org {
 
 const byName = (a: Org, b: Org) => a.name.localeCompare(b.name);
 
-const ministries: Org[] = [
-  ...getMinistriesByCategory("ministerial"),
-  ...getMinistriesByCategory("non-ministerial"),
-  ...getMinistriesByCategory("agency"),
-]
-  .map((m) => ({
-    slug: m.slug,
-    name: m.name,
-    shortDescription: m.shortDescription,
-    href: `/ministries/${m.slug}`,
-  }))
-  .sort(byName);
+const ministries: Org[] = MINISTRIES.map((m) => ({
+  slug: m.slug,
+  name: m.name,
+  shortDescription: m.shortDescription,
+  href: `/ministries/${m.slug}`,
+})).sort(byName);
 
 const departments: Org[] = DEPARTMENTS.map((d) => ({
   slug: d.slug,
   name: d.name,
   shortDescription: d.shortDescription,
   href: `/departments/${d.slug}`,
+})).sort(byName);
+
+const stateBodies: Org[] = STATE_BODIES.map((s) => ({
+  slug: s.slug,
+  name: s.name,
+  shortDescription: s.shortDescription,
+  href: `/state-bodies/${s.slug}`,
 })).sort(byName);
 
 const ALL_GROUPS = [
@@ -57,6 +59,13 @@ const ALL_GROUPS = [
       "Statutory bodies, agencies, departments and public corporations that work with government.",
     items: departments,
   },
+  {
+    id: "state-bodies",
+    title: "State bodies",
+    description:
+      "State-owned enterprises, public corporations and statutory bodies.",
+    items: stateBodies,
+  },
 ].filter((group) => group.items.length > 0);
 
 function filterGroups(query: string) {
@@ -68,7 +77,7 @@ function filterGroups(query: string) {
   })).filter((group) => group.items.length > 0);
 }
 
-export default async function OrganizationsPage({
+export default async function OrganisationsPage({
   searchParams,
 }: {
   searchParams: Promise<{ q?: string }>;
@@ -77,7 +86,7 @@ export default async function OrganizationsPage({
   const query = q.trim();
   const groups = filterGroups(query);
   const totalResults = groups.reduce((sum, g) => sum + g.items.length, 0);
-  const basePath = "/government/organizations";
+  const basePath = "/government/organisations";
 
   return (
     <>
@@ -152,7 +161,7 @@ export default async function OrganizationsPage({
                     id={group.id}
                     key={group.id}
                   >
-                    <div className="md:col-span-1">
+                    <div className="min-w-0 md:col-span-1">
                       <Heading
                         as="h2"
                         className="text-[20px] leading-tight"
@@ -164,7 +173,7 @@ export default async function OrganizationsPage({
                         {group.items.length}
                       </p>
                     </div>
-                    <ul className="flex flex-col md:col-span-2">
+                    <ul className="flex min-w-0 flex-col md:col-span-2">
                       {group.items.map((item) => (
                         <li
                           className="border-grey-00 border-b py-s first:pt-0"
@@ -172,7 +181,7 @@ export default async function OrganizationsPage({
                         >
                           <Link
                             as={NextLink}
-                            className="text-[19px] leading-normal"
+                            className="wrap-break-word text-[19px] leading-normal"
                             href={item.href}
                           >
                             {item.name}

--- a/src/app/state-bodies/[slug]/page.tsx
+++ b/src/app/state-bodies/[slug]/page.tsx
@@ -6,7 +6,7 @@ import remarkGfm from "remark-gfm";
 
 import { markdownComponents } from "@/components/markdown-content";
 import { MinistryPage } from "@/components/ministry/ministry-page";
-import { getMinistryBySlug, MINISTRIES } from "@/data/ministries";
+import { getStateBodyBySlug, STATE_BODIES } from "@/data/state-bodies";
 import { getContentBody } from "@/lib/content-body";
 import rehypeSectionise from "@/lib/rehype-sectionise";
 
@@ -15,7 +15,7 @@ interface Params {
 }
 
 export function generateStaticParams(): Params[] {
-  return MINISTRIES.map((m) => ({ slug: m.slug }));
+  return STATE_BODIES.map((s) => ({ slug: s.slug }));
 }
 
 export async function generateMetadata({
@@ -24,21 +24,21 @@ export async function generateMetadata({
   params: Promise<Params>;
 }): Promise<Metadata> {
   const { slug } = await params;
-  const ministry = getMinistryBySlug(slug);
-  if (!ministry) return {};
-  return { title: ministry.name };
+  const stateBody = getStateBodyBySlug(slug);
+  if (!stateBody) return {};
+  return { title: stateBody.name };
 }
 
-export default async function MinistryDetailPage({
+export default async function StateBodyDetailPage({
   params,
 }: {
   params: Promise<Params>;
 }) {
   const { slug } = await params;
-  const ministry = getMinistryBySlug(slug);
-  if (!ministry) notFound();
+  const stateBody = getStateBodyBySlug(slug);
+  if (!stateBody) notFound();
 
-  const md = await getContentBody("ministries", slug);
+  const md = await getContentBody("state-bodies", slug);
   const body = md ? (
     <div className="space-y-6 lg:space-y-8">
       <ReactMarkdown
@@ -53,15 +53,12 @@ export default async function MinistryDetailPage({
 
   return (
     <MinistryPage
-      associatedDepartments={ministry.associatedDepartments}
       body={body}
-      contact={ministry.contact}
-      featured={ministry.featured}
-      minister={ministry.minister}
-      onlineServices={ministry.onlineServices}
-      originalSource={ministry.originalSource}
-      services={ministry.services}
-      title={ministry.name}
+      contact={stateBody.contact}
+      leadershipLabel="Director"
+      minister={stateBody.head}
+      originalSource={stateBody.originalSource}
+      title={stateBody.name}
     />
   );
 }

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,11 +1,12 @@
 import { Logo } from "@govtech-bb/react";
 import Link from "next/link";
 import { Banner } from "./banner";
+import { MobileNav } from "./mobile-nav";
 
 export const Header = () => (
   <div>
     <Banner />
-    <header className="bg-yellow-100">
+    <header className="relative bg-yellow-100">
       <div className="container">
         <div className="flex items-center gap-3 py-s lg:py-xm">
           <Link aria-label="Go to the alpha.gov.bb homepage" href="/">
@@ -14,28 +15,7 @@ export const Header = () => (
               className="h-6.75 w-69 lg:h-8.75 lg:w-88.75"
             />
           </Link>
-          <nav aria-label="Primary" className="ml-auto">
-            <ul className="flex items-center gap-xs sm:gap-s">
-              <li>
-                <Link className="font-medium hover:underline" href="/">
-                  Home
-                </Link>
-              </li>
-              <li>
-                <Link className="font-medium hover:underline" href="/services">
-                  Services
-                </Link>
-              </li>
-              <li>
-                <Link
-                  className="font-medium hover:underline"
-                  href="/government/organizations"
-                >
-                  Organisations
-                </Link>
-              </li>
-            </ul>
-          </nav>
+          <MobileNav />
         </div>
       </div>
     </header>

--- a/src/components/layout/mobile-nav.tsx
+++ b/src/components/layout/mobile-nav.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useId, useState } from "react";
+
+const ITEMS = [
+  { href: "/", label: "Home" },
+  { href: "/services", label: "Services" },
+  { href: "/government/organisations", label: "Organisations" },
+];
+
+function HamburgerIcon() {
+  return (
+    <span aria-hidden="true" className="relative block h-4 w-6">
+      <span className="absolute top-0 left-0 h-0.5 w-6 bg-current" />
+      <span className="absolute top-1/2 left-0 h-0.5 w-6 -translate-y-1/2 bg-current" />
+      <span className="absolute bottom-0 left-0 h-0.5 w-6 bg-current" />
+    </span>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <span aria-hidden="true" className="relative block h-5 w-5">
+      <span className="absolute top-1/2 left-0 h-0.5 w-5 -translate-y-1/2 rotate-45 bg-current" />
+      <span className="absolute top-1/2 left-0 h-0.5 w-5 -translate-y-1/2 -rotate-45 bg-current" />
+    </span>
+  );
+}
+
+export function MobileNav() {
+  const [open, setOpen] = useState(false);
+  const id = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => {
+      document.body.style.overflow = prev;
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <nav aria-label="Primary" className="ml-auto sm:contents">
+      <button
+        aria-controls={id}
+        aria-expanded={open}
+        aria-label="Open menu"
+        className="-mr-2 flex h-10 w-10 items-center justify-center sm:hidden"
+        onClick={() => setOpen(true)}
+        type="button"
+      >
+        <HamburgerIcon />
+      </button>
+
+      {open && (
+        <div
+          aria-modal="true"
+          className="fixed inset-0 z-50 flex flex-col bg-white-00 sm:hidden"
+          id={id}
+          role="dialog"
+        >
+          <div className="bg-yellow-100">
+            <div className="container">
+              <div className="flex items-center py-s">
+                <span className="font-bold text-[20px]">Menu</span>
+                <button
+                  aria-label="Close menu"
+                  className="-mr-2 ml-auto flex h-10 w-10 items-center justify-center"
+                  onClick={() => setOpen(false)}
+                  type="button"
+                >
+                  <CloseIcon />
+                </button>
+              </div>
+            </div>
+          </div>
+          <ul className="flex flex-col">
+            {ITEMS.map((item) => (
+              <li className="border-grey-00 border-b" key={item.href}>
+                <div className="container">
+                  <Link
+                    className="block py-4 font-medium text-[20px] hover:underline"
+                    href={item.href}
+                    onClick={() => setOpen(false)}
+                  >
+                    {item.label}
+                  </Link>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <ul className="hidden sm:ml-auto sm:flex sm:items-center sm:gap-s">
+        {ITEMS.map((item) => (
+          <li key={item.href}>
+            <Link className="font-medium hover:underline" href={item.href}>
+              {item.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/ministry/ministry-page.tsx
+++ b/src/components/ministry/ministry-page.tsx
@@ -60,7 +60,6 @@ function renderContactValue(item: ContactItem): ReactNode {
 
 export interface MinistryPageProps {
   title: string;
-  intro: ReactNode;
   body?: ReactNode;
   featured?: FeaturedItem[];
   services?: MinistryService[];
@@ -74,7 +73,6 @@ export interface MinistryPageProps {
 
 export function MinistryPage({
   title,
-  intro,
   body,
   featured,
   services,
@@ -99,14 +97,9 @@ export function MinistryPage({
 
       <section className="bg-teal-00 py-l text-white-00">
         <div className="container grid grid-cols-1 items-center gap-m lg:grid-cols-[2fr_1fr] lg:gap-xl">
-          <div className="flex flex-col gap-s">
-            <Heading as="h1" className="text-white-00">
-              {title}
-            </Heading>
-            <Text as="p" className="text-white-00">
-              {intro}
-            </Text>
-          </div>
+          <Heading as="h1" className="text-white-00">
+            {title}
+          </Heading>
         </div>
       </section>
 

--- a/src/components/search-form.tsx
+++ b/src/components/search-form.tsx
@@ -18,20 +18,20 @@ export function SearchForm({
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const trimmed = query.trim();
-    if (!trimmed && emptyFallbackPath) {
-      router.push(emptyFallbackPath);
+    if (!trimmed) {
+      router.push(emptyFallbackPath ?? "/services");
       return;
     }
-    router.push(
-      trimmed
-        ? `${searchPath}?q=${encodeURIComponent(trimmed)}`
-        : (emptyFallbackPath ?? "/services")
-    );
+    router.push(`${searchPath}?q=${encodeURIComponent(trimmed)}`);
   }
 
   return (
-    <search aria-label="Search">
-      <form action={searchPath} className="flex w-full" onSubmit={handleSubmit}>
+    <search aria-label="Search" className="block w-full min-w-0">
+      <form
+        action={searchPath}
+        className="flex w-full min-w-0"
+        onSubmit={handleSubmit}
+      >
         <label className="sr-only" htmlFor="site-search">
           Search
         </label>

--- a/src/content/state-bodies/water-authority.md
+++ b/src/content/state-bodies/water-authority.md
@@ -1,0 +1,1 @@
+The Barbados Water Authority (BWA) is a Statutory Body established by an act of Legislature on 8th October, 1980 to replace the Waterworks Department of Government.

--- a/src/data/departments.ts
+++ b/src/data/departments.ts
@@ -1,14 +1,6 @@
-import type { ContactItem, Minister } from "@/data/mda-types";
+import type { MdaEntry } from "@/data/mda-types";
 
-export interface Department {
-  slug: string;
-  name: string;
-  shortDescription?: string;
-  intro?: string;
-  head?: Minister;
-  contact?: ContactItem[];
-  originalSource?: string;
-}
+export type Department = MdaEntry;
 
 // Source: https://www.gov.bb/Departments (verified)
 export const DEPARTMENTS: Department[] = [

--- a/src/data/mda-types.ts
+++ b/src/data/mda-types.ts
@@ -30,3 +30,13 @@ export interface AssociatedDepartmentGroup {
   category?: string;
   items: string[];
 }
+
+export interface MdaEntry {
+  slug: string;
+  name: string;
+  shortDescription?: string;
+  intro?: string;
+  head?: Minister;
+  contact?: ContactItem[];
+  originalSource?: string;
+}

--- a/src/data/state-bodies.ts
+++ b/src/data/state-bodies.ts
@@ -1,0 +1,40 @@
+import type { MdaEntry } from "@/data/mda-types";
+
+export type StateBody = MdaEntry;
+
+export const STATE_BODIES: StateBody[] = [
+  {
+    slug: "water-authority",
+    name: "Barbados Water Authority",
+    shortDescription:
+      "The Barbados Water Authority (BWA) is a Statutory Body established by an act of Legislature on 8th October, 1980 to replace the Waterworks Department of Government.",
+    intro:
+      "The Barbados Water Authority (BWA) is a Statutory Body established by an act of Legislature on 8th October, 1980 to replace the Waterworks Department of Government.",
+    contact: [
+      { label: "Email", type: "email", value: "customercare@bwa.bb" },
+      { label: "Telephone", type: "phone", value: "(246) 434-4200" },
+      { label: "Telephone", type: "phone", value: "(246) 434-4292" },
+      { label: "Telephone", type: "phone", value: "(246) 228-0155" },
+      {
+        label: "Website",
+        type: "website",
+        value: "http://barbadoswaterauthority.com/",
+      },
+      {
+        label: "Address",
+        value: [
+          "Pine Commercial Estate",
+          "The Pine",
+          "St. Michael",
+          "P.O. Box 1260",
+          "Bridgetown",
+        ],
+      },
+    ],
+    originalSource: "https://www.gov.bb/State-Bodies/water-authority",
+  },
+];
+
+export function getStateBodyBySlug(slug: string): StateBody | undefined {
+  return STATE_BODIES.find((s) => s.slug === slug);
+}


### PR DESCRIPTION
## Summary
- Migrates the first state body (**Barbados Water Authority**) following the MDA pattern from #552: data entry, markdown content, and a `/state-bodies/[slug]` route.
- Renames `/government/organizations` → `/government/organisations` (British spelling) and adds a **State bodies** group to that listing.
- Adds a **MobileNav** component: hamburger toggle that opens a full-screen overlay (yellow bar + stacked links), body-scroll lock, Escape closes. CSS-only icons (no SVG).
- Refactors: extracts shared `MdaEntry` interface; `Department` and `StateBody` are now type aliases. Removes intro paragraph from `MinistryPage` hero (and dead prop). Simplifies `search-form` empty-query branch.

## Test plan
- [ ] Visit `/government/organisations` on mobile and desktop — search section should not overflow
- [ ] Tap hamburger on mobile — overlay opens, scroll locked, Escape closes, link tap closes + navigates
- [ ] Visit `/state-bodies/water-authority` — page renders with contact card and migrated source banner
- [ ] Verify existing `/ministries/[slug]` and `/departments/[slug]` pages still render (no `intro` regression)
- [ ] Confirm old `/government/organizations` URL is no longer linked anywhere