### PR TITLE
Add Request a Presidential Visit for a Centenarian form

### DIFF
--- a/src/components/forms/builder/declaration-step.tsx
+++ b/src/components/forms/builder/declaration-step.tsx
@@ -154,7 +154,9 @@ export function DeclarationStep({ step, serviceTitle }: DeclarationStepProps) {
             {nameInputFields.map((field) => (
               <DynamicField field={field} key={field.name} />
             ))}
-            {dateField && <DynamicField field={dateField} />}
+            {dateField && !dateField.hidden && (
+              <DynamicField field={dateField} />
+            )}
           </>
         )}
 

--- a/src/components/forms/builder/dynamic-field.tsx
+++ b/src/components/forms/builder/dynamic-field.tsx
@@ -191,12 +191,16 @@ function ComputedAgeFromDateField({
 /**
  * Get the CSS class for field width
  */
-function getWidthClass(width?: "short" | "medium" | "full"): string {
+function getWidthClass(
+  width?: "short" | "medium" | "two-thirds" | "full"
+): string {
   switch (width) {
     case "short":
       return "w-full md:w-1/3";
     case "medium":
       return "w-full md:w-1/2";
+    case "two-thirds":
+      return "w-full md:w-2/3";
     case "full":
       return "w-full";
     default:
@@ -424,23 +428,54 @@ export function DynamicField({
                 onValueChange={controllerField.onChange}
                 value={controllerField.value as string}
               >
-                {f.options?.map((option) => (
-                  <Fragment key={option.value}>
-                    <Radio
-                      id={
-                        inlineConditionals
-                          ? option.value
-                          : `${f.name}-${option.value}`
-                      }
-                      label={option.label}
-                      value={option.value}
-                    />
-                    {/* Render conditional fields that match this radio option */}
-                    {inlineConditionals
-                      ?.filter((cf) => cf.conditionalOn?.value === option.value)
-                      .map((cf) => renderConditionalField(cf))}
-                  </Fragment>
-                ))}
+                {f.options?.map((option) => {
+                  const matchingConditionals =
+                    inlineConditionals?.filter(
+                      (cf) => cf.conditionalOn?.value === option.value
+                    ) ?? [];
+                  const groupLabel = f.conditionalGroups?.[option.value]?.label;
+                  const showGroup =
+                    groupLabel &&
+                    matchingConditionals.length > 0 &&
+                    controllerField.value === option.value;
+                  return (
+                    <Fragment key={option.value}>
+                      <Radio
+                        id={
+                          inlineConditionals
+                            ? option.value
+                            : `${f.name}-${option.value}`
+                        }
+                        label={option.label}
+                        value={option.value}
+                      />
+                      {showGroup ? (
+                        <div className="motion-safe:fade-in motion-safe:slide-in-from-top-2 mt-6 pl-5 motion-safe:animate-in motion-safe:duration-200">
+                          <div className="space-y-6 border-blue-40 border-l-4 py-2 pl-s lg:w-[50vw]">
+                            <p className="font-bold text-[20px] text-mid-grey-00 leading-[1.7]">
+                              {groupLabel}
+                            </p>
+                            {matchingConditionals.map((cf) => {
+                              const condError = getNestedValue<FieldError>(
+                                errors as Record<string, unknown>,
+                                cf.name
+                              );
+                              return (
+                                <div key={cf.name}>
+                                  {renderFieldContent(cf, condError)}
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      ) : (
+                        matchingConditionals.map((cf) =>
+                          renderConditionalField(cf)
+                        )
+                      )}
+                    </Fragment>
+                  );
+                })}
               </RadioGroup>
             )}
           />

--- a/src/components/forms/builder/dynamic-step.tsx
+++ b/src/components/forms/builder/dynamic-step.tsx
@@ -1,4 +1,5 @@
 import { ErrorSummary, Heading, Text } from "@govtech-bb/react";
+import { Fragment } from "react";
 import { type FieldError, useFormContext } from "react-hook-form";
 import ReactMarkdown from "react-markdown";
 import { markdownComponents } from "@/components/markdown-content";
@@ -109,12 +110,25 @@ export function DynamicStep({ step, serviceTitle }: DynamicStepProps) {
             const conditionalFields = step.fields.filter(
               (f) => f.conditionalOn?.field === field.name
             );
+            const notices = step.inlineNotices?.filter(
+              (n) => n.afterField === field.name
+            );
             return (
-              <DynamicField
-                conditionalFields={conditionalFields}
-                field={field}
-                key={field.name}
-              />
+              <Fragment key={field.name}>
+                <DynamicField
+                  conditionalFields={conditionalFields}
+                  field={field}
+                />
+                {notices?.map((notice) => (
+                  <div
+                    className="space-y-1 rounded-sm bg-blue-10 p-s text-[1.25rem] leading-normal"
+                    key={`${notice.afterField}-${notice.title}`}
+                  >
+                    <p className="font-bold">{notice.title}</p>
+                    <p className="text-mid-grey-00">{notice.body}</p>
+                  </div>
+                ))}
+              </Fragment>
             );
           })}
       </div>

--- a/src/components/forms/request-a-presidential-visit-for-a-centenarian-form.tsx
+++ b/src/components/forms/request-a-presidential-visit-for-a-centenarian-form.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import DynamicMultiStepForm from "@/components/forms/builder/multi-step-form";
+import { formSteps } from "@/schema/request-a-presidential-visit-for-a-centenarian";
+
+export default function RequestAPresidentialVisitForACentenarianForm() {
+  return (
+    <DynamicMultiStepForm
+      formSteps={formSteps}
+      ministryName="Office of the President"
+      notificationEmail="testing@govtech.bb"
+      serviceTitle="Request a Presidential Visit for a Centenarian"
+      storageKey="request-a-presidential-visit-for-a-centenarian"
+      submissionMode="serverActionOnly"
+    />
+  );
+}

--- a/src/content/request-a-presidential-visit-for-a-centenarian/index.md
+++ b/src/content/request-a-presidential-visit-for-a-centenarian/index.md
@@ -1,0 +1,42 @@
+---
+title: "Request a Presidential Visit for a Centenarian"
+description: "Ask the President to visit a Barbadian who is turning 100 years old."
+stage: "alpha"
+publish_date: 2026-05-14
+---
+
+Use this service to ask the President, Lieutenant Colonel Jeffrey Bostic, to visit a Barbadian who is turning 100 years old.
+
+> You must submit this request at least 3 months before the birthday.
+
+## What you'll need
+
+- the centenarian's full name and date of birth
+- the centenarian's home address, and the address for the visit if different
+- the name, address, and phone number of the person to contact about the arrangements
+- scans or photos of the required documents
+
+## Documents you'll need to upload
+
+- Original birth certificate with names included (required for all centenarians).
+- Original marriage certificate(s) if she is or has been married (female centenarians only).
+
+If there is a discrepancy in the documents, an affidavit may also be required.
+
+## How to apply
+
+### Apply online
+
+Most people finish this in about 10 minutes.
+
+<a data-start-link href="/pensions-and-gratuities/request-a-presidential-visit-for-a-centenarian/form">Start now</a>
+
+### Apply by post
+
+Write a letter with the centenarian's name, date of birth, home address, visit address (if different), and the name, address, and phone number of the contact person. Include the required original documents and send to:
+
+Private Secretary to the President  
+Office of the President  
+State House  
+Government Hill  
+St Michael

--- a/src/data/content-directory.ts
+++ b/src/data/content-directory.ts
@@ -281,6 +281,19 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
           },
         ],
       },
+      {
+        title: "Request a Presidential Visit for a Centenarian",
+        slug: "request-a-presidential-visit-for-a-centenarian",
+        description:
+          "Ask the President to visit a Barbadian who is turning 100 years old. Submit at least 3 months before the birthday.",
+        subPages: [
+          {
+            slug: "form",
+            title: "Request a Presidential Visit for a Centenarian",
+            type: "component",
+          },
+        ],
+      },
     ],
   },
   {

--- a/src/lib/form-registry.ts
+++ b/src/lib/form-registry.ts
@@ -58,6 +58,12 @@ export const FORM_COMPONENTS = {
   "crop-over-permits": lazy(
     () => import("@/components/forms/crop-over-permits-form")
   ),
+  "request-a-presidential-visit-for-a-centenarian": lazy(
+    () =>
+      import(
+        "@/components/forms/request-a-presidential-visit-for-a-centenarian-form"
+      )
+  ),
   // Add other forms here
 } as const;
 
@@ -86,6 +92,8 @@ export const FORM_STORAGE_KEYS: Record<FormSlug, string> = {
   "calculate-severance-pay": "calculate-severance-pay",
   "calculate-your-pension": "calculate-your-pension",
   "crop-over-permits": "crop-over-permits",
+  "request-a-presidential-visit-for-a-centenarian":
+    "request-a-presidential-visit-for-a-centenarian",
 };
 
 /**

--- a/src/lib/forms/remote-form-schema.ts
+++ b/src/lib/forms/remote-form-schema.ts
@@ -80,7 +80,7 @@ const baseFieldShape = {
   hidden: z.boolean().optional(),
   conditionalOn: conditionalRuleSchema.optional(),
   skipValidationWhenShowHideOpen: z.string().optional(),
-  width: z.enum(["short", "medium", "full"]).optional(),
+  width: z.enum(["short", "medium", "two-thirds", "full"]).optional(),
 };
 
 const textLikeFormFieldSchema = z

--- a/src/lib/schema-generator.ts
+++ b/src/lib/schema-generator.ts
@@ -267,6 +267,14 @@ function createFieldSchema(field: FormField): z.ZodTypeAny {
         case "minYear":
           dateSchema = dateValidation.minYear(dateSchema, rule.year, label);
           break;
+        case "ageRange":
+          dateSchema = dateValidation.ageRange(
+            dateSchema,
+            rule.minAge,
+            rule.maxAge,
+            rule.message
+          );
+          break;
         default: {
           const _exhaustiveCheck: never = rule as never;
           throw new Error(`Unknown date validation type: ${_exhaustiveCheck}`);

--- a/src/lib/validation/date-validation.ts
+++ b/src/lib/validation/date-validation.ts
@@ -254,6 +254,32 @@ export const dateValidation = {
         path: ["year"],
       }
     ),
+
+  ageRange: (
+    schema: ReturnType<typeof createDateSchema>,
+    minAge: number,
+    maxAge: number,
+    message: string
+  ) =>
+    schema.refine(
+      (value) => {
+        const dob = parseAndStrip(value);
+        if (!dob) {
+          return false;
+        }
+        const today = stripTime(new Date());
+        const hasHadBirthdayThisYear =
+          today.getMonth() > dob.getMonth() ||
+          (today.getMonth() === dob.getMonth() &&
+            today.getDate() >= dob.getDate());
+        const age =
+          today.getFullYear() -
+          dob.getFullYear() -
+          (hasHadBirthdayThisYear ? 0 : 1);
+        return age >= minAge && age <= maxAge;
+      },
+      { message }
+    ),
 };
 
 // ? should I move this as a utility in design system, to formate and deformat date?

--- a/src/schema/request-a-presidential-visit-for-a-centenarian.ts
+++ b/src/schema/request-a-presidential-visit-for-a-centenarian.ts
@@ -1,0 +1,320 @@
+import { barbadosParishes, NAME_REGEX, PHONE_REGEX } from "@/data/constants";
+import type { FormStep } from "@/types";
+
+export const formSteps: FormStep[] = [
+  {
+    id: "centenarian-info",
+    title: "Tell us about the centenarian",
+    fields: [
+      {
+        name: "centenarian.fullName",
+        label: "Full name",
+        width: "two-thirds",
+        type: "text",
+        validation: {
+          required: "Enter the centenarian's full name",
+          minLength: {
+            value: 2,
+            message: "Full name must be at least 2 characters",
+          },
+          pattern: {
+            value: NAME_REGEX,
+            message:
+              "Full name must contain only letters, spaces, hyphens, or apostrophes",
+          },
+        },
+      },
+      {
+        name: "centenarian.dateOfBirth",
+        label: "Date of birth",
+        placeholder: "For example, 27 3 1925",
+        type: "date",
+        width: "two-thirds",
+        validation: {
+          required: "Enter the centenarian's date of birth",
+          date: {
+            type: "ageRange",
+            minAge: 99,
+            maxAge: 100,
+            message:
+              "The centenarian must be turning or have turned 100. Check the date of birth is correct.",
+          },
+        },
+      },
+      {
+        name: "centenarian.sex",
+        label: "What is the sex of the centenarian?",
+        hint: "This determines which documents you need to upload.",
+        type: "radio",
+        validation: {
+          required: "Choose male or female",
+        },
+        options: [
+          { label: "Male", value: "male" },
+          { label: "Female", value: "female" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "addresses",
+    title: "Where does the centenarian live?",
+    fields: [
+      {
+        name: "home.addressLine1",
+        label: "Address line 1",
+        type: "text",
+        width: "two-thirds",
+        validation: {
+          required: "Enter the first line of the home address",
+          minLength: {
+            value: 2,
+            message: "Address must be at least 2 characters",
+          },
+        },
+      },
+      {
+        name: "home.addressLine2",
+        label: "Address line 2 (optional)",
+        type: "text",
+        width: "two-thirds",
+        validation: { required: false },
+      },
+      {
+        name: "home.parish",
+        label: "Parish",
+        type: "select",
+        width: "two-thirds",
+        validation: {
+          required: "Choose a parish",
+        },
+        options: barbadosParishes,
+      },
+      {
+        name: "visitSameAddress",
+        label: "Will the visit take place at this address?",
+        type: "radio",
+        validation: {
+          required: "Choose where the visit will take place",
+        },
+        options: [
+          { label: "Yes", value: "yes" },
+          {
+            label: "No — the visit will be at a different address",
+            value: "no",
+          },
+        ],
+        conditionalGroups: {
+          no: { label: "Address for the visit" },
+        },
+      },
+      {
+        name: "visit.addressLine1",
+        label: "Address line 1",
+        type: "text",
+        validation: {
+          required: "Enter the first line of the visit address",
+          minLength: {
+            value: 2,
+            message: "Address must be at least 2 characters",
+          },
+        },
+        conditionalOn: {
+          field: "visitSameAddress",
+          value: "no",
+        },
+      },
+      {
+        name: "visit.addressLine2",
+        label: "Address line 2 (optional)",
+        type: "text",
+        validation: { required: false },
+        conditionalOn: {
+          field: "visitSameAddress",
+          value: "no",
+        },
+      },
+      {
+        name: "visit.parish",
+        label: "Parish",
+        type: "select",
+
+        validation: {
+          required: "Choose a parish for the visit address",
+        },
+        options: barbadosParishes,
+        conditionalOn: {
+          field: "visitSameAddress",
+          value: "no",
+        },
+      },
+    ],
+  },
+  {
+    id: "contact-person",
+    title: "Who should we contact about the arrangements?",
+    description:
+      "Give us the details of the person the Office of the President should contact.",
+    fields: [
+      {
+        name: "contact.fullName",
+        label: "Full name",
+        type: "text",
+        width: "two-thirds",
+        validation: {
+          required: "Enter the contact person's full name",
+          minLength: {
+            value: 2,
+            message: "Full name must be at least 2 characters",
+          },
+          pattern: {
+            value: NAME_REGEX,
+            message:
+              "Full name must contain only letters, spaces, hyphens, or apostrophes",
+          },
+        },
+      },
+      {
+        name: "contact.addressLine1",
+        label: "Address line 1",
+        type: "text",
+        width: "two-thirds",
+        validation: {
+          required: "Enter the contact person's address",
+          minLength: {
+            value: 2,
+            message: "Address must be at least 2 characters",
+          },
+        },
+      },
+      {
+        name: "contact.addressLine2",
+        label: "Address line 2 (optional)",
+        type: "text",
+        width: "two-thirds",
+        validation: { required: false },
+      },
+      {
+        name: "contact.parish",
+        label: "Parish",
+        type: "select",
+        width: "two-thirds",
+        validation: {
+          required: "Choose a parish",
+        },
+        options: barbadosParishes,
+      },
+      {
+        name: "contact.telephoneNumber",
+        label: "Phone number",
+        hint: "For example, 246-555-1234",
+        type: "tel",
+        width: "two-thirds",
+        validation: {
+          required: "Enter a phone number",
+          pattern: {
+            value: PHONE_REGEX,
+            message:
+              "Enter a valid phone number (for example, 246-555-1234 or 1-246-234-5678)",
+          },
+        },
+      },
+      {
+        name: "contact.email",
+        label: "Email address",
+        hint: "We'll send you a confirmation of your request. For example, name@example.com",
+        type: "email",
+        width: "two-thirds",
+        validation: {
+          required: "Enter your email address",
+        },
+      },
+    ],
+  },
+  {
+    id: "upload-documents",
+    title: "Upload your documents",
+    description:
+      "Upload a scan or clear photo. Accepted formats: PDF, JPG, PNG. Max 5MB per file.",
+    inlineNotices: [
+      {
+        afterField: "documents.birthCertificate",
+        title: "If any names differ across documents",
+        body: "An affidavit may be required. The Office of the President will contact you if this is needed.",
+      },
+    ],
+    fields: [
+      {
+        name: "documents.birthCertificate",
+        label: "Birth certificate",
+        hint: "Original birth certificate with names included. Required for all centenarians.",
+        type: "file",
+        validation: {
+          required: "Upload the birth certificate",
+        },
+      },
+      {
+        name: "documents.marriageCertificate",
+        label: "Marriage certificate(s)",
+        hint: "Upload if she is or has been married. Add files one at a time.",
+        type: "file",
+        multiple: true,
+        validation: { required: false },
+        conditionalOn: {
+          field: "centenarian.sex",
+          value: "female",
+        },
+      },
+    ],
+  },
+  {
+    id: "check-your-answers",
+    title: "Check your answers",
+    fields: [],
+  },
+  {
+    id: "declaration",
+    title: "Declaration",
+    fields: [
+      {
+        name: "declaration.confirmed",
+        label:
+          "I confirm that the information I have given is correct to the best of my knowledge, that the request will be received at least 3 months before the birthday, and that the documents I have uploaded are true copies of the originals.",
+        type: "checkbox",
+        validation: {
+          required: "You must confirm the declaration to continue",
+        },
+      },
+      {
+        name: "declaration.dateOfDeclaration",
+        label: "Date of declaration",
+        hidden: true,
+        placeholder: "",
+        type: "date",
+        validation: {
+          required: "Date is required",
+          date: {
+            type: "pastOrToday",
+          },
+        },
+      },
+    ],
+  },
+  {
+    id: "confirmation",
+    title: "Request submitted",
+    fields: [],
+    bodyContent: `## What happens next
+
+The Office of the President will review your request and contact the person you named to discuss the arrangements.
+
+If you don't hear back within 4 weeks, contact the Office of the President directly.
+
+### Need help?
+
+**Office of the President**
+**Address:** State House, Government Hill, St Michael
+`,
+    enableFeedback: true,
+  },
+];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,7 +29,8 @@ export type DateValidationRule =
   | { type: "onOrAfter"; date: string; description?: string }
   | { type: "onOrBefore"; date: string; description?: string }
   | { type: "between"; start: string; end: string; description?: string }
-  | { type: "minYear"; year: number };
+  | { type: "minYear"; year: number }
+  | { type: "ageRange"; minAge: number; maxAge: number; message: string };
 
 export type FieldValidationOperator = {
   condition: "gte";
@@ -126,7 +127,7 @@ export type BaseFormField = {
   /** Field name of a ShowHide state field — when that state is "open", validation is skipped for this field */
   skipValidationWhenShowHideOpen?: string;
   /** Controls the rendered width of the field */
-  width?: "short" | "medium" | "full";
+  width?: "short" | "medium" | "two-thirds" | "full";
 };
 
 /** A date input field with date-specific validation. */
@@ -141,6 +142,12 @@ export type OptionFormField = BaseFormField & {
   validation: NonDateFieldValidation;
   /** The list of selectable options */
   options: SelectOption[];
+  /**
+   * Optional. Groups conditional follow-up fields under a single labelled
+   * container, keyed by the triggering option value. Without this, each
+   * conditional field renders in its own bordered block.
+   */
+  conditionalGroups?: Record<string, { label: string }>;
 };
 
 /** A single yes/no checkbox, or a group when `options` is set. */
@@ -276,6 +283,16 @@ export type RepeatableStepConfig = {
   sharedFields?: string[];
 };
 
+/** Informational callout shown inline between fields in a step. */
+export type InlineNotice = {
+  /** Field name this notice should appear after */
+  afterField: string;
+  /** Bold heading text */
+  title: string;
+  /** Body text shown below the heading */
+  body: string;
+};
+
 /** A single step in a multi-step form wizard. */
 export type FormStep = {
   /** Unique step identifier */
@@ -288,6 +305,8 @@ export type FormStep = {
   description?: string;
   /** Fields to render in this step */
   fields: FormField[];
+  /** Optional informational callouts rendered inline after specific fields */
+  inlineNotices?: InlineNotice[];
   /** Condition that must be met for this step to be visible */
   conditionalOn?: ConditionalRule;
   /** Markdown content for confirmation page body (replaces fields) */


### PR DESCRIPTION
## Summary

- Adds a new form under **Pensions and Gratuities**: *Request a Presidential Visit for a Centenarian*. Schema-driven (lives in `src/schema/`), wired into the existing dynamic form builder, with server-action email submission (notify recipient currently `testing@govtech.bb` — swap before launch).
- Extends the form-builder primitives with small, additive features that other forms can opt into:
  - `ageRange` date validation rule (dynamic window vs today, custom message).
  - `conditionalGroups` on radio fields — group conditional follow-up fields under one labelled bordered container instead of stacked per-field borders.
  - `inlineNotices` on `FormStep` — render an info callout between fields.
  - `width: "two-thirds"` variant alongside `short` / `medium` / `full`.
  - `DeclarationStep` fallback render now respects `hidden: true` on the auto-filled date-of-declaration field (still auto-populates, just doesn't render the input).

## Test plan

- [ ] Visit `/pensions-and-gratuities/request-a-presidential-visit-for-a-centenarian` and confirm the index page renders with "Start now" link
- [ ] Step 1: Date of birth — enter an age outside 99–100 and confirm the message *"The centenarian must be turning or have turned 100. Check the date of birth is correct."* surfaces
- [ ] Step 2: Select "No — the visit will be at a different address" and confirm the three visit-address fields render under a single "Address for the visit" label with one blue left border (not three separate stacked borders)
- [ ] Step 4: Verify the "If any names differ across documents" notice renders below the file upload
- [ ] Step 6 (Declaration): Verify the day/month/year inputs are not shown, only the confirmation checkbox
- [ ] Submit the form and confirm both emails are sent (applicant confirmation to `contact.email`, staff notification to `testing@govtech.bb`)
- [ ] Force an SES failure (e.g. unset `MAIL_FROM`) and confirm the user sees the red "There was a problem submitting your form" banner and stays on the declaration step — they should NOT reach the confirmation page
- [ ] Regression: run an existing form (e.g. Get a Primary School Textbook Grant) and confirm widths, conditional follow-up rendering, and declaration step are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)