### PR TITLE
fix(forms): hardcode form notification emails (hotfix to prod)

### DIFF
--- a/src/app/(content)/[...slug]/page.tsx
+++ b/src/app/(content)/[...slug]/page.tsx
@@ -218,8 +218,8 @@ export default async function Page({ params }: ContentPageProps) {
       return (
         <DynamicFormLoader
           formSlug={pageSlug}
-          notificationCc={process.env.TEST_NOTIFICATION_EMAIL_COPY ?? null}
-          notificationEmail={process.env.TEST_NOTIFICATION_EMAIL ?? null}
+          notificationCc="testing@govtech.bb"
+          notificationEmail="shannon.clarke@govtech.bb"
         />
       );
     }
@@ -294,12 +294,8 @@ export default async function Page({ params }: ContentPageProps) {
           }
         >
           <YouthOpportunityForm
-            notificationCc={process.env.TEST_NOTIFICATION_EMAIL_COPY ?? null}
-            notificationEmail={
-              process.env.TEST_NOTIFICATION_EMAIL ??
-              opportunity.contact?.email ??
-              null
-            }
+            notificationCc="testing@govtech.bb"
+            notificationEmail="shannon.clarke@govtech.bb"
             opportunityId={opportunity.id}
             opportunityTitle={opportunity.title}
           />

--- a/src/app/youth/opportunities/[id]/form/page.tsx
+++ b/src/app/youth/opportunities/[id]/form/page.tsx
@@ -66,12 +66,8 @@ export default async function YouthOpportunityFormPage({
       }
     >
       <YouthOpportunityForm
-        notificationCc={process.env.TEST_NOTIFICATION_EMAIL_COPY ?? null}
-        notificationEmail={
-          process.env.TEST_NOTIFICATION_EMAIL ??
-          opportunity.contact?.email ??
-          null
-        }
+        notificationCc="testing@govtech.bb"
+        notificationEmail="shannon.clarke@govtech.bb"
         opportunityId={opportunity.id}
         opportunityTitle={opportunity.title}
       />

--- a/src/components/forms/builder/multi-step-form.tsx
+++ b/src/components/forms/builder/multi-step-form.tsx
@@ -1106,6 +1106,7 @@ export default function DynamicMultiStepForm({
               : undefined,
             referenceNumber: generatedReferenceNumber,
           });
+          console.log("[debug] sendFormSubmissionEmails result", emailResult);
           if (!emailResult.success) {
             throw new Error(emailResult.error ?? "Email submission failed");
           }
@@ -1123,7 +1124,7 @@ export default function DynamicMultiStepForm({
 
         if (webhookProgrammeCode) {
           try {
-            await sendFormSubmittedWebhook({
+            const webhookResult = await sendFormSubmittedWebhook({
               applicantEmail: extractApplicantEmail(
                 cleanedData as Record<string, unknown>
               ),
@@ -1137,6 +1138,10 @@ export default function DynamicMultiStepForm({
               programmeCode: webhookProgrammeCode,
               referenceNumber: generatedReferenceNumber,
             });
+            console.log(
+              "[debug] sendFormSubmittedWebhook result",
+              webhookResult
+            );
           } catch (webhookError) {
             console.error(
               "Form submission webhook dispatch failed",


### PR DESCRIPTION
## Summary
- Hotfix to ensure form-submission notifications work without relying on `TEST_NOTIFICATION_EMAIL` / `TEST_NOTIFICATION_EMAIL_COPY` env vars
- `notificationEmail` is hardcoded to `shannon.clarke@govtech.bb`
- `notificationCc` is hardcoded to `testing@govtech.bb`
- Also includes the prior `chore(forms)` temporary debug log of email + webhook server-action results, which is useful while we verify routing in prod

## Test plan
- [ ] Submit a form on a `/youth/opportunities/[id]/form` page and confirm the email is delivered to `shannon.clarke@govtech.bb` with `testing@govtech.bb` cc'd
- [ ] Submit a form on a `(content)/[...slug]/form` page and confirm the same
- [ ] Confirm the webhook payload still routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)