### PR TITLE
fix(webhook): flatten form_data so receiver can route submissions

### DIFF
--- a/src/components/forms/builder/multi-step-form.tsx
+++ b/src/components/forms/builder/multi-step-form.tsx
@@ -252,32 +252,49 @@ function normalizeDates(value: unknown): unknown {
 function buildWebhookFormData(
   data: Record<string, unknown>
 ): Record<string, unknown> {
-  const HOISTED_KEYS = new Set(["firstName", "lastName", "email", "phone"]);
-  const {
-    applicant: applicantRaw,
-    declaration: _omitDeclaration,
-    ...rest
-  } = data;
+  // Receiver expects a flat form_data object (e.g. { parish: "..." }) rather
+  // than a nested one (e.g. { applicant: { parish: "..." } }). Hoist the
+  // inner fields of each top-level namespace (applicant, interest, etc.) to
+  // the top level of form_data. Skip:
+  //  - `declaration` entirely (operational metadata; not part of application
+  //    content)
+  //  - applicant.firstName / lastName / email / phone (already represented
+  //    on the top-level `applicant` block)
+  const APPLICANT_HOISTED_TO_TOP = new Set([
+    "firstName",
+    "lastName",
+    "email",
+    "phone",
+  ]);
+  const result: Record<string, unknown> = {};
 
-  const normalizedRest = normalizeDates(rest) as Record<string, unknown>;
+  for (const [namespaceKey, namespaceValue] of Object.entries(data)) {
+    if (namespaceKey === "declaration") {
+      continue;
+    }
 
-  if (!applicantRaw || typeof applicantRaw !== "object") {
-    return normalizedRest;
-  }
-
-  const trimmedApplicant: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(
-    applicantRaw as Record<string, unknown>
-  )) {
-    if (!HOISTED_KEYS.has(key)) {
-      trimmedApplicant[key] = normalizeDates(value);
+    if (
+      namespaceValue &&
+      typeof namespaceValue === "object" &&
+      !Array.isArray(namespaceValue)
+    ) {
+      for (const [innerKey, innerValue] of Object.entries(
+        namespaceValue as Record<string, unknown>
+      )) {
+        if (
+          namespaceKey === "applicant" &&
+          APPLICANT_HOISTED_TO_TOP.has(innerKey)
+        ) {
+          continue;
+        }
+        result[innerKey] = normalizeDates(innerValue);
+      }
+    } else {
+      result[namespaceKey] = normalizeDates(namespaceValue);
     }
   }
 
-  if (Object.keys(trimmedApplicant).length > 0) {
-    return { ...normalizedRest, applicant: trimmedApplicant };
-  }
-  return normalizedRest;
+  return result;
 }
 
 /**


### PR DESCRIPTION
## Summary

- The case-management receiver returns `201 Created` for our current nested `form_data` payload, but submissions never reach the staff dashboard.
- Confirmed today that prod submissions (e.g. \`BYAC-1505-0HK27PS\` and earlier prod refs) are HTTP-accepted but **not** routed into the dashboard.
- The expected payload shape (per the integration spec) has \`form_data\` flat — for example \`form_data: { parish: \"St. Michael\" }\` — rather than nested under namespaces like \`form_data.applicant.parish\`.

## Change

Rewrites \`buildWebhookFormData\` in [multi-step-form.tsx](src/components/forms/builder/multi-step-form.tsx) to hoist each top-level namespace's inner fields to the top of \`form_data\`:

| Before | After |
| --- | --- |
| \`form_data: { applicant: { parish, citizenship, dateOfBirth }, interest: { motivation } }\` | \`form_data: { parish, citizenship, dateOfBirth, motivation }\` |

- Skips \`declaration\` entirely (operational metadata).
- Skips applicant fields already on the top-level \`applicant\` block (\`firstName\`, \`lastName\`, \`email\`, \`phone\`) so they aren't duplicated.
- Preserves existing date normalization (e.g. \`{day, month, year}\` → ISO string).

## Test plan

- [ ] Deploy this and submit a fresh BYAC form on prod
- [ ] Confirm the new ref (\`BYAC-DDMM-XXXXXXX\`) **appears in the MoY case-management staff dashboard**
- [ ] Confirm \`testing@govtech.bb\` still receives both the applicant confirmation and the staff notification

## Related

- Earlier prod refs that are NOT in the dashboard: \`BYAC-1405-OMC6S0N\`, \`BYAC-1405-AJLMZKB\`, \`BYAC-1505-0HK27PS\` (and possibly others). MoY may want to clean these up once this fix is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)