### PR TITLE
feat(content): feature flag visitor-permit-application as protected

### DIFF
--- a/src/data/content-directory.ts
+++ b/src/data/content-directory.ts
@@ -370,6 +370,7 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
       {
         title: "Visitor permit application",
         slug: "visitor-permit-application",
+        protected: true,
         source_url:
           "https://www.gov.bb/Visit-Barbados/visitorpermitapplication",
         description:


### PR DESCRIPTION
## Summary

- Adds `protected: true` to the `visitor-permit-application` entry in the content directory

## Behaviour

The existing `protected` flag infrastructure (introduced in #605) means this change automatically:

| Surface | Behaviour |
|---|---|
| Category listing (`/travel-id-citizenship`) | Entry hidden from public |
| Search results | Excluded from search index at build time |
| Sitemap | Excluded |

## Test plan

- [ ] Visit `/travel-id-citizenship` — "Visitor permit application" should not appear in the list
- [ ] Search for "visitor permit" — should return no results for this entry
- [ ] Run `npm run dev:index` and confirm the entry is absent from `public/search-index.json`

Made with [Cursor](https://cursor.com)