### PR TITLE
fix(research-access): use SITE_URL for redirect origin

### DIFF
--- a/src/app/api/research-access/route.ts
+++ b/src/app/api/research-access/route.ts
@@ -1,6 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { COOKIE_NAME, isValidToken } from "@/lib/research-access";
-import { SITE_URL } from "@/lib/site-url";
 
 /**
  * Validate redirect URL to prevent open redirect attacks.
@@ -29,10 +28,11 @@ export function GET(request: NextRequest) {
   const token = searchParams.get("token");
   const redirectTo = getSafeRedirect(searchParams.get("redirect"));
   const revoke = searchParams.get("revoke");
+  const origin = process.env.NEXT_PUBLIC_SITE_URL ?? request.nextUrl.origin;
 
   // Handle revoke request
   if (revoke === "true") {
-    const response = NextResponse.redirect(new URL(redirectTo, SITE_URL));
+    const response = NextResponse.redirect(new URL(redirectTo, origin));
     response.cookies.set(COOKIE_NAME, "", { maxAge: 0, path: "/" });
     return response;
   }
@@ -49,7 +49,7 @@ export function GET(request: NextRequest) {
     return NextResponse.json({ error: "Invalid token" }, { status: 403 });
   }
 
-  const response = NextResponse.redirect(new URL(redirectTo, SITE_URL));
+  const response = NextResponse.redirect(new URL(redirectTo, origin));
   response.cookies.set(COOKIE_NAME, token, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",

--- a/src/app/api/research-access/route.ts
+++ b/src/app/api/research-access/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { COOKIE_NAME, isValidToken } from "@/lib/research-access";
+import { SITE_URL } from "@/lib/site-url";
 
 /**
  * Validate redirect URL to prevent open redirect attacks.
@@ -31,7 +32,7 @@ export function GET(request: NextRequest) {
 
   // Handle revoke request
   if (revoke === "true") {
-    const response = NextResponse.redirect(new URL(redirectTo, request.url));
+    const response = NextResponse.redirect(new URL(redirectTo, SITE_URL));
     response.cookies.set(COOKIE_NAME, "", { maxAge: 0, path: "/" });
     return response;
   }
@@ -48,7 +49,7 @@ export function GET(request: NextRequest) {
     return NextResponse.json({ error: "Invalid token" }, { status: 403 });
   }
 
-  const response = NextResponse.redirect(new URL(redirectTo, request.url));
+  const response = NextResponse.redirect(new URL(redirectTo, SITE_URL));
   response.cookies.set(COOKIE_NAME, token, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",


### PR DESCRIPTION
## Summary
- `/api/research-access?revoke=true` (and the token-grant flow) redirected to `http://localhost:3000` on the prod Amplify deployment because the SSR Lambda receives requests with an internal `Host` header, so `request.url` resolves to localhost.
- In `src/app/api/research-access/route.ts`, read `process.env.NEXT_PUBLIC_SITE_URL` directly and fall back to `request.nextUrl.origin`. Matches the pattern in `src/app/api/payments/ezpay/redirect/route.ts:36`.

## Why not use the SITE_URL helper
`SITE_URL` defaults to `https://alpha.gov.bb` when the env var is unset — fine for SEO/canonical/OG metadata, but for a redirect that fallback would send local devs to prod after revoking. Falling back to `request.nextUrl.origin` keeps local dev working (the Amplify Lambda quirk only affects prod) without forcing every dev to set `NEXT_PUBLIC_SITE_URL` in `.env.local`.

## Notes
- `src/app/api/payments/ezpay/redirect/route.ts:36` reads `NEXT_PUBLIC_APP_URL` (not whitelisted in `amplify.yml`), so it has the same latent bug. Not fixed here — flagging for a follow-up.

## Test plan
- [ ] On the prod deployment, visit `/api/research-access?revoke=true` and confirm the redirect lands on the public origin (not localhost) and the `research-access` cookie is cleared.
- [ ] Visit `/api/research-access?token=<token>&redirect=/some-path` on prod and confirm it redirects to `<public-origin>/some-path` with the cookie set.
- [ ] On local dev (with `NEXT_PUBLIC_SITE_URL` unset), confirm the revoke link redirects to `http://localhost:3000/`, not prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)