### PR TITLE
chore(amplify): remove unused TEST_NOTIFICATION_EMAIL env-var allowlist

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -24,9 +24,6 @@ frontend:
         # and submissions are never registered with MoY.
         - env | grep -e WEBHOOK_URL >> .env.production || true
         - env | grep -e WEBHOOK_SECRET >> .env.production || true
-        # Test-only notification recipients used by forms during verification.
-        - env | grep -e TEST_NOTIFICATION_EMAIL >> .env.production || true
-        - env | grep -e TEST_NOTIFICATION_EMAIL_COPY >> .env.production || true
         - env | grep -e EZPAY_API_KEY >> .env.production || true
         - env | grep -e EZPAY_BASE_URL >> .env.production || true
         - env | grep -e NEXT_PUBLIC_EZPAY_BASE_URL >> .env.production || true


### PR DESCRIPTION
## Summary

Removes the two \`TEST_NOTIFICATION_EMAIL\` / \`TEST_NOTIFICATION_EMAIL_COPY\` lines from [amplify.yml](amplify.yml) that I added in PR #594. They were never referenced anywhere in the source — \`grep -rn 'TEST_NOTIFICATION_EMAIL' src\` returns no hits.

The corresponding values are already hardcoded at the form call sites:

| File | \`notificationEmail\` | \`notificationCc\` |
| --- | --- | --- |
| [src/app/youth/opportunities/[id]/form/page.tsx](src/app/youth/opportunities/%5Bid%5D/form/page.tsx) | \`shannon.clarke@govtech.bb\` | \`testing@govtech.bb\` |
| [src/app/(content)/[...slug]/page.tsx](src/app/%28content%29/%5B...slug%5D/page.tsx) (DynamicFormLoader) | \`shannon.clarke@govtech.bb\` | \`testing@govtech.bb\` |
| [src/app/(content)/[...slug]/page.tsx](src/app/%28content%29/%5B...slug%5D/page.tsx) (YouthOpportunityForm) | \`shannon.clarke@govtech.bb\` | \`testing@govtech.bb\` |

## Test plan

- [ ] Confirm form submissions still send the staff notification to \`shannon.clarke@govtech.bb\` with a CC to \`testing@govtech.bb\` after this PR merges and Amplify rebuilds
- [ ] (Optional) Remove the now-orphaned \`TEST_NOTIFICATION_EMAIL\` and \`TEST_NOTIFICATION_EMAIL_COPY\` entries from the Amplify Console env-var settings to keep them tidy

🤖 Generated with [Claude Code](https://claude.com/claude-code)