### PR TITLE
fix(content): restore /start links on non-protected entry pages

### DIFF
--- a/src/app/(content)/[...slug]/page.tsx
+++ b/src/app/(content)/[...slug]/page.tsx
@@ -142,11 +142,9 @@ export default async function Page({ params }: ContentPageProps) {
       );
     }
 
-    if (page.protected) {
-      const hasAccess = await hasResearchAccess();
-      if (!hasAccess) {
-        notFound();
-      }
+    const researchAccess = await hasResearchAccess();
+    if (page.protected && !researchAccess) {
+      notFound();
     }
 
     const markdownContent = await getMarkdownContent([pageSlug]);
@@ -161,7 +159,10 @@ export default async function Page({ params }: ContentPageProps) {
           event="page-service-view"
           form={pageSlug}
         />
-        <MarkdownContent markdown={markdownContent} />
+        <MarkdownContent
+          hasResearchAccess={!page.protected || researchAccess}
+          markdown={markdownContent}
+        />
       </>
     );
   }
@@ -207,11 +208,9 @@ export default async function Page({ params }: ContentPageProps) {
     const subPage = page.subPages?.find((sp) => sp.slug === subPageSlug);
     const isProtected = page.protected || subPage?.protected;
 
-    if (isProtected) {
-      const hasAccess = await hasResearchAccess();
-      if (!hasAccess) {
-        notFound();
-      }
+    const researchAccess = await hasResearchAccess();
+    if (isProtected && !researchAccess) {
+      notFound();
     }
 
     // Handle form pages (JSX components)
@@ -245,7 +244,10 @@ export default async function Page({ params }: ContentPageProps) {
             form={pageSlug}
           />
         )}
-        <MarkdownContent markdown={markdownContent} />
+        <MarkdownContent
+          hasResearchAccess={!isProtected || researchAccess}
+          markdown={markdownContent}
+        />
       </>
     );
   }


### PR DESCRIPTION
## Summary
- The protected-field refactor (cdfb218d) dropped the `hasResearchAccess` prop on both `<MarkdownContent>` call sites in `src/app/(content)/[...slug]/page.tsx`. With the prop defaulting to `false`, the rehype `hide-start-links` plugin stripped `/start` anchors from every entry-point page — not just protected ones.
- Reads the research-access cookie once per branch and passes `hasResearchAccess={!isProtected || researchAccess}` down so non-protected pages always show their CTA and protected pages keep their existing route-level 404 + research-access behavior.

## Test plan
- [ ] Visit a non-protected entry page that has a `/start` CTA without the research-access cookie — `/start` button renders.
- [ ] Visit the Centenarian entry (protected) without the cookie — route 404s.
- [ ] Visit the Centenarian entry with the cookie — `/start` button renders and any `data-external-form` placeholder is hidden.
- [ ] Visit the Visitor Permit application (protected) with and without the cookie — same expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)