### PR TITLE
RELEASE 2026-05-22 part 2: hide categories whose pages are all protected

### DIFF
--- a/src/app/(content)/[...slug]/page.tsx
+++ b/src/app/(content)/[...slug]/page.tsx
@@ -16,7 +16,7 @@ import { getFormStorageKey } from "@/lib/form-registry";
 import { getMarkdownContent } from "@/lib/markdown";
 import { hasResearchAccess } from "@/lib/research-access";
 import { SITE_URL } from "@/lib/site-url";
-import { findSubPageTitleFromPath } from "@/lib/utils";
+import { findSubPageTitleFromPath, isCategoryHidden } from "@/lib/utils";
 import {
   getYouthOpportunityNotificationCc,
   getYouthOpportunityNotificationEmail,
@@ -48,6 +48,9 @@ export default async function Page({ params }: ContentPageProps) {
     }
 
     const researchAccess = await hasResearchAccess();
+    if (!researchAccess && isCategoryHidden(category)) {
+      notFound();
+    }
     const visiblePages = category.pages.filter(
       (p) => !p.protected || researchAccess
     );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,9 @@ import NextLink from "next/link";
 import { HelpfulBox } from "@/components/layout/helpful-box";
 import { SearchForm } from "@/components/search-form";
 import { INFORMATION_ARCHITECTURE } from "@/data/content-directory";
+import { hasResearchAccess } from "@/lib/research-access";
 import { SITE_URL } from "@/lib/site-url";
+import { isCategoryHidden } from "@/lib/utils";
 
 export const metadata: Metadata = {
   title: { absolute: "Government Services | Government of Barbados" },
@@ -33,7 +35,12 @@ export const metadata: Metadata = {
   },
 };
 
-export default function Home() {
+export default async function Home() {
+  const researchAccess = await hasResearchAccess();
+  const visibleCategories = INFORMATION_ARCHITECTURE.filter(
+    (category) => researchAccess || !isCategoryHidden(category)
+  );
+
   return (
     <>
       <section className="border-yellow-00 border-b-4 bg-yellow-100">
@@ -87,7 +94,7 @@ export default function Home() {
             <Heading as="h2">Government services</Heading>
 
             <div className="flex flex-col">
-              {INFORMATION_ARCHITECTURE.map((service) => (
+              {visibleCategories.map((service) => (
                 <div
                   className="border-grey-00 border-t-2 py-4 first:border-0 lg:py-8"
                   key={service.title}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { MetadataRoute } from "next";
 import { INFORMATION_ARCHITECTURE } from "@/data/content-directory";
 import { SITE_URL } from "@/lib/site-url";
+import { isCategoryHidden } from "@/lib/utils";
 
 const contentDir = path.join(process.cwd(), "src", "content");
 
@@ -38,6 +39,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   ];
 
   for (const category of INFORMATION_ARCHITECTURE) {
+    if (isCategoryHidden(category)) continue;
+
     entries.push({
       url: `${SITE_URL}/${category.slug}`,
       changeFrequency: "weekly",

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import type { InformationContent, PageType } from "@/types/content";
+import { isCategoryHidden } from "./utils";
+
+function category(pages: PageType[]): InformationContent {
+  return {
+    title: "Test",
+    slug: "test",
+    pages,
+  };
+}
+
+const visiblePage: PageType = {
+  title: "Open",
+  slug: "open",
+  description: "",
+};
+
+const protectedPage: PageType = {
+  title: "Hidden",
+  slug: "hidden",
+  description: "",
+  protected: true,
+};
+
+describe("isCategoryHidden", () => {
+  it("returns true when the category has no pages", () => {
+    expect(isCategoryHidden(category([]))).toBe(true);
+  });
+
+  it("returns true when every page is protected", () => {
+    expect(isCategoryHidden(category([protectedPage, protectedPage]))).toBe(
+      true
+    );
+  });
+
+  it("returns false when at least one page is not protected", () => {
+    expect(isCategoryHidden(category([protectedPage, visiblePage]))).toBe(
+      false
+    );
+  });
+
+  it("returns false when no pages are protected", () => {
+    expect(isCategoryHidden(category([visiblePage, visiblePage]))).toBe(false);
+  });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -121,3 +121,10 @@ export const findCategoryByPageSlug = (
   INFORMATION_ARCHITECTURE.find((category) =>
     category.pages.some((page) => page.slug === slug)
   );
+
+/**
+ * A category is hidden from the public when it has no pages, or every page
+ * is protected. Research-access users still see it.
+ */
+export const isCategoryHidden = (category: InformationContent): boolean =>
+  category.pages.length === 0 || category.pages.every((page) => page.protected);


### PR DESCRIPTION
## Summary
- Hides a category from the public homepage, category index, and sitemap when every page in the category is `protected` (or the category has no pages). Research-access users see no change.
- Today this hides **Pensions and Gratuities** (only page is `Calculate your pension`, which is protected).

## Commits
- de8a6b77 Merge pull request #614 from govtech-bb/feat/hide-fully-protected-categories
- 05cbb796 feat(content): hide categories whose pages are all protected

🤖 Generated with [Claude Code](https://claude.com/claude-code)