### PR TITLE
feat(content): unprotect renew-reminder

### DIFF
--- a/src/data/content-directory.ts
+++ b/src/data/content-directory.ts
@@ -435,7 +435,6 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
       {
         title: "Get a reminder before a document expires",
         slug: "renew-reminder",
-        protected: true,
         keywords: [
           "reminder",
           "renew",


### PR DESCRIPTION
## Summary
- Removes the `protected: true` flag from the renew-reminder entry in `src/data/content-directory.ts`, exposing the page outside the feature-flag gate.

## Test plan
- [ ] Verify `/youth-and-community/...` (or relevant parent IA) renders the renew-reminder link without requiring the protected flag.
- [ ] Confirm the renew-reminder form/detail page is reachable in an environment where protected content is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)