### PR TITLE
chore(content-directory): move centenarian visit to Family, birth and relationships

### DIFF
--- a/src/content/request-a-presidential-visit-for-a-centenarian/index.md
+++ b/src/content/request-a-presidential-visit-for-a-centenarian/index.md
@@ -29,7 +29,7 @@ If there is a discrepancy in the documents, an affidavit may also be required.
 
 Most people finish this in about 10 minutes.
 
-<a data-start-link href="/pensions-and-gratuities/request-a-presidential-visit-for-a-centenarian/form">Start now</a>
+<a data-start-link href="/family-birth-relationships/request-a-presidential-visit-for-a-centenarian/form">Start now</a>
 
 ### Apply by post
 

--- a/src/data/content-directory.ts
+++ b/src/data/content-directory.ts
@@ -97,6 +97,19 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
         source_url: "",
         description: "",
       },
+      {
+        title: "Request a Presidential Visit for a Centenarian",
+        slug: "request-a-presidential-visit-for-a-centenarian",
+        description:
+          "Ask the President to visit a Barbadian who is turning 100 years old. Submit at least 3 months before the birthday.",
+        subPages: [
+          {
+            slug: "form",
+            title: "Request a Presidential Visit for a Centenarian",
+            type: "component",
+          },
+        ],
+      },
     ],
   },
   {
@@ -290,19 +303,6 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
           {
             slug: "form",
             title: "Pension calculator",
-            type: "component",
-          },
-        ],
-      },
-      {
-        title: "Request a Presidential Visit for a Centenarian",
-        slug: "request-a-presidential-visit-for-a-centenarian",
-        description:
-          "Ask the President to visit a Barbadian who is turning 100 years old. Submit at least 3 months before the birthday.",
-        subPages: [
-          {
-            slug: "form",
-            title: "Request a Presidential Visit for a Centenarian",
             type: "component",
           },
         ],


### PR DESCRIPTION
## Summary

- Moves "Request a Presidential Visit for a Centenarian" out of **Pensions and Gratuities** and into **Family, birth and relationships**, placing it alongside other life-event entries (births, deaths, marriages).
- Updates the "Start now" link in [src/content/request-a-presidential-visit-for-a-centenarian/index.md](src/content/request-a-presidential-visit-for-a-centenarian/index.md) so the form URL tracks the new parent category (`/family-birth-relationships/...` instead of `/pensions-and-gratuities/...`).

## URL change

- Old: `/pensions-and-gratuities/request-a-presidential-visit-for-a-centenarian`
- New: `/family-birth-relationships/request-a-presidential-visit-for-a-centenarian`

Anyone who bookmarked or shared the old URL will land on a 404. Worth deciding whether to add a redirect.

## Test plan

- [ ] On the preview deploy, navigate to **Family, birth and relationships** and confirm the centenarian entry is listed
- [ ] Confirm it no longer appears under **Pensions and Gratuities**
- [ ] Open the centenarian page and click **Start now** — verify it routes to `/family-birth-relationships/request-a-presidential-visit-for-a-centenarian/form` and the form renders
- [ ] Hit the old URL (`/pensions-and-gratuities/request-a-presidential-visit-for-a-centenarian`) and confirm it 404s (or redirects, if redirect is added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)