### PR TITLE
fix(husky): pre-commit hook no longer stashes or formats outside staged set

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,68 +1,54 @@
 #!/bin/sh
-# Exit on any error
+# Pre-commit hook — format files staged for this commit via Ultracite,
+# then re-stage them so any auto-fixes land in the commit.
+#
+# Design notes
+# ────────────
+# - Only operates on files staged for this commit, by passing them explicitly
+#   to `ultracite fix`. The previous hook ran `npx ultracite fix` with no
+#   arguments, which formats the whole project — that pulled unrelated files
+#   into the worktree and caused stash conflicts during restore.
+#
+# - The working tree is never reset to match the index, and `git stash` is
+#   never used. The previous hook used `git stash push --keep-index` and a
+#   later `git stash pop`; because `ultracite fix` modified files outside the
+#   staged set, the pop hit conflicts and dropped literal `<<<<<<<` markers
+#   into source files.
+#
+# - Partially-staged files (file has both staged and unstaged hunks) are
+#   refused with a clear message rather than handled silently. Auto-formatting
+#   a partially-staged file would sweep the unstaged hunks into the commit.
+#
+# - The commit is blocked if Ultracite returns non-zero (unfixable lint
+#   errors), thanks to `set -e` propagating through the pipeline.
+
 set -e
 
-# Check if there are any staged files
-if [ -z "$(git diff --cached --name-only)" ]; then
-  echo "No staged files to format"
-  exit 0
-fi
-
-# Store the hash of staged changes to detect modifications
-STAGED_HASH=$(git diff --cached | sha256sum | cut -d' ' -f1)
-
-# Save list of staged files (handling all file states)
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR)
-PARTIALLY_STAGED=$(git diff --name-only)
+[ -z "$STAGED_FILES" ] && exit 0
 
-# Stash unstaged changes to preserve working directory
-# --keep-index keeps staged changes in working tree
-git stash push --quiet --keep-index --message "pre-commit-stash" || true
-STASHED=$?
+# Limit to file types Biome / Ultracite handles. Other staged files are
+# committed untouched.
+FORMATTABLE=$(printf '%s\n' "$STAGED_FILES" |
+  grep -E '\.(js|jsx|ts|tsx|mjs|cjs|json|jsonc)$' || true)
+[ -z "$FORMATTABLE" ] && exit 0
 
-# Run formatter on the staged files
-npx ultracite fix
-FORMAT_EXIT_CODE=$?
-
-# Restore working directory state
-if [ $STASHED -eq 0 ]; then
-  # Re-stage the formatted files
-  if [ -n "$STAGED_FILES" ]; then
-    echo "$STAGED_FILES" | while IFS= read -r file; do
-      if [ -f "$file" ]; then
-        git add "$file"
-      fi
-    done
-  fi
-  
-  # Restore unstaged changes
-  git stash pop --quiet || true
-  
-  # Restore partial staging if files were partially staged
-  if [ -n "$PARTIALLY_STAGED" ]; then
-    for file in $PARTIALLY_STAGED; do
-      if [ -f "$file" ] && echo "$STAGED_FILES" | grep -q "^$file$"; then
-        # File was partially staged - need to unstage the unstaged parts
-        git restore --staged "$file" 2>/dev/null || true
-        git add -p "$file" < /dev/null 2>/dev/null || git add "$file"
-      fi
-    done
-  fi
-else
-  # No stash was created, just re-add the formatted files
-  if [ -n "$STAGED_FILES" ]; then
-    echo "$STAGED_FILES" | while IFS= read -r file; do
-      if [ -f "$file" ]; then
-        git add "$file"
-      fi
-    done
+# Refuse to format files that are partially staged. Anything in both
+# `git diff --cached --name-only` and `git diff --name-only` has mixed state.
+UNSTAGED=$(git diff --name-only)
+if [ -n "$UNSTAGED" ]; then
+  PARTIAL=$(printf '%s\n%s\n' "$FORMATTABLE" "$UNSTAGED" | sort | uniq -d)
+  if [ -n "$PARTIAL" ]; then
+    printf '✋ Pre-commit: refusing to auto-format partially-staged files:\n'
+    printf '%s\n' "$PARTIAL" | sed 's/^/   /'
+    printf '\nStage all your changes (git add <file>) or stash unstaged work, then retry.\n'
+    exit 1
   fi
 fi
 
-# Check if staged files actually changed
-NEW_STAGED_HASH=$(git diff --cached | sha256sum | cut -d' ' -f1)
-if [ "$STAGED_HASH" != "$NEW_STAGED_HASH" ]; then
-  echo "✨ Files formatted by Ultracite"
-fi
+# Format the staged files in place, then re-stage. NUL-separated input keeps
+# us safe against filenames containing spaces.
+printf '%s\n' "$FORMATTABLE" | tr '\n' '\0' | xargs -0 npx ultracite fix
+printf '%s\n' "$FORMATTABLE" | tr '\n' '\0' | xargs -0 git add
 
-exit $FORMAT_EXIT_CODE
+printf '✨ Ultracite formatted staged files\n'


### PR DESCRIPTION
## Summary

Two bugs in `.husky/pre-commit` combined to corrupt working trees on commit (e.g. https://github.com/govtech-bb/frontend-alpha/pull/587 hit this and had to be committed with `--no-verify`):

1. **Whole-project formatting.** `npx ultracite fix` was invoked with no arguments, so Ultracite reformatted every JS/TS/JSON file in the repo — including files outside the staged set.
2. **Stash race.** The hook used `git stash push --keep-index` before formatting and `git stash pop` afterwards. With the working tree now containing Ultracite's edits to unrelated files, the pop produced merge conflicts on those files and dropped literal `<<<<<<<` markers into source. The cleanup branches were also unreachable because `set -e` short-circuited their `$?` captures.

This PR replaces the hook with a minimal, lint-staged-style implementation:

- Passes **only the staged JS/TS/JSON files explicitly** to `ultracite fix`. Ultracite never touches files outside the commit.
- **Refuses partially-staged files** (intersection of `git diff --cached --name-only` and `git diff --name-only`) with a clear actionable message, instead of trying to reconcile staged vs unstaged versions of the same file.
- **Drops `git stash` entirely.** The working tree is never reset to match the index, so unstaged changes are never at risk.
- Uses NUL-separated input to `xargs` for filenames with spaces.
- Relies on `set -e` to propagate Ultracite's non-zero exit so unfixable lint errors still block the commit.

The commit on this branch (`acd55487`) was created with the **new** hook active — Ultracite skipped it correctly (shell scripts aren't in the file-extension filter), so the hook successfully no-op'd on its own commit.

## Test plan

Smoke tests run in a temp git repo with the new hook installed:

- [x] **No staged files** → hook exits 0 silently.
- [x] **Non-JS staged** (`README.md`) → hook exits 0 silently.
- [x] **Partially-staged JS file** (staged hunk + later unstaged edit) → hook prints `✋ refusing to auto-format partially-staged files: <file>` and exits 1.
- [x] **Happy path** (poorly-formatted `.ts` file staged): hook runs `ultracite fix`, file is reformatted in place (`const x  =   1; export {x};` → `const x = 1;\n\nexport { x };`), re-staged, exit 0.
- [x] **Self-test**: this branch's own commit went through the new hook with no `--no-verify`.
- [x] `sh -n .husky/pre-commit` syntax check passes.

## Notes

- Behaviour change worth flagging: partially-staged files are now **refused** rather than auto-handled. The previous hook silently tried to preserve partial staging via `git restore --staged` + `git add -p < /dev/null`, which never actually restored the unstaged hunks correctly anyway. The new error message tells the user what to do.
- The `package-lock.json` peer-dependency-metadata drift that has been around all session is still uncommitted in your tree — left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)