### PR TITLE
fix(stage-banner): drop redundant horizontal padding inside container

### DIFF
--- a/src/components/stage-banner.tsx
+++ b/src/components/stage-banner.tsx
@@ -34,7 +34,7 @@ export const StageBanner = ({
   const href = isMigrated ? originalSource : (url ?? DEFAULT_URL[stage]);
   const isExternal = isMigrated;
   return (
-    <StatusBanner className={className} variant={stage}>
+    <StatusBanner className={`px-0 ${className ?? ""}`} variant={stage}>
       <Text as="p">
         {prefix}
         {href ? (


### PR DESCRIPTION
qucik fix for status banner 



Before: 

<img width="2992" height="376" alt="image" src="https://github.com/user-attachments/assets/f2c0ee62-21d2-4cfe-8450-3c94aa6ba46d" />


AFter:



<img width="2992" height="376" alt="image" src="https://github.com/user-attachments/assets/6bf83aa8-c84b-4546-9ec9-2f5ba693bdf2" />

