### PR TITLE
RELEASE 2026-05-15 part 1

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,68 +1,54 @@
 #!/bin/sh
-# Exit on any error
+# Pre-commit hook — format files staged for this commit via Ultracite,
+# then re-stage them so any auto-fixes land in the commit.
+#
+# Design notes
+# ────────────
+# - Only operates on files staged for this commit, by passing them explicitly
+#   to `ultracite fix`. The previous hook ran `npx ultracite fix` with no
+#   arguments, which formats the whole project — that pulled unrelated files
+#   into the worktree and caused stash conflicts during restore.
+#
+# - The working tree is never reset to match the index, and `git stash` is
+#   never used. The previous hook used `git stash push --keep-index` and a
+#   later `git stash pop`; because `ultracite fix` modified files outside the
+#   staged set, the pop hit conflicts and dropped literal `<<<<<<<` markers
+#   into source files.
+#
+# - Partially-staged files (file has both staged and unstaged hunks) are
+#   refused with a clear message rather than handled silently. Auto-formatting
+#   a partially-staged file would sweep the unstaged hunks into the commit.
+#
+# - The commit is blocked if Ultracite returns non-zero (unfixable lint
+#   errors), thanks to `set -e` propagating through the pipeline.
+
 set -e
 
-# Check if there are any staged files
-if [ -z "$(git diff --cached --name-only)" ]; then
-  echo "No staged files to format"
-  exit 0
-fi
-
-# Store the hash of staged changes to detect modifications
-STAGED_HASH=$(git diff --cached | sha256sum | cut -d' ' -f1)
-
-# Save list of staged files (handling all file states)
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR)
-PARTIALLY_STAGED=$(git diff --name-only)
+[ -z "$STAGED_FILES" ] && exit 0
 
-# Stash unstaged changes to preserve working directory
-# --keep-index keeps staged changes in working tree
-git stash push --quiet --keep-index --message "pre-commit-stash" || true
-STASHED=$?
+# Limit to file types Biome / Ultracite handles. Other staged files are
+# committed untouched.
+FORMATTABLE=$(printf '%s\n' "$STAGED_FILES" |
+  grep -E '\.(js|jsx|ts|tsx|mjs|cjs|json|jsonc)$' || true)
+[ -z "$FORMATTABLE" ] && exit 0
 
-# Run formatter on the staged files
-npx ultracite fix
-FORMAT_EXIT_CODE=$?
-
-# Restore working directory state
-if [ $STASHED -eq 0 ]; then
-  # Re-stage the formatted files
-  if [ -n "$STAGED_FILES" ]; then
-    echo "$STAGED_FILES" | while IFS= read -r file; do
-      if [ -f "$file" ]; then
-        git add "$file"
-      fi
-    done
-  fi
-  
-  # Restore unstaged changes
-  git stash pop --quiet || true
-  
-  # Restore partial staging if files were partially staged
-  if [ -n "$PARTIALLY_STAGED" ]; then
-    for file in $PARTIALLY_STAGED; do
-      if [ -f "$file" ] && echo "$STAGED_FILES" | grep -q "^$file$"; then
-        # File was partially staged - need to unstage the unstaged parts
-        git restore --staged "$file" 2>/dev/null || true
-        git add -p "$file" < /dev/null 2>/dev/null || git add "$file"
-      fi
-    done
-  fi
-else
-  # No stash was created, just re-add the formatted files
-  if [ -n "$STAGED_FILES" ]; then
-    echo "$STAGED_FILES" | while IFS= read -r file; do
-      if [ -f "$file" ]; then
-        git add "$file"
-      fi
-    done
+# Refuse to format files that are partially staged. Anything in both
+# `git diff --cached --name-only` and `git diff --name-only` has mixed state.
+UNSTAGED=$(git diff --name-only)
+if [ -n "$UNSTAGED" ]; then
+  PARTIAL=$(printf '%s\n%s\n' "$FORMATTABLE" "$UNSTAGED" | sort | uniq -d)
+  if [ -n "$PARTIAL" ]; then
+    printf '✋ Pre-commit: refusing to auto-format partially-staged files:\n'
+    printf '%s\n' "$PARTIAL" | sed 's/^/   /'
+    printf '\nStage all your changes (git add <file>) or stash unstaged work, then retry.\n'
+    exit 1
   fi
 fi
 
-# Check if staged files actually changed
-NEW_STAGED_HASH=$(git diff --cached | sha256sum | cut -d' ' -f1)
-if [ "$STAGED_HASH" != "$NEW_STAGED_HASH" ]; then
-  echo "✨ Files formatted by Ultracite"
-fi
+# Format the staged files in place, then re-stage. NUL-separated input keeps
+# us safe against filenames containing spaces.
+printf '%s\n' "$FORMATTABLE" | tr '\n' '\0' | xargs -0 npx ultracite fix
+printf '%s\n' "$FORMATTABLE" | tr '\n' '\0' | xargs -0 git add
 
-exit $FORMAT_EXIT_CODE
+printf '✨ Ultracite formatted staged files\n'

--- a/src/app/(content)/[...slug]/page.tsx
+++ b/src/app/(content)/[...slug]/page.tsx
@@ -215,7 +215,13 @@ export default async function Page({ params }: ContentPageProps) {
 
     // Handle form pages (JSX components)
     if (subPageSlug === "form") {
-      return <DynamicFormLoader formSlug={pageSlug} />;
+      return (
+        <DynamicFormLoader
+          formSlug={pageSlug}
+          notificationCc={process.env.TEST_NOTIFICATION_EMAIL_COPY ?? null}
+          notificationEmail={process.env.TEST_NOTIFICATION_EMAIL ?? null}
+        />
+      );
     }
 
     // Handle other sub-pages (markdown)
@@ -288,7 +294,12 @@ export default async function Page({ params }: ContentPageProps) {
           }
         >
           <YouthOpportunityForm
-            notificationEmail={opportunity.contact?.email ?? null}
+            notificationCc={process.env.TEST_NOTIFICATION_EMAIL_COPY ?? null}
+            notificationEmail={
+              process.env.TEST_NOTIFICATION_EMAIL ??
+              opportunity.contact?.email ??
+              null
+            }
             opportunityId={opportunity.id}
             opportunityTitle={opportunity.title}
           />

--- a/src/app/actions/send-form-submission-emails.tsx
+++ b/src/app/actions/send-form-submission-emails.tsx
@@ -26,6 +26,7 @@ const submissionEmailPayloadSchema = z.object({
   formData: z.record(z.string(), z.unknown()),
   applicantEmail: z.string().email().nullable(),
   notificationEmail: z.string().email().nullable(),
+  notificationCc: z.array(z.string().email()).optional(),
   ministryName: z.string().optional(),
 });
 
@@ -174,11 +175,13 @@ function flattenDataForEmail(
 
 async function sendEmail({
   to,
+  cc,
   subject,
   html,
   referenceNumber,
 }: {
   to: string;
+  cc?: string[];
   subject: string;
   html: string;
   referenceNumber: string;
@@ -188,6 +191,9 @@ async function sendEmail({
   log("INFO", "ses.send.attempt", {
     referenceNumber,
     recipient: maskEmail(to),
+    cc: cc?.length
+      ? cc.map((address) => maskEmail(address)).join(",")
+      : "(none)",
     subject,
     fromAddress: maskEmail(mailFrom),
     configurationSet: configurationSet ?? "(none)",
@@ -196,7 +202,10 @@ async function sendEmail({
 
   const command = new SendEmailCommand({
     FromEmailAddress: mailFrom,
-    Destination: { ToAddresses: [to] },
+    Destination: {
+      ToAddresses: [to],
+      ...(cc?.length ? { CcAddresses: cc } : {}),
+    },
     ...(configurationSet && {
       ConfigurationSetName: configurationSet,
       ...(tagKey &&
@@ -217,6 +226,9 @@ async function sendEmail({
   log("INFO", "ses.send.success", {
     referenceNumber,
     recipient: maskEmail(to),
+    cc: cc?.length
+      ? cc.map((address) => maskEmail(address)).join(",")
+      : "(none)",
     subject,
     messageId: response.MessageId ?? "(unknown)",
     durationMs: Date.now() - sendStart,
@@ -318,6 +330,7 @@ export async function sendFormSubmissionEmails(
     formName,
     ministryName,
     notificationEmail,
+    notificationCc,
     referenceNumber,
   } = parsed.data;
 
@@ -372,6 +385,7 @@ export async function sendFormSubmissionEmails(
 
   const resolvedApplicantEmail = safeTestEmail ?? applicantEmail;
   const resolvedNotificationEmail = safeTestEmail ?? notificationEmail;
+  const resolvedNotificationCc = safeTestEmail ? undefined : notificationCc;
 
   if (safeTestEmail) {
     log("WARN", "sendFormSubmissionEmails.email_override_active", {
@@ -413,11 +427,15 @@ export async function sendFormSubmissionEmails(
     log("INFO", "sendFormSubmissionEmails.queuing_notification", {
       referenceNumber,
       recipient: maskEmail(resolvedNotificationEmail),
+      cc: resolvedNotificationCc?.length
+        ? resolvedNotificationCc.map((address) => maskEmail(address)).join(",")
+        : "(none)",
     });
     sendTasks.push({
       label: `staff notification to ${resolvedNotificationEmail}`,
       promise: sendEmail({
         to: resolvedNotificationEmail,
+        cc: resolvedNotificationCc,
         subject: `New submission: ${formName} (${referenceNumber})`,
         html: notificationHtml,
         referenceNumber,

--- a/src/app/youth/opportunities/[id]/form/_components/youth-opportunity-form.tsx
+++ b/src/app/youth/opportunities/[id]/form/_components/youth-opportunity-form.tsx
@@ -8,12 +8,14 @@ interface Props {
   opportunityId: string;
   opportunityTitle: string;
   notificationEmail: string | null;
+  notificationCc?: string | null;
 }
 
 export function YouthOpportunityForm({
   opportunityId,
   opportunityTitle,
   notificationEmail,
+  notificationCc = null,
 }: Props) {
   const formSteps = buildYouthOpportunityFormSteps(opportunityTitle);
   const programmeCode = getYouthOpportunityServiceCode(opportunityId);
@@ -25,6 +27,7 @@ export function YouthOpportunityForm({
       continueOnEmailFailure
       formSteps={formSteps}
       ministryName="Ministry of Youth, Sports and Community Empowerment"
+      notificationCc={notificationCc}
       notificationEmail={notificationEmail}
       serviceTitle={`Apply for ${opportunityTitle}`}
       storageKey={`youth-opportunity-${opportunityId}`}

--- a/src/app/youth/opportunities/[id]/form/page.tsx
+++ b/src/app/youth/opportunities/[id]/form/page.tsx
@@ -66,7 +66,12 @@ export default async function YouthOpportunityFormPage({
       }
     >
       <YouthOpportunityForm
-        notificationEmail={opportunity.contact?.email ?? null}
+        notificationCc={process.env.TEST_NOTIFICATION_EMAIL_COPY ?? null}
+        notificationEmail={
+          process.env.TEST_NOTIFICATION_EMAIL ??
+          opportunity.contact?.email ??
+          null
+        }
         opportunityId={opportunity.id}
         opportunityTitle={opportunity.title}
       />

--- a/src/components/dynamic-form-loader.tsx
+++ b/src/components/dynamic-form-loader.tsx
@@ -6,9 +6,15 @@ import { NoScriptMessage } from "./no-script-message";
 
 interface DynamicFormLoaderProps {
   formSlug: string;
+  notificationEmail?: string | null;
+  notificationCc?: string | null;
 }
 
-export function DynamicFormLoader({ formSlug }: DynamicFormLoaderProps) {
+export function DynamicFormLoader({
+  formSlug,
+  notificationEmail = null,
+  notificationCc = null,
+}: DynamicFormLoaderProps) {
   const FormComponent = FORM_COMPONENTS[formSlug as FormSlug];
 
   if (!FormComponent) {
@@ -23,7 +29,10 @@ export function DynamicFormLoader({ formSlug }: DynamicFormLoaderProps) {
       </noscript>
       <div className="js-only">
         <Suspense fallback={<div className="container">Loading form...</div>}>
-          <FormComponent />
+          <FormComponent
+            notificationCc={notificationCc}
+            notificationEmail={notificationEmail}
+          />
         </Suspense>
       </div>
     </>

--- a/src/components/forms/builder/multi-step-form.tsx
+++ b/src/components/forms/builder/multi-step-form.tsx
@@ -252,32 +252,49 @@ function normalizeDates(value: unknown): unknown {
 function buildWebhookFormData(
   data: Record<string, unknown>
 ): Record<string, unknown> {
-  const HOISTED_KEYS = new Set(["firstName", "lastName", "email", "phone"]);
-  const {
-    applicant: applicantRaw,
-    declaration: _omitDeclaration,
-    ...rest
-  } = data;
+  // Receiver expects a flat form_data object (e.g. { parish: "..." }) rather
+  // than a nested one (e.g. { applicant: { parish: "..." } }). Hoist the
+  // inner fields of each top-level namespace (applicant, interest, etc.) to
+  // the top level of form_data. Skip:
+  //  - `declaration` entirely (operational metadata; not part of application
+  //    content)
+  //  - applicant.firstName / lastName / email / phone (already represented
+  //    on the top-level `applicant` block)
+  const APPLICANT_HOISTED_TO_TOP = new Set([
+    "firstName",
+    "lastName",
+    "email",
+    "phone",
+  ]);
+  const result: Record<string, unknown> = {};
 
-  const normalizedRest = normalizeDates(rest) as Record<string, unknown>;
+  for (const [namespaceKey, namespaceValue] of Object.entries(data)) {
+    if (namespaceKey === "declaration") {
+      continue;
+    }
 
-  if (!applicantRaw || typeof applicantRaw !== "object") {
-    return normalizedRest;
-  }
-
-  const trimmedApplicant: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(
-    applicantRaw as Record<string, unknown>
-  )) {
-    if (!HOISTED_KEYS.has(key)) {
-      trimmedApplicant[key] = normalizeDates(value);
+    if (
+      namespaceValue &&
+      typeof namespaceValue === "object" &&
+      !Array.isArray(namespaceValue)
+    ) {
+      for (const [innerKey, innerValue] of Object.entries(
+        namespaceValue as Record<string, unknown>
+      )) {
+        if (
+          namespaceKey === "applicant" &&
+          APPLICANT_HOISTED_TO_TOP.has(innerKey)
+        ) {
+          continue;
+        }
+        result[innerKey] = normalizeDates(innerValue);
+      }
+    } else {
+      result[namespaceKey] = normalizeDates(namespaceValue);
     }
   }
 
-  if (Object.keys(trimmedApplicant).length > 0) {
-    return { ...normalizedRest, applicant: trimmedApplicant };
-  }
-  return normalizedRest;
+  return result;
 }
 
 /**

--- a/src/components/forms/builder/multi-step-form.tsx
+++ b/src/components/forms/builder/multi-step-form.tsx
@@ -542,6 +542,8 @@ interface DynamicMultiStepFormProps {
   serviceTitle: string;
   storageKey?: string;
   notificationEmail?: string | null;
+  /** Additional addresses copied on staff-notification emails only (not on applicant confirmations). */
+  notificationCc?: string | string[] | null;
   ministryName?: string | null;
   submissionMode?: "api" | "serverActionOnly";
   /** Overrides pathname segment[0] for analytics when the form is not under IA routes. */
@@ -567,6 +569,7 @@ export default function DynamicMultiStepForm({
   serviceTitle,
   storageKey = "multi-step-form-storage",
   notificationEmail = null,
+  notificationCc = null,
   ministryName = null,
   submissionMode = "api",
   analyticsCategory,
@@ -1079,6 +1082,11 @@ export default function DynamicMultiStepForm({
             formName: serviceTitle,
             ministryName: ministryName ?? undefined,
             notificationEmail,
+            notificationCc: notificationCc
+              ? Array.isArray(notificationCc)
+                ? notificationCc
+                : [notificationCc]
+              : undefined,
             referenceNumber: generatedReferenceNumber,
           });
           if (!emailResult.success) {
@@ -1164,6 +1172,11 @@ export default function DynamicMultiStepForm({
             formName: serviceTitle,
             ministryName: ministryName ?? undefined,
             notificationEmail,
+            notificationCc: notificationCc
+              ? Array.isArray(notificationCc)
+                ? notificationCc
+                : [notificationCc]
+              : undefined,
             referenceNumber,
           });
           if (!emailResult.success) {

--- a/src/components/forms/request-a-presidential-visit-for-a-centenarian-form.tsx
+++ b/src/components/forms/request-a-presidential-visit-for-a-centenarian-form.tsx
@@ -3,12 +3,21 @@
 import DynamicMultiStepForm from "@/components/forms/builder/multi-step-form";
 import { formSteps } from "@/schema/request-a-presidential-visit-for-a-centenarian";
 
-export default function RequestAPresidentialVisitForACentenarianForm() {
+interface Props {
+  notificationEmail?: string | null;
+  notificationCc?: string | null;
+}
+
+export default function RequestAPresidentialVisitForACentenarianForm({
+  notificationEmail = null,
+  notificationCc = null,
+}: Props = {}) {
   return (
     <DynamicMultiStepForm
       formSteps={formSteps}
       ministryName="Office of the President"
-      notificationEmail="testing@govtech.bb"
+      notificationCc={notificationCc}
+      notificationEmail={notificationEmail}
       serviceTitle="Request a Presidential Visit for a Centenarian"
       storageKey="request-a-presidential-visit-for-a-centenarian"
       submissionMode="serverActionOnly"

--- a/src/content/terms-conditions.md
+++ b/src/content/terms-conditions.md
@@ -12,7 +12,7 @@ All content on this website is and shall remain the sole and exclusive property 
 
 ### Disclaimer of Warranties
 
-GOV.BB operates this site to inform users as to our various services, projects, how to communicate with us, and other information about our company. The information contained herein is not intended as a substitute for qualified technical or engineering services and under no circumstances shall be deemed to constitute such services. Users should also note that Internet software including, but not limited to, browsers or even transmission problems can produce inaccurate or incomplete copies of documents when downloaded and displayed on a user's computer.
+GOV.BB operates this site to inform users as to our various services, projects, how to communicate with us, and other information about the Government of Barbados. The information contained herein is not intended as a substitute for qualified technical or engineering services and under no circumstances shall be deemed to constitute such services. Users should also note that Internet software including, but not limited to, browsers or even transmission problems can produce inaccurate or incomplete copies of documents when downloaded and displayed on a user's computer.
 
 GOV.BB makes no warranties or representations of any kind, whether express or implied, as to the validity, accuracy, or reliability of any of the content found herein or on any other websites linked to or from this website. Any and all information contained herein or in such other websites is provided "AS IS" and without warranties of any kind, whether express or implied.
 
@@ -24,97 +24,35 @@ As a convenience to the user, certain links in this website will connect the u
 
 As consideration for any use of this website, including merely accessing the website, you agree to be bound by the laws of Barbados, without regard to any conflicts of law principles. You further agree to be subject to the jurisdiction of any of the courts of Barbados for any dispute relating in any way to your use of this website.
 
-### Data Protection and Privacy
+### Your Data
 
-This website is operated by the Ministry of Innovation, Science and Smart Technology, which acts as the Data Controller for personal information collected through alpha.gov.bb. We process personal information in accordance with the Data Protection Act 2019 of Barbados.
+alpha.gov.bb is run by the Ministry of Innovation, Science and Smart Technology. We handle your information under the Data Protection Act 2019.
 
-The sections below describe what information we collect, where it is stored, how long we keep it, and the rights available to you under the Act.
+### What we collect
 
-### Information We Collect
+What you type into an application form, any files you upload, payment details you enter on EZpay+, and basic analytics about how the site is used.
 
-When you use this website to apply for a government service, we may collect:
+### Where it's stored
 
-- Personal identification details that you enter into an application form (for example: name, date of birth, national identification number, contact details, address)
-- Information about other persons named in an application (for example: a deceased relative on a post office redirection, a child on a textbook grant)
-- Supporting documents and images that you choose to upload as attachments
-- Payment details required to complete a transaction, processed through the Government of Barbados EZpay+ platform
-- Technical information about your visit, including pages viewed, form interactions, time spent, and device information used to improve the service
-- Feedback that you choose to submit through the website
+The site runs on Amazon Web Services in the United States. This means your information leaves Barbados to be processed.
 
-We collect only the information needed to process the service you are requesting or to operate, secure, and improve the website.
+- **Forms without payment** are emailed straight to the relevant Ministry, Department or Agency. We don't keep a copy.
+- **Forms with payment** are encrypted and held only until payment goes through, then deleted. Anything left unpaid for 72 hours is deleted automatically.
+- **Uploaded files** pass through our storage for the few seconds it takes to attach them to your application.
+- **Payment records** (your name, email, amount, transaction number) are kept for accounting and audit. They don't include what you wrote in the form.
+- **Error logs and analytics** never contain the values you type. Email addresses in logs are masked.
+- **Partly filled forms** live only in your own browser so you can go back a step without losing your work.
 
-### Where Your Data Is Stored
+### Cookies
 
-Personal information submitted through alpha.gov.bb is processed using cloud services provided by Amazon Web Services (AWS) in the United States (the `us-east-1` region). The categories of storage are:
+We use your browser's session storage to remember your progress through a form. We don't use tracking cookies.
 
-- **Application form data submitted for services that do not require payment** is transmitted to the Government's form-processing service, validated, sent by email to the relevant Ministry, Department or Agency (MDA), and is **not retained** by alpha.gov.bb after the email has been sent.
-- **Application form data submitted for services that require payment** is held in an encrypted form in a PostgreSQL database for the limited period needed to complete the payment. Once payment is successful and the MDA has been notified by email, the encrypted application data is deleted from the database. If payment is not completed within 72 hours, the encrypted application data is automatically deleted by a scheduled cleanup process.
-- **Supporting documents and uploaded attachments** are transmitted to AWS Simple Storage Service (S3) for the limited time needed to attach them to your application. In normal operation this is a matter of seconds.
-- **Payment records** — including your name, email address, the amount paid, the payment method, the transaction number and the payment status — are retained in the payment database for accounting, audit and reconciliation purposes. Payment records do not contain the contents of the application form.
-- **Emails** containing your submission are sent to the relevant MDA through Amazon Simple Email Service (SES). The MDA's email retention policy applies once the email is received.
-- **Operational logs** are recorded by Amazon CloudWatch and by Sentry to allow us to diagnose errors and to monitor the health of the service. Email addresses appearing in logs are masked (for example, "us***@domain.com").
-- **Analytics events** (page views, form-step progress, durations and validation error counts) are recorded by Umami. Analytics events do not include the values you type into form fields.
-- **Partially completed forms** are stored only in your own web browser (in session storage) so that you can navigate between steps without losing your progress. This data is cleared when you close the browser tab, submit the form, or visit the start page for that service.
+### Your rights
 
-### Cross-Border Transfer of Information
+Under the Data Protection Act 2019 you can ask to see, correct or delete the information we hold about you, and you can complain to the Data Protection Commissioner.
 
-Because alpha.gov.bb is hosted on AWS infrastructure in the United States, personal information you submit through this website is transferred outside of Barbados for processing. The transfer is made under the contractual safeguards offered by AWS, which is certified to international standards including ISO 27001 and SOC 2. We make this transfer in order to deliver the digital services available through this website. By submitting information through the website you acknowledge this transfer.
+Contact: **privacy@govtech.bb**
 
-### How Long We Keep Your Information
+### Changes
 
-| Category of information | Retention period |
-| --- | --- |
-| Application form data (non-payment services) | Not retained after the notification email is sent to the MDA |
-| Application form data (payment services, before payment) | Held encrypted until payment is completed, or up to 72 hours if abandoned |
-| Application form data (payment services, after payment) | Deleted once the MDA has been notified by email |
-| Uploaded supporting documents | Retained only for the time needed to process the application (typically seconds) |
-| Payment records (name, email, amount, status, transaction number) | Retained for as long as required by applicable accounting and audit obligations |
-| Confirmation and notification emails | Retained by the MDA in accordance with that MDA's records policy |
-| Operational logs (CloudWatch, Sentry) | Retained according to standard log-retention periods; identifiers are masked |
-| Analytics events (Umami) | Retained in aggregate form to support service improvement |
-| Session storage on your device | Cleared when you close the browser tab, submit the form, or visit the start page |
-
-Once the MDA has received your application, that MDA becomes responsible for the further processing and retention of your information under its own records management policy.
-
-### Cookies and Browser Storage
-
-This website uses a small number of technologies that store information in your browser:
-
-- **Session storage** is used by online application forms to remember your progress between steps. This data never leaves your device unless you choose to submit the form.
-- **A research-access cookie** may be set when you follow a private invitation link to take part in user research. The cookie is HTTP-only, expires after 24 hours, and only grants access to a research form; it does not identify you.
-- **Analytics** uses a privacy-respecting analytics service (Umami) that does not set tracking cookies on your device for cross-site profiling. Analytics measurements use technical signals only.
-
-You can clear browser storage at any time using your browser's settings.
-
-### Your Rights Under the Data Protection Act 2019
-
-The Data Protection Act 2019 gives you rights in relation to the personal information that we hold about you. These include:
-
-- The right to be informed about how your information is used (this notice)
-- The right of access to the information we hold about you
-- The right to request correction of information that is inaccurate or incomplete
-- The right to request erasure of your information where the lawful basis for processing it no longer applies
-- The right to restrict or object to certain types of processing
-- The right not to be subject to a decision based solely on automated processing
-- The right to lodge a complaint with the Data Protection Commissioner
-
-To exercise any of these rights, contact us using the details below. We may need to verify your identity before responding so that we do not disclose information to the wrong person. If you are not satisfied with our response, you may contact the Office of the Data Protection Commissioner of Barbados.
-
-### Security
-
-We protect your information using a combination of technical and organisational measures, including encryption of application data while it is stored in the payment workflow, encrypted connections (HTTPS) between your browser and the website, masking of identifiers in our logs, and access controls on the systems that hold payment records. No method of transmission or storage over the internet is completely secure, and we cannot guarantee absolute security.
-
-### Lawful Basis for Processing
-
-We process your personal information on the basis that the processing is necessary for the performance of a task carried out in the public interest or in the exercise of official authority vested in the Government of Barbados, and, where applicable, on the basis of your consent (for example, when you choose to provide feedback or take part in user research).
-
-### Contact
-
-Questions about this notice, requests to exercise your rights under the Data Protection Act 2019, or concerns about how your information has been handled should be sent to:
-
-**Email:** privacy@govtech.bb
-**Data Controller:** Ministry of Innovation, Science and Smart Technology, Government of Barbados
-
-### Changes to This Notice
-
-alpha.gov.bb is an alpha service that is being actively developed. We may update this notice from time to time to reflect changes to the services we offer, the systems that support them, or the law. Material changes will be published on this page with an updated publication date.
+alpha.gov.bb is still in alpha and changes often. We'll update this page when how we handle your data changes.

--- a/src/content/terms-conditions.md
+++ b/src/content/terms-conditions.md
@@ -1,7 +1,7 @@
 ---
 title: "Terms & Conditions"
 source_url: https://www.gov.bb/terms-conditions
-publish_date: 2025-10-15
+publish_date: 2026-05-14
 ---
 
 ### Ownership of Website Content
@@ -23,3 +23,98 @@ As a convenience to the user, certain links in this website will connect the u
 ### Governing Law
 
 As consideration for any use of this website, including merely accessing the website, you agree to be bound by the laws of Barbados, without regard to any conflicts of law principles. You further agree to be subject to the jurisdiction of any of the courts of Barbados for any dispute relating in any way to your use of this website.
+
+### Data Protection and Privacy
+
+This website is operated by the Ministry of Innovation, Science and Smart Technology, which acts as the Data Controller for personal information collected through alpha.gov.bb. We process personal information in accordance with the Data Protection Act 2019 of Barbados.
+
+The sections below describe what information we collect, where it is stored, how long we keep it, and the rights available to you under the Act.
+
+### Information We Collect
+
+When you use this website to apply for a government service, we may collect:
+
+- Personal identification details that you enter into an application form (for example: name, date of birth, national identification number, contact details, address)
+- Information about other persons named in an application (for example: a deceased relative on a post office redirection, a child on a textbook grant)
+- Supporting documents and images that you choose to upload as attachments
+- Payment details required to complete a transaction, processed through the Government of Barbados EZpay+ platform
+- Technical information about your visit, including pages viewed, form interactions, time spent, and device information used to improve the service
+- Feedback that you choose to submit through the website
+
+We collect only the information needed to process the service you are requesting or to operate, secure, and improve the website.
+
+### Where Your Data Is Stored
+
+Personal information submitted through alpha.gov.bb is processed using cloud services provided by Amazon Web Services (AWS) in the United States (the `us-east-1` region). The categories of storage are:
+
+- **Application form data submitted for services that do not require payment** is transmitted to the Government's form-processing service, validated, sent by email to the relevant Ministry, Department or Agency (MDA), and is **not retained** by alpha.gov.bb after the email has been sent.
+- **Application form data submitted for services that require payment** is held in an encrypted form in a PostgreSQL database for the limited period needed to complete the payment. Once payment is successful and the MDA has been notified by email, the encrypted application data is deleted from the database. If payment is not completed within 72 hours, the encrypted application data is automatically deleted by a scheduled cleanup process.
+- **Supporting documents and uploaded attachments** are transmitted to AWS Simple Storage Service (S3) for the limited time needed to attach them to your application. In normal operation this is a matter of seconds.
+- **Payment records** — including your name, email address, the amount paid, the payment method, the transaction number and the payment status — are retained in the payment database for accounting, audit and reconciliation purposes. Payment records do not contain the contents of the application form.
+- **Emails** containing your submission are sent to the relevant MDA through Amazon Simple Email Service (SES). The MDA's email retention policy applies once the email is received.
+- **Operational logs** are recorded by Amazon CloudWatch and by Sentry to allow us to diagnose errors and to monitor the health of the service. Email addresses appearing in logs are masked (for example, "us***@domain.com").
+- **Analytics events** (page views, form-step progress, durations and validation error counts) are recorded by Umami. Analytics events do not include the values you type into form fields.
+- **Partially completed forms** are stored only in your own web browser (in session storage) so that you can navigate between steps without losing your progress. This data is cleared when you close the browser tab, submit the form, or visit the start page for that service.
+
+### Cross-Border Transfer of Information
+
+Because alpha.gov.bb is hosted on AWS infrastructure in the United States, personal information you submit through this website is transferred outside of Barbados for processing. The transfer is made under the contractual safeguards offered by AWS, which is certified to international standards including ISO 27001 and SOC 2. We make this transfer in order to deliver the digital services available through this website. By submitting information through the website you acknowledge this transfer.
+
+### How Long We Keep Your Information
+
+| Category of information | Retention period |
+| --- | --- |
+| Application form data (non-payment services) | Not retained after the notification email is sent to the MDA |
+| Application form data (payment services, before payment) | Held encrypted until payment is completed, or up to 72 hours if abandoned |
+| Application form data (payment services, after payment) | Deleted once the MDA has been notified by email |
+| Uploaded supporting documents | Retained only for the time needed to process the application (typically seconds) |
+| Payment records (name, email, amount, status, transaction number) | Retained for as long as required by applicable accounting and audit obligations |
+| Confirmation and notification emails | Retained by the MDA in accordance with that MDA's records policy |
+| Operational logs (CloudWatch, Sentry) | Retained according to standard log-retention periods; identifiers are masked |
+| Analytics events (Umami) | Retained in aggregate form to support service improvement |
+| Session storage on your device | Cleared when you close the browser tab, submit the form, or visit the start page |
+
+Once the MDA has received your application, that MDA becomes responsible for the further processing and retention of your information under its own records management policy.
+
+### Cookies and Browser Storage
+
+This website uses a small number of technologies that store information in your browser:
+
+- **Session storage** is used by online application forms to remember your progress between steps. This data never leaves your device unless you choose to submit the form.
+- **A research-access cookie** may be set when you follow a private invitation link to take part in user research. The cookie is HTTP-only, expires after 24 hours, and only grants access to a research form; it does not identify you.
+- **Analytics** uses a privacy-respecting analytics service (Umami) that does not set tracking cookies on your device for cross-site profiling. Analytics measurements use technical signals only.
+
+You can clear browser storage at any time using your browser's settings.
+
+### Your Rights Under the Data Protection Act 2019
+
+The Data Protection Act 2019 gives you rights in relation to the personal information that we hold about you. These include:
+
+- The right to be informed about how your information is used (this notice)
+- The right of access to the information we hold about you
+- The right to request correction of information that is inaccurate or incomplete
+- The right to request erasure of your information where the lawful basis for processing it no longer applies
+- The right to restrict or object to certain types of processing
+- The right not to be subject to a decision based solely on automated processing
+- The right to lodge a complaint with the Data Protection Commissioner
+
+To exercise any of these rights, contact us using the details below. We may need to verify your identity before responding so that we do not disclose information to the wrong person. If you are not satisfied with our response, you may contact the Office of the Data Protection Commissioner of Barbados.
+
+### Security
+
+We protect your information using a combination of technical and organisational measures, including encryption of application data while it is stored in the payment workflow, encrypted connections (HTTPS) between your browser and the website, masking of identifiers in our logs, and access controls on the systems that hold payment records. No method of transmission or storage over the internet is completely secure, and we cannot guarantee absolute security.
+
+### Lawful Basis for Processing
+
+We process your personal information on the basis that the processing is necessary for the performance of a task carried out in the public interest or in the exercise of official authority vested in the Government of Barbados, and, where applicable, on the basis of your consent (for example, when you choose to provide feedback or take part in user research).
+
+### Contact
+
+Questions about this notice, requests to exercise your rights under the Data Protection Act 2019, or concerns about how your information has been handled should be sent to:
+
+**Email:** privacy@govtech.bb
+**Data Controller:** Ministry of Innovation, Science and Smart Technology, Government of Barbados
+
+### Changes to This Notice
+
+alpha.gov.bb is an alpha service that is being actively developed. We may update this notice from time to time to reflect changes to the services we offer, the systems that support them, or the law. Material changes will be published on this page with an updated publication date.


### PR DESCRIPTION
This PR will merge the current branch to 'prod' branch

## Description
Promotes four changes from `main` into `prod`: an expanded Terms & Conditions page (Data Protection Act 2019 disclosures), CC-recipient support for staff form-notification emails driven by env vars, a rewrite of the Husky pre-commit hook to eliminate stash-pop conflicts, and a wording fix on the existing T&Cs.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

(The pre-commit hook rewrite is a tooling/bug fix; the T&Cs additions are documentation; the email CC feature is a new feature.)

## Changes made

### Terms & Conditions — Data Protection Act 2019 section ([src/content/terms-conditions.md](src/content/terms-conditions.md))
- Adds a `Your Data` section covering what we collect, where it's stored (AWS US region), retention of forms with/without payment, uploaded files, payment records, error logs, and partly-filled forms.
- Adds `Cookies`, `Your rights`, contact (`privacy@govtech.bb`), and `Changes` subsections.
- Replaces the word "company" with "Government of Barbados" in the Disclaimer of Warranties.
- Bumps `publish_date` to `2026-05-14`.

### Form submission emails — CC support + env-driven test recipients
- [src/app/actions/send-form-submission-emails.tsx](src/app/actions/send-form-submission-emails.tsx): extends the payload schema with optional `notificationCc: string[]`, threads CC addresses through `sendEmail`, adds them to the SES `Destination.CcAddresses`, and includes masked CC values in `ses.send.attempt` / `ses.send.success` logs. CC is suppressed when `safeTestEmail` (email override) is active so staff CCs aren't leaked to test inboxes.
- [src/components/forms/builder/multi-step-form.tsx](src/components/forms/builder/multi-step-form.tsx): accepts `notificationCc?: string | string[] | null` and forwards it to the server action on both the API and `serverActionOnly` paths. JSDoc clarifies CC applies only to staff notifications, not applicant confirmations.
- [src/components/dynamic-form-loader.tsx](src/components/dynamic-form-loader.tsx): forwards `notificationEmail` and `notificationCc` props through to the dynamic form component.
- [src/app/(content)/[...slug]/page.tsx](src/app/%28content%29/%5B...slug%5D/page.tsx) and [src/app/youth/opportunities/[id]/form/page.tsx](src/app/youth/opportunities/%5Bid%5D/form/page.tsx): wire `process.env.TEST_NOTIFICATION_EMAIL` (overrides recipient) and `process.env.TEST_NOTIFICATION_EMAIL_COPY` (CC) into the dynamic form loader and youth opportunity form. The youth flow still falls back to the opportunity contact email when the env var is unset.
- [src/app/youth/opportunities/[id]/form/_components/youth-opportunity-form.tsx](src/app/youth/opportunities/%5Bid%5D/form/_components/youth-opportunity-form.tsx) and [src/components/forms/request-a-presidential-visit-for-a-centenarian-form.tsx](src/components/forms/request-a-presidential-visit-for-a-centenarian-form.tsx): accept and pass through `notificationCc`. The centenarian form no longer hard-codes `testing@govtech.bb` — recipient is now supplied via props/env.

### Husky pre-commit hook rewrite ([.husky/pre-commit](.husky/pre-commit))
- Replaces the previous `git stash push --keep-index` + `git stash pop` flow that occasionally produced literal `<<<<<<<` conflict markers in source files.
- Now passes the staged file list explicitly to `npx ultracite fix` so formatting is scoped to the commit, and re-stages with `xargs -0 git add`.
- Filters to formattable extensions (`.js/.jsx/.ts/.tsx/.mjs/.cjs/.json/.jsonc`).
- Refuses to run when any file is partially staged, with a clear message, instead of silently sweeping unstaged hunks into the commit.

### Notes
- The CC env vars (`TEST_NOTIFICATION_EMAIL`, `TEST_NOTIFICATION_EMAIL_COPY`) are intended to redirect/copy staff notifications during testing. If they are unset in the prod environment, behavior is unchanged from the previous release. Confirm prod env config is intentional before merge.
- Removing the hard-coded `testing@govtech.bb` from the centenarian form means that form will now have no notification recipient unless one is supplied via env or the route's `page.tsx`. Verify the centenarian route wires `notificationEmail` before relying on it in prod.

## Testing

1. **Terms & Conditions** — Visit `/terms-conditions`; confirm the new "Your Data", "Cookies", "Your rights" and "Changes" sections render, and that the Disclaimer of Warranties paragraph reads "Government of Barbados" rather than "our company".
2. **Form email CC** —
   - Set `TEST_NOTIFICATION_EMAIL` and `TEST_NOTIFICATION_EMAIL_COPY` in the env, restart the app, submit any IA-routed form (`/<ministry>/<service>/form`).
   - Verify the staff notification arrives at `TEST_NOTIFICATION_EMAIL` with `TEST_NOTIFICATION_EMAIL_COPY` in the CC header, and the applicant confirmation has no CC.
   - With `SAFE_TEST_EMAIL` set, confirm CCs are suppressed (check `ses.send.attempt` logs for `cc: (none)`).
   - Repeat for `/youth/opportunities/[id]/form` to confirm env override beats `opportunity.contact?.email`.
3. **Pre-commit hook** — In a working clone:
   - Stage a poorly-formatted `.tsx` file; commit; verify Ultracite rewrites it and the commit includes the formatted version.
   - Partially stage a file (stage one hunk, leave another); commit; verify the hook aborts with the "refusing to auto-format partially-staged files" message.
   - Attempt to finish an in-progress merge commit with `MERGE_HEAD` present — confirm a clean `--no-verify` path still works (existing known limitation).
4. **Visual regression** — Re-run Chromatic/Percy on `/terms-conditions` and the affected form routes.

## Related Github Issue(s)/Trello Ticket(s)
- #577 (terms & conditions)
- #587 (form email CC + env-driven test recipients)
- #588 (pre-commit hook stash race)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (visual regression snapshots)
- [ ] Documentation updated
