### PR TITLE
fix(youth-opportunities): also route catch-all form path per opportunity

### DIFF
--- a/src/app/(content)/[...slug]/page.tsx
+++ b/src/app/(content)/[...slug]/page.tsx
@@ -17,6 +17,10 @@ import { getFormStorageKey } from "@/lib/form-registry";
 import { getMarkdownContent } from "@/lib/markdown";
 import { hasResearchAccess } from "@/lib/research-access";
 import {
+  getYouthOpportunityNotificationCc,
+  getYouthOpportunityNotificationEmail,
+} from "@/lib/youth-opportunity-notification";
+import {
   fetchServiceConfig,
   hasProtectedSubpages,
   isServiceProtected,
@@ -294,8 +298,10 @@ export default async function Page({ params }: ContentPageProps) {
           }
         >
           <YouthOpportunityForm
-            notificationCc="testing@govtech.bb"
-            notificationEmail="shannon.clarke@govtech.bb"
+            notificationCc={getYouthOpportunityNotificationCc(opportunity)}
+            notificationEmail={getYouthOpportunityNotificationEmail(
+              opportunity
+            )}
             opportunityId={opportunity.id}
             opportunityTitle={opportunity.title}
           />

--- a/src/app/youth/opportunities/[id]/form/page.tsx
+++ b/src/app/youth/opportunities/[id]/form/page.tsx
@@ -4,13 +4,14 @@ import { Suspense } from "react";
 import { FormSkeleton } from "@/components/forms/form-skeleton";
 import opportunitiesData from "@/data/opportunities.json";
 import { SITE_URL } from "@/lib/site-url";
+import {
+  getYouthOpportunityNotificationCc,
+  getYouthOpportunityNotificationEmail,
+} from "@/lib/youth-opportunity-notification";
 import type { Opportunity } from "../../_components/opportunities-list";
 import { YouthOpportunityForm } from "./_components/youth-opportunity-form";
 
 const opportunities = opportunitiesData as Opportunity[];
-
-const DEFAULT_YOUTH_OPPORTUNITY_NOTIFICATION_EMAIL =
-  "shannon.clarke@govtech.bb";
 
 function findOpportunity(id: string): Opportunity | undefined {
   return opportunities.find((opp) => opp.id === id);
@@ -69,11 +70,8 @@ export default async function YouthOpportunityFormPage({
       }
     >
       <YouthOpportunityForm
-        notificationCc={opportunity.notificationCc ?? null}
-        notificationEmail={
-          opportunity.notificationEmail ??
-          DEFAULT_YOUTH_OPPORTUNITY_NOTIFICATION_EMAIL
-        }
+        notificationCc={getYouthOpportunityNotificationCc(opportunity)}
+        notificationEmail={getYouthOpportunityNotificationEmail(opportunity)}
         opportunityId={opportunity.id}
         opportunityTitle={opportunity.title}
       />

--- a/src/lib/youth-opportunity-notification.ts
+++ b/src/lib/youth-opportunity-notification.ts
@@ -1,0 +1,19 @@
+import type { Opportunity } from "@/app/youth/opportunities/_components/opportunities-list";
+
+export const DEFAULT_YOUTH_OPPORTUNITY_NOTIFICATION_EMAIL =
+  "shannon.clarke@govtech.bb";
+
+export function getYouthOpportunityNotificationEmail(
+  opportunity: Pick<Opportunity, "notificationEmail">
+): string {
+  return (
+    opportunity.notificationEmail ??
+    DEFAULT_YOUTH_OPPORTUNITY_NOTIFICATION_EMAIL
+  );
+}
+
+export function getYouthOpportunityNotificationCc(
+  opportunity: Pick<Opportunity, "notificationCc">
+): string | null {
+  return opportunity.notificationCc ?? null;
+}


### PR DESCRIPTION
## Summary
Follow-up to #598. The `YouthOpportunityForm` is rendered in two routes; the direct `/youth/opportunities/[id]/form` route was updated in #598 but the IA-driven catch-all route at `src/app/(content)/[...slug]/page.tsx` (e.g. `/youth-and-opportunities/<page>/<opportunity>/form`) was still hardcoding the notification recipient to `shannon.clarke@govtech.bb` and the CC to `testing@govtech.bb`.

- Extracted the per-opportunity routing into `src/lib/youth-opportunity-notification.ts` (`getYouthOpportunityNotificationEmail` / `getYouthOpportunityNotificationCc`).
- Updated both the direct route and the catch-all route to use the helper.
- Behavior matches #598: per-opportunity `notificationEmail` (with a default fallback) and optional per-opportunity `notificationCc` (no fallback).

## Test plan
- [ ] Submit a youth-opportunity form via an IA path like `/youth-and-opportunities/<page>/<opportunity>/form` and confirm the notification reaches `ydp.blockcommittee@barbados.gov.bb` (not `shannon.clarke@govtech.bb`).
- [ ] Confirm no CC is sent (since none is set in `opportunities.json`).
- [ ] Override `notificationEmail` on one opportunity and confirm only that form routes to the new recipient via both routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)