### PR TITLE
feat(youth-opportunities): reset form state on detail page

### DIFF
--- a/src/app/(content)/[...slug]/page.tsx
+++ b/src/app/(content)/[...slug]/page.tsx
@@ -195,10 +195,15 @@ export default async function Page({ params }: ContentPageProps) {
         notFound();
       }
       return (
-        <OpportunityDetail
-          applyHref={`/${categorySlug}/${pageSlug}/${subPageSlug}/form`}
-          opportunity={opportunity}
-        />
+        <>
+          <ClearFormStorage
+            storageKey={`youth-opportunity-${opportunity.id}`}
+          />
+          <OpportunityDetail
+            applyHref={`/${categorySlug}/${pageSlug}/${subPageSlug}/form`}
+            opportunity={opportunity}
+          />
+        </>
       );
     }
 


### PR DESCRIPTION
## Summary

- Mount `<ClearFormStorage>` in the IA catch-all opportunity-detail branch of `src/app/(content)/[...slug]/page.tsx` so returning to a youth opportunity page (e.g. `/youth-and-community/youth-development-leadership/byac`) wipes that opportunity's stored form state.
- Mirrors the existing `/start` convention used by regular forms — fresh slate when the user re-enters via the front door, but a refresh while filling the form does NOT lose progress.
- Fires only on the IA catch-all route; the direct `/youth/opportunities/[id]` detail route is untouched.

## Test plan

- [ ] Visit `/youth-and-community/youth-development-leadership/byac/form`, fill some fields, advance a step. Navigate back to `…/byac`. Re-enter the form → fields empty, step 1.
- [ ] Same setup, but navigate back via the direct route `/youth/opportunities/byac`. Re-enter the form → fields still populated (control: direct route does NOT reset).
- [ ] On the form page, hit refresh → state persists.
- [ ] Open a different opportunity (e.g. `…/another-opportunity`) and confirm its form state is untouched after visiting `…/byac`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)