### PR TITLE
feat(youth-opportunities): dispatch case-management webhook on form submission

### DIFF
--- a/src/app/actions/generate-application-code.ts
+++ b/src/app/actions/generate-application-code.ts
@@ -1,0 +1,39 @@
+"use server";
+
+import { randomInt } from "node:crypto";
+import {
+  generateApplicationCode,
+  SERVICES,
+  type ServiceCode,
+} from "@/lib/application-code";
+
+const COUNTER_CAPACITY = 36 ** 3;
+
+function isServiceCode(value: string): value is ServiceCode {
+  return value in SERVICES;
+}
+
+/**
+ * Server action that issues a fresh application tracking code. The 3-char
+ * base36 counter slot is filled with a CSPRNG random integer (no persistent
+ * counter is currently wired up); the trailing 4-char random suffix from
+ * `generateApplicationCode` keeps collision risk negligible.
+ */
+// biome-ignore lint/suspicious/useAwait: Next.js server actions must be async even when the implementation is synchronous.
+export async function generateApplicationCodeForService(
+  service: string
+): Promise<
+  { success: true; code: string } | { success: false; error: string }
+> {
+  if (!isServiceCode(service)) {
+    return {
+      success: false,
+      error: `Unknown service code: ${service}`,
+    };
+  }
+
+  const applicationId = randomInt(0, COUNTER_CAPACITY);
+  const code = generateApplicationCode(service, applicationId);
+
+  return { success: true, code };
+}

--- a/src/app/actions/send-form-submitted-webhook.ts
+++ b/src/app/actions/send-form-submitted-webhook.ts
@@ -1,0 +1,196 @@
+"use server";
+
+import * as Sentry from "@sentry/nextjs";
+import { z } from "zod";
+
+const webhookPayloadSchema = z.object({
+  referenceNumber: z.string().min(1),
+  programmeCode: z.string().min(1),
+  applicantName: z.string(),
+  applicantEmail: z.string().email().nullable(),
+  formData: z.record(z.string(), z.unknown()),
+});
+
+type WebhookPayload = z.infer<typeof webhookPayloadSchema>;
+
+type LogLevel = "INFO" | "WARN" | "ERROR";
+
+const cloudwatchLog: Record<LogLevel, (message: string) => void> = {
+  INFO: console.info,
+  WARN: console.warn,
+  ERROR: console.error,
+};
+
+function log(
+  level: LogLevel,
+  event: string,
+  fields?: Record<string, unknown>
+): void {
+  cloudwatchLog[level](
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      service: "form-submitted-webhook",
+      event,
+      ...fields,
+    })
+  );
+}
+
+function maskEmail(email: string | null | undefined): string {
+  if (!email) return "(none)";
+  const atIndex = email.indexOf("@");
+  if (atIndex < 0) return "***";
+  const local = email.slice(0, atIndex);
+  const domain = email.slice(atIndex + 1);
+  const visible = local.slice(0, Math.min(2, local.length));
+  return `${visible}***@${domain}`;
+}
+
+function buildWebhookEndpoint(baseUrl: string): string {
+  // `URL` resolves `api/webhooks/...` against the base safely whether or not
+  // the configured WEBHOOK_URL has a trailing slash.
+  const normalisedBase = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  return new URL("api/webhooks/form-submitted", normalisedBase).toString();
+}
+
+export async function sendFormSubmittedWebhook(payload: WebhookPayload) {
+  const webhookUrl = process.env.WEBHOOK_URL;
+  const webhookSecret = process.env.WEBHOOK_SECRET;
+  const actionStart = Date.now();
+
+  const correlationRef =
+    typeof payload?.referenceNumber === "string"
+      ? payload.referenceNumber
+      : "unknown";
+
+  if (!(webhookUrl && webhookSecret)) {
+    log("WARN", "sendFormSubmittedWebhook.not_configured", {
+      referenceNumber: correlationRef,
+      hasWebhookUrl: Boolean(webhookUrl),
+      hasWebhookSecret: Boolean(webhookSecret),
+      hint: "Set WEBHOOK_URL and WEBHOOK_SECRET to dispatch case-management webhooks",
+    });
+    return {
+      success: false as const,
+      error: "Webhook is not configured",
+    };
+  }
+
+  const parsed = webhookPayloadSchema.safeParse(payload);
+  if (!parsed.success) {
+    const flatErrors = parsed.error.flatten();
+    log("ERROR", "sendFormSubmittedWebhook.validation_failed", {
+      referenceNumber: correlationRef,
+      fieldErrors: flatErrors.fieldErrors,
+      formErrors: flatErrors.formErrors,
+    });
+    Sentry.captureMessage(
+      "sendFormSubmittedWebhook: payload validation failed",
+      {
+        level: "error",
+        extra: {
+          referenceNumber: correlationRef,
+          fieldErrors: flatErrors.fieldErrors,
+        },
+      }
+    );
+    return {
+      success: false as const,
+      error: "Invalid webhook payload",
+    };
+  }
+
+  const {
+    applicantEmail,
+    applicantName,
+    formData,
+    programmeCode,
+    referenceNumber,
+  } = parsed.data;
+
+  const endpoint = buildWebhookEndpoint(webhookUrl);
+
+  log("INFO", "sendFormSubmittedWebhook.attempt", {
+    referenceNumber,
+    programmeCode,
+    endpoint,
+    applicantEmail: maskEmail(applicantEmail),
+  });
+
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": webhookSecret,
+      },
+      body: JSON.stringify({
+        code: referenceNumber,
+        programme_code: programmeCode,
+        applicant: {
+          name: applicantName,
+          email: applicantEmail,
+        },
+        form_data: formData,
+      }),
+    });
+
+    const responseBody = await response.text().catch(() => "");
+
+    if (!response.ok) {
+      log("ERROR", "sendFormSubmittedWebhook.http_error", {
+        referenceNumber,
+        programmeCode,
+        status: response.status,
+        statusText: response.statusText,
+        responseBody: responseBody.slice(0, 500),
+        durationMs: Date.now() - actionStart,
+      });
+      Sentry.captureMessage("sendFormSubmittedWebhook: non-2xx response", {
+        level: "error",
+        extra: {
+          referenceNumber,
+          programmeCode,
+          status: response.status,
+          responseBody: responseBody.slice(0, 500),
+        },
+      });
+      return {
+        success: false as const,
+        status: response.status,
+        responseBody,
+        error: `Webhook responded with ${response.status}`,
+      };
+    }
+
+    log("INFO", "sendFormSubmittedWebhook.success", {
+      referenceNumber,
+      programmeCode,
+      status: response.status,
+      durationMs: Date.now() - actionStart,
+    });
+
+    return {
+      success: true as const,
+      status: response.status,
+      responseBody,
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unknown webhook error";
+    log("ERROR", "sendFormSubmittedWebhook.network_error", {
+      referenceNumber,
+      programmeCode,
+      error: message,
+      durationMs: Date.now() - actionStart,
+    });
+    Sentry.captureException(error, {
+      extra: { referenceNumber, programmeCode },
+    });
+    return {
+      success: false as const,
+      error: message,
+    };
+  }
+}

--- a/src/app/youth/opportunities/[id]/form/_components/youth-opportunity-form.tsx
+++ b/src/app/youth/opportunities/[id]/form/_components/youth-opportunity-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import DynamicMultiStepForm from "@/components/forms/builder/multi-step-form";
+import { getYouthOpportunityServiceCode } from "@/data/youth-opportunity-service-codes";
 import { buildYouthOpportunityFormSteps } from "@/schema/youth-opportunity-default";
 
 interface Props {
@@ -15,6 +16,7 @@ export function YouthOpportunityForm({
   notificationEmail,
 }: Props) {
   const formSteps = buildYouthOpportunityFormSteps(opportunityTitle);
+  const programmeCode = getYouthOpportunityServiceCode(opportunityId);
 
   return (
     <DynamicMultiStepForm
@@ -27,6 +29,7 @@ export function YouthOpportunityForm({
       serviceTitle={`Apply for ${opportunityTitle}`}
       storageKey={`youth-opportunity-${opportunityId}`}
       submissionMode="serverActionOnly"
+      webhookProgrammeCode={programmeCode}
     />
   );
 }

--- a/src/components/forms/builder/multi-step-form.tsx
+++ b/src/components/forms/builder/multi-step-form.tsx
@@ -5,7 +5,9 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { type FieldError, FormProvider, useForm } from "react-hook-form";
+import { generateApplicationCodeForService } from "@/app/actions/generate-application-code";
 import { sendFormSubmissionEmails } from "@/app/actions/send-form-submission-emails";
+import { sendFormSubmittedWebhook } from "@/app/actions/send-form-submitted-webhook";
 import { ReviewStep } from "@/components/forms/builder/review-step";
 import { FormSkeleton } from "@/components/forms/form-skeleton";
 import { useFormTracking } from "@/hooks/use-form-tracking";
@@ -467,6 +469,12 @@ interface DynamicMultiStepFormProps {
    * best-effort email behaviour already used by the "api" submission mode.
    */
   continueOnEmailFailure?: boolean;
+  /**
+   * When set and `submissionMode` is `"serverActionOnly"`, the case-management
+   * webhook is dispatched with this programme code after a successful
+   * submission. Webhook failures are logged but never block the submission.
+   */
+  webhookProgrammeCode?: string | null;
 }
 
 export default function DynamicMultiStepForm({
@@ -479,6 +487,7 @@ export default function DynamicMultiStepForm({
   analyticsCategory,
   confirmationFormId,
   continueOnEmailFailure = false,
+  webhookProgrammeCode = null,
 }: DynamicMultiStepFormProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -942,16 +951,39 @@ export default function DynamicMultiStepForm({
     setSubmissionError(null);
 
     try {
-      // Extract customer name before cleaning data
-      const applicantFirstName = (data["applicant.firstName"] as string) || "";
-      const applicantLastName = (data["applicant.lastName"] as string) || "";
-      const customerName = `${applicantFirstName} ${applicantLastName}`.trim();
-
       // Clean up data to remove fields from hidden conditional steps
       const cleanedData = cleanFormDataForSubmission(data);
 
+      // Extract customer name. react-hook-form stores dot-notation field names
+      // as nested objects, so we resolve `applicant.firstName` via path lookup
+      // rather than treating it as a flat key.
+      const applicantFirstName =
+        getNestedValue<string>(
+          cleanedData as Record<string, unknown>,
+          "applicant.firstName"
+        ) ?? "";
+      const applicantLastName =
+        getNestedValue<string>(
+          cleanedData as Record<string, unknown>,
+          "applicant.lastName"
+        ) ?? "";
+      const customerName = `${applicantFirstName} ${applicantLastName}`.trim();
+
       if (submissionMode === "serverActionOnly") {
-        const generatedReferenceNumber = `REF-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+        let generatedReferenceNumber = `REF-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+
+        if (webhookProgrammeCode) {
+          const codeResult =
+            await generateApplicationCodeForService(webhookProgrammeCode);
+          if (codeResult.success) {
+            generatedReferenceNumber = codeResult.code;
+          } else {
+            console.error(
+              "Application code generation failed; falling back to REF format",
+              codeResult.error
+            );
+          }
+        }
 
         try {
           const emailResult = await sendFormSubmissionEmails({
@@ -976,6 +1008,25 @@ export default function DynamicMultiStepForm({
             });
             tracking.trackSubmitError("Remote form email submission failed");
             return;
+          }
+        }
+
+        if (webhookProgrammeCode) {
+          try {
+            await sendFormSubmittedWebhook({
+              applicantEmail: extractApplicantEmail(
+                cleanedData as Record<string, unknown>
+              ),
+              applicantName: customerName,
+              formData: cleanedData as Record<string, unknown>,
+              programmeCode: webhookProgrammeCode,
+              referenceNumber: generatedReferenceNumber,
+            });
+          } catch (webhookError) {
+            console.error(
+              "Form submission webhook dispatch failed",
+              webhookError
+            );
           }
         }
 

--- a/src/data/youth-opportunity-service-codes.ts
+++ b/src/data/youth-opportunity-service-codes.ts
@@ -1,0 +1,36 @@
+import type { ServiceCode } from "@/lib/application-code";
+
+/**
+ * Maps a youth opportunity ID (from `opportunities.json`) to the SERVICE_CODE
+ * expected by the downstream case-management webhook. Values are typed against
+ * the canonical `ServiceCode` union from `@/lib/application-code`, so an
+ * unknown service prefix is a compile-time error.
+ */
+export const YOUTH_OPPORTUNITY_SERVICE_CODES: Record<string, ServiceCode> = {
+  byac: "BYAC",
+  ydp: "YDP",
+  pathways: "PATH",
+  "bright-sparks-2": "SPARKS",
+  "bridge-to-future-2025": "BRIDGE",
+  cip: "CIP",
+  btu: "BTU",
+  "cyber-security-training": "CYBER",
+  "web-design-entrepreneurs": "WEBDEV",
+  cap: "CAP",
+  yes: "YES",
+  yar: "YAR",
+  "community-canvas": "CANVAS",
+  "national-summer-camp": "CAMP",
+  ceep: "CEEP",
+  "mission-barbados": "MISSION",
+  "barbados-blooming-libraries": "BLOOM",
+  cmc: "CMC",
+  "spreading-joy-2025": "JOY",
+  "centre-access": "BOOKING",
+};
+
+export function getYouthOpportunityServiceCode(
+  opportunityId: string
+): ServiceCode | null {
+  return YOUTH_OPPORTUNITY_SERVICE_CODES[opportunityId] ?? null;
+}

--- a/src/lib/application-code.ts
+++ b/src/lib/application-code.ts
@@ -1,0 +1,73 @@
+import "server-only";
+import { randomInt } from "node:crypto";
+
+const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"; // 36 chars
+
+/**
+ * Catalogue of valid service prefixes. Using a const object gives us a
+ * compile-time-checked union type, so passing an invalid prefix is a
+ * TypeScript error — not a runtime surprise.
+ */
+export const SERVICES = {
+  BYAC: "Barbados Youth Advance Corps",
+  YDP: "Youth Development Programme",
+  PATH: "Pathways Employability Programme",
+  SPARKS: "Bright Sparks Educational Project 2.0",
+  BRIDGE: "Bridge to the Future Workshop",
+  CIP: "Community Impact Programme",
+  BTU: "Block Transformation Unit (Project Dawn)",
+  CYBER: "Cyber Security Training Workshop",
+  WEBDEV: "Web Page Design and Maintenance for Entrepreneurs",
+  CAP: "Community Arts Programme",
+  YES: "Youth Entrepreneurship Scheme – First Contact",
+  YAR: "Youth Achieving Results",
+  CANVAS: "Community Canvas",
+  CAMP: "National Summer Camp Programme",
+  CEEP: "Community Engagement and Educational Programme",
+  MISSION: "Mission Barbados",
+  BLOOM: "Barbados is Blooming (Little Libraries)",
+  CMC: "Centre Management Committee",
+  JOY: "Spreading Joy at Christmas",
+  BOOKING: "Book a Community Centre",
+} as const;
+
+export type ServiceCode = keyof typeof SERVICES;
+
+function encodeBase36(n: number, width: number): string {
+  if (n < 0) throw new Error("Counter must be non-negative");
+  if (n >= 36 ** width) {
+    throw new Error(`Counter ${n} exceeds capacity for width ${width}`);
+  }
+  return n.toString(36).toUpperCase().padStart(width, "0");
+}
+
+function randomSuffix(length: number): string {
+  let result = "";
+  for (let i = 0; i < length; i++) {
+    result += ALPHABET[randomInt(0, ALPHABET.length)];
+  }
+  return result;
+}
+
+function formatDDMM(date: Date): string {
+  const dd = String(date.getDate()).padStart(2, "0");
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  return `${dd}${mm}`;
+}
+
+/**
+ * Generate an application tracking code:
+ *   <SERVICE>-<DDMM>-<counter><random>
+ *
+ * The ServiceCode type ensures only valid prefixes from SERVICES compile.
+ */
+export function generateApplicationCode(
+  service: ServiceCode,
+  applicationId: number,
+  date: Date = new Date()
+): string {
+  const datePart = formatDDMM(date);
+  const counterPart = encodeBase36(applicationId, 3);
+  const randomPart = randomSuffix(4);
+  return `${service}-${datePart}-${counterPart}${randomPart}`;
+}


### PR DESCRIPTION
Adds a server action that POSTs each youth-opportunity submission to the case-management service with a service-prefixed reference number (SERVICE-DDMM-counter+random). Wires the dispatch into the multi-step form's serverActionOnly path and maps each opportunity id to its SERVICE_CODE.

Also fixes a pre-existing bug where the customer name extraction in multi-step-form used bracket access on dot-notation field paths and always resolved to an empty string.

## Description
<!-- Summarize the changes based on added/changed functionality --><!-- Summarize the changes based on added/changed functionality -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

<!--List the files changed and why -->

### Notes
<!--Add notes for anything unrelated to the specified categories -->

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->


## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
