### PR TITLE
RELEASE 2026-05-22: unprotect renew-reminder

### DIFF
--- a/src/data/content-directory.ts
+++ b/src/data/content-directory.ts
@@ -435,7 +435,6 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
       {
         title: "Get a reminder before a document expires",
         slug: "renew-reminder",
-        protected: true,
         keywords: [
           "reminder",
           "renew",


### PR DESCRIPTION
## Summary
- Removes the `protected: true` flag from the renew-reminder entry, exposing the page outside the feature-flag gate (#621).

## Test plan
- [ ] Verify renew-reminder is reachable in prod after deploy without the protected flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)