### PR TITLE
DNM - Add data storage and DPA 2019 sections to Terms & Conditions

### DIFF
--- a/src/content/terms-conditions.md
+++ b/src/content/terms-conditions.md
@@ -12,7 +12,7 @@ All content on this website is and shall remain the sole and exclusive property 
 
 ### Disclaimer of Warranties
 
-GOV.BB operates this site to inform users as to our various services, projects, how to communicate with us, and other information about our company. The information contained herein is not intended as a substitute for qualified technical or engineering services and under no circumstances shall be deemed to constitute such services. Users should also note that Internet software including, but not limited to, browsers or even transmission problems can produce inaccurate or incomplete copies of documents when downloaded and displayed on a user's computer.
+GOV.BB operates this site to inform users as to our various services, projects, how to communicate with us, and other information about the Government of Barbados. The information contained herein is not intended as a substitute for qualified technical or engineering services and under no circumstances shall be deemed to constitute such services. Users should also note that Internet software including, but not limited to, browsers or even transmission problems can produce inaccurate or incomplete copies of documents when downloaded and displayed on a user's computer.
 
 GOV.BB makes no warranties or representations of any kind, whether express or implied, as to the validity, accuracy, or reliability of any of the content found herein or on any other websites linked to or from this website. Any and all information contained herein or in such other websites is provided "AS IS" and without warranties of any kind, whether express or implied.
 
@@ -24,97 +24,35 @@ As a convenience to the user, certain links in this website will connect the u
 
 As consideration for any use of this website, including merely accessing the website, you agree to be bound by the laws of Barbados, without regard to any conflicts of law principles. You further agree to be subject to the jurisdiction of any of the courts of Barbados for any dispute relating in any way to your use of this website.
 
-### Data Protection and Privacy
+### Your Data
 
-This website is operated by the Ministry of Innovation, Science and Smart Technology, which acts as the Data Controller for personal information collected through alpha.gov.bb. We process personal information in accordance with the Data Protection Act 2019 of Barbados.
+alpha.gov.bb is run by the Ministry of Innovation, Science and Smart Technology. We handle your information under the Data Protection Act 2019.
 
-The sections below describe what information we collect, where it is stored, how long we keep it, and the rights available to you under the Act.
+### What we collect
 
-### Information We Collect
+What you type into an application form, any files you upload, payment details you enter on EZpay+, and basic analytics about how the site is used.
 
-When you use this website to apply for a government service, we may collect:
+### Where it's stored
 
-- Personal identification details that you enter into an application form (for example: name, date of birth, national identification number, contact details, address)
-- Information about other persons named in an application (for example: a deceased relative on a post office redirection, a child on a textbook grant)
-- Supporting documents and images that you choose to upload as attachments
-- Payment details required to complete a transaction, processed through the Government of Barbados EZpay+ platform
-- Technical information about your visit, including pages viewed, form interactions, time spent, and device information used to improve the service
-- Feedback that you choose to submit through the website
+The site runs on Amazon Web Services in the United States. This means your information leaves Barbados to be processed.
 
-We collect only the information needed to process the service you are requesting or to operate, secure, and improve the website.
+- **Forms without payment** are emailed straight to the relevant Ministry, Department or Agency. We don't keep a copy.
+- **Forms with payment** are encrypted and held only until payment goes through, then deleted. Anything left unpaid for 72 hours is deleted automatically.
+- **Uploaded files** pass through our storage for the few seconds it takes to attach them to your application.
+- **Payment records** (your name, email, amount, transaction number) are kept for accounting and audit. They don't include what you wrote in the form.
+- **Error logs and analytics** never contain the values you type. Email addresses in logs are masked.
+- **Partly filled forms** live only in your own browser so you can go back a step without losing your work.
 
-### Where Your Data Is Stored
+### Cookies
 
-Personal information submitted through alpha.gov.bb is processed using cloud services provided by Amazon Web Services (AWS) in the United States (the `us-east-1` region). The categories of storage are:
+We use your browser's session storage to remember your progress through a form. We don't use tracking cookies.
 
-- **Application form data submitted for services that do not require payment** is transmitted to the Government's form-processing service, validated, sent by email to the relevant Ministry, Department or Agency (MDA), and is **not retained** by alpha.gov.bb after the email has been sent.
-- **Application form data submitted for services that require payment** is held in an encrypted form in a PostgreSQL database for the limited period needed to complete the payment. Once payment is successful and the MDA has been notified by email, the encrypted application data is deleted from the database. If payment is not completed within 72 hours, the encrypted application data is automatically deleted by a scheduled cleanup process.
-- **Supporting documents and uploaded attachments** are transmitted to AWS Simple Storage Service (S3) for the limited time needed to attach them to your application. In normal operation this is a matter of seconds.
-- **Payment records** — including your name, email address, the amount paid, the payment method, the transaction number and the payment status — are retained in the payment database for accounting, audit and reconciliation purposes. Payment records do not contain the contents of the application form.
-- **Emails** containing your submission are sent to the relevant MDA through Amazon Simple Email Service (SES). The MDA's email retention policy applies once the email is received.
-- **Operational logs** are recorded by Amazon CloudWatch and by Sentry to allow us to diagnose errors and to monitor the health of the service. Email addresses appearing in logs are masked (for example, "us***@domain.com").
-- **Analytics events** (page views, form-step progress, durations and validation error counts) are recorded by Umami. Analytics events do not include the values you type into form fields.
-- **Partially completed forms** are stored only in your own web browser (in session storage) so that you can navigate between steps without losing your progress. This data is cleared when you close the browser tab, submit the form, or visit the start page for that service.
+### Your rights
 
-### Cross-Border Transfer of Information
+Under the Data Protection Act 2019 you can ask to see, correct or delete the information we hold about you, and you can complain to the Data Protection Commissioner.
 
-Because alpha.gov.bb is hosted on AWS infrastructure in the United States, personal information you submit through this website is transferred outside of Barbados for processing. The transfer is made under the contractual safeguards offered by AWS, which is certified to international standards including ISO 27001 and SOC 2. We make this transfer in order to deliver the digital services available through this website. By submitting information through the website you acknowledge this transfer.
+Contact: **privacy@govtech.bb**
 
-### How Long We Keep Your Information
+### Changes
 
-| Category of information | Retention period |
-| --- | --- |
-| Application form data (non-payment services) | Not retained after the notification email is sent to the MDA |
-| Application form data (payment services, before payment) | Held encrypted until payment is completed, or up to 72 hours if abandoned |
-| Application form data (payment services, after payment) | Deleted once the MDA has been notified by email |
-| Uploaded supporting documents | Retained only for the time needed to process the application (typically seconds) |
-| Payment records (name, email, amount, status, transaction number) | Retained for as long as required by applicable accounting and audit obligations |
-| Confirmation and notification emails | Retained by the MDA in accordance with that MDA's records policy |
-| Operational logs (CloudWatch, Sentry) | Retained according to standard log-retention periods; identifiers are masked |
-| Analytics events (Umami) | Retained in aggregate form to support service improvement |
-| Session storage on your device | Cleared when you close the browser tab, submit the form, or visit the start page |
-
-Once the MDA has received your application, that MDA becomes responsible for the further processing and retention of your information under its own records management policy.
-
-### Cookies and Browser Storage
-
-This website uses a small number of technologies that store information in your browser:
-
-- **Session storage** is used by online application forms to remember your progress between steps. This data never leaves your device unless you choose to submit the form.
-- **A research-access cookie** may be set when you follow a private invitation link to take part in user research. The cookie is HTTP-only, expires after 24 hours, and only grants access to a research form; it does not identify you.
-- **Analytics** uses a privacy-respecting analytics service (Umami) that does not set tracking cookies on your device for cross-site profiling. Analytics measurements use technical signals only.
-
-You can clear browser storage at any time using your browser's settings.
-
-### Your Rights Under the Data Protection Act 2019
-
-The Data Protection Act 2019 gives you rights in relation to the personal information that we hold about you. These include:
-
-- The right to be informed about how your information is used (this notice)
-- The right of access to the information we hold about you
-- The right to request correction of information that is inaccurate or incomplete
-- The right to request erasure of your information where the lawful basis for processing it no longer applies
-- The right to restrict or object to certain types of processing
-- The right not to be subject to a decision based solely on automated processing
-- The right to lodge a complaint with the Data Protection Commissioner
-
-To exercise any of these rights, contact us using the details below. We may need to verify your identity before responding so that we do not disclose information to the wrong person. If you are not satisfied with our response, you may contact the Office of the Data Protection Commissioner of Barbados.
-
-### Security
-
-We protect your information using a combination of technical and organisational measures, including encryption of application data while it is stored in the payment workflow, encrypted connections (HTTPS) between your browser and the website, masking of identifiers in our logs, and access controls on the systems that hold payment records. No method of transmission or storage over the internet is completely secure, and we cannot guarantee absolute security.
-
-### Lawful Basis for Processing
-
-We process your personal information on the basis that the processing is necessary for the performance of a task carried out in the public interest or in the exercise of official authority vested in the Government of Barbados, and, where applicable, on the basis of your consent (for example, when you choose to provide feedback or take part in user research).
-
-### Contact
-
-Questions about this notice, requests to exercise your rights under the Data Protection Act 2019, or concerns about how your information has been handled should be sent to:
-
-**Email:** privacy@govtech.bb
-**Data Controller:** Ministry of Innovation, Science and Smart Technology, Government of Barbados
-
-### Changes to This Notice
-
-alpha.gov.bb is an alpha service that is being actively developed. We may update this notice from time to time to reflect changes to the services we offer, the systems that support them, or the law. Material changes will be published on this page with an updated publication date.
+alpha.gov.bb is still in alpha and changes often. We'll update this page when how we handle your data changes.

--- a/src/content/terms-conditions.md
+++ b/src/content/terms-conditions.md
@@ -1,7 +1,7 @@
 ---
 title: "Terms & Conditions"
 source_url: https://www.gov.bb/terms-conditions
-publish_date: 2025-10-15
+publish_date: 2026-05-14
 ---
 
 ### Ownership of Website Content
@@ -23,3 +23,98 @@ As a convenience to the user, certain links in this website will connect the u
 ### Governing Law
 
 As consideration for any use of this website, including merely accessing the website, you agree to be bound by the laws of Barbados, without regard to any conflicts of law principles. You further agree to be subject to the jurisdiction of any of the courts of Barbados for any dispute relating in any way to your use of this website.
+
+### Data Protection and Privacy
+
+This website is operated by the Ministry of Innovation, Science and Smart Technology, which acts as the Data Controller for personal information collected through alpha.gov.bb. We process personal information in accordance with the Data Protection Act 2019 of Barbados.
+
+The sections below describe what information we collect, where it is stored, how long we keep it, and the rights available to you under the Act.
+
+### Information We Collect
+
+When you use this website to apply for a government service, we may collect:
+
+- Personal identification details that you enter into an application form (for example: name, date of birth, national identification number, contact details, address)
+- Information about other persons named in an application (for example: a deceased relative on a post office redirection, a child on a textbook grant)
+- Supporting documents and images that you choose to upload as attachments
+- Payment details required to complete a transaction, processed through the Government of Barbados EZpay+ platform
+- Technical information about your visit, including pages viewed, form interactions, time spent, and device information used to improve the service
+- Feedback that you choose to submit through the website
+
+We collect only the information needed to process the service you are requesting or to operate, secure, and improve the website.
+
+### Where Your Data Is Stored
+
+Personal information submitted through alpha.gov.bb is processed using cloud services provided by Amazon Web Services (AWS) in the United States (the `us-east-1` region). The categories of storage are:
+
+- **Application form data submitted for services that do not require payment** is transmitted to the Government's form-processing service, validated, sent by email to the relevant Ministry, Department or Agency (MDA), and is **not retained** by alpha.gov.bb after the email has been sent.
+- **Application form data submitted for services that require payment** is held in an encrypted form in a PostgreSQL database for the limited period needed to complete the payment. Once payment is successful and the MDA has been notified by email, the encrypted application data is deleted from the database. If payment is not completed within 72 hours, the encrypted application data is automatically deleted by a scheduled cleanup process.
+- **Supporting documents and uploaded attachments** are transmitted to AWS Simple Storage Service (S3) for the limited time needed to attach them to your application. In normal operation this is a matter of seconds.
+- **Payment records** — including your name, email address, the amount paid, the payment method, the transaction number and the payment status — are retained in the payment database for accounting, audit and reconciliation purposes. Payment records do not contain the contents of the application form.
+- **Emails** containing your submission are sent to the relevant MDA through Amazon Simple Email Service (SES). The MDA's email retention policy applies once the email is received.
+- **Operational logs** are recorded by Amazon CloudWatch and by Sentry to allow us to diagnose errors and to monitor the health of the service. Email addresses appearing in logs are masked (for example, "us***@domain.com").
+- **Analytics events** (page views, form-step progress, durations and validation error counts) are recorded by Umami. Analytics events do not include the values you type into form fields.
+- **Partially completed forms** are stored only in your own web browser (in session storage) so that you can navigate between steps without losing your progress. This data is cleared when you close the browser tab, submit the form, or visit the start page for that service.
+
+### Cross-Border Transfer of Information
+
+Because alpha.gov.bb is hosted on AWS infrastructure in the United States, personal information you submit through this website is transferred outside of Barbados for processing. The transfer is made under the contractual safeguards offered by AWS, which is certified to international standards including ISO 27001 and SOC 2. We make this transfer in order to deliver the digital services available through this website. By submitting information through the website you acknowledge this transfer.
+
+### How Long We Keep Your Information
+
+| Category of information | Retention period |
+| --- | --- |
+| Application form data (non-payment services) | Not retained after the notification email is sent to the MDA |
+| Application form data (payment services, before payment) | Held encrypted until payment is completed, or up to 72 hours if abandoned |
+| Application form data (payment services, after payment) | Deleted once the MDA has been notified by email |
+| Uploaded supporting documents | Retained only for the time needed to process the application (typically seconds) |
+| Payment records (name, email, amount, status, transaction number) | Retained for as long as required by applicable accounting and audit obligations |
+| Confirmation and notification emails | Retained by the MDA in accordance with that MDA's records policy |
+| Operational logs (CloudWatch, Sentry) | Retained according to standard log-retention periods; identifiers are masked |
+| Analytics events (Umami) | Retained in aggregate form to support service improvement |
+| Session storage on your device | Cleared when you close the browser tab, submit the form, or visit the start page |
+
+Once the MDA has received your application, that MDA becomes responsible for the further processing and retention of your information under its own records management policy.
+
+### Cookies and Browser Storage
+
+This website uses a small number of technologies that store information in your browser:
+
+- **Session storage** is used by online application forms to remember your progress between steps. This data never leaves your device unless you choose to submit the form.
+- **A research-access cookie** may be set when you follow a private invitation link to take part in user research. The cookie is HTTP-only, expires after 24 hours, and only grants access to a research form; it does not identify you.
+- **Analytics** uses a privacy-respecting analytics service (Umami) that does not set tracking cookies on your device for cross-site profiling. Analytics measurements use technical signals only.
+
+You can clear browser storage at any time using your browser's settings.
+
+### Your Rights Under the Data Protection Act 2019
+
+The Data Protection Act 2019 gives you rights in relation to the personal information that we hold about you. These include:
+
+- The right to be informed about how your information is used (this notice)
+- The right of access to the information we hold about you
+- The right to request correction of information that is inaccurate or incomplete
+- The right to request erasure of your information where the lawful basis for processing it no longer applies
+- The right to restrict or object to certain types of processing
+- The right not to be subject to a decision based solely on automated processing
+- The right to lodge a complaint with the Data Protection Commissioner
+
+To exercise any of these rights, contact us using the details below. We may need to verify your identity before responding so that we do not disclose information to the wrong person. If you are not satisfied with our response, you may contact the Office of the Data Protection Commissioner of Barbados.
+
+### Security
+
+We protect your information using a combination of technical and organisational measures, including encryption of application data while it is stored in the payment workflow, encrypted connections (HTTPS) between your browser and the website, masking of identifiers in our logs, and access controls on the systems that hold payment records. No method of transmission or storage over the internet is completely secure, and we cannot guarantee absolute security.
+
+### Lawful Basis for Processing
+
+We process your personal information on the basis that the processing is necessary for the performance of a task carried out in the public interest or in the exercise of official authority vested in the Government of Barbados, and, where applicable, on the basis of your consent (for example, when you choose to provide feedback or take part in user research).
+
+### Contact
+
+Questions about this notice, requests to exercise your rights under the Data Protection Act 2019, or concerns about how your information has been handled should be sent to:
+
+**Email:** privacy@govtech.bb
+**Data Controller:** Ministry of Innovation, Science and Smart Technology, Government of Barbados
+
+### Changes to This Notice
+
+alpha.gov.bb is an alpha service that is being actively developed. We may update this notice from time to time to reflect changes to the services we offer, the systems that support them, or the law. Material changes will be published on this page with an updated publication date.


### PR DESCRIPTION
## Description

Expands the alpha.gov.bb Terms & Conditions page to cover data protection, drafted against the Barbados Data Protection Act 2019, with factual disclosures of where personal information is stored, how long it is retained, and the cross-border transfer to AWS `us-east-1` in the United States.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Changes Made

- `src/content/terms-conditions.md` — preserves the existing Ownership / Disclaimer / Governing Law sections and adds Data Protection and Privacy, Information We Collect, Where Your Data Is Stored, Cross-Border Transfer, How Long We Keep Your Information (retention table), Cookies and Browser Storage, Your Rights Under the DPA 2019, Security, Lawful Basis for Processing, Contact (privacy@govtech.bb), and Changes to This Notice. Frontmatter `publish_date` bumped to `2026-05-14`.

### Notes
- Storage and retention statements are grounded in the actual behaviour of the form-processor-api (non-payment form data is not persisted; payment-form data is AES-encrypted in PostgreSQL until payment completes or 72 hours pass; uploads pass through S3 for the seconds needed to attach them; payment records persist for audit; logs mask identifiers).
- The Ministry of Innovation, Science and Smart Technology is named as Data Controller.
- The DPA 2019 rights list deliberately omits a response-time SLA — to be set separately by ops/legal.
- Legal / Data Protection sign-off recommended before merge.

## Testing
- [ ] Visual regression tests added for all device sizes
- [ ] Verify all pages render correctly
- [ ] Test responsive layout across device sizes (snapshots created)
- [ ] Check accessibility standards are met
- [ ] Validate markdown formatting renders properly
- [ ] Test navigation and breadcrumbs

## Related Github Issue(s)/Trello Ticket(s)
<!-- Link any related issues: Fixes #123 -->


## Checklist
- [ ] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [x] Documentation updated