### PR TITLE
Release: research-access redirect origin fix

### DIFF
--- a/src/app/api/research-access/route.ts
+++ b/src/app/api/research-access/route.ts
@@ -1,6 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { COOKIE_NAME, isValidToken } from "@/lib/research-access";
-import { SITE_URL } from "@/lib/site-url";
 
 /**
  * Validate redirect URL to prevent open redirect attacks.
@@ -29,10 +28,11 @@ export function GET(request: NextRequest) {
   const token = searchParams.get("token");
   const redirectTo = getSafeRedirect(searchParams.get("redirect"));
   const revoke = searchParams.get("revoke");
+  const origin = process.env.NEXT_PUBLIC_SITE_URL ?? request.nextUrl.origin;
 
   // Handle revoke request
   if (revoke === "true") {
-    const response = NextResponse.redirect(new URL(redirectTo, SITE_URL));
+    const response = NextResponse.redirect(new URL(redirectTo, origin));
     response.cookies.set(COOKIE_NAME, "", { maxAge: 0, path: "/" });
     return response;
   }
@@ -49,7 +49,7 @@ export function GET(request: NextRequest) {
     return NextResponse.json({ error: "Invalid token" }, { status: 403 });
   }
 
-  const response = NextResponse.redirect(new URL(redirectTo, SITE_URL));
+  const response = NextResponse.redirect(new URL(redirectTo, origin));
   response.cookies.set(COOKIE_NAME, token, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",

--- a/src/app/api/research-access/route.ts
+++ b/src/app/api/research-access/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { COOKIE_NAME, isValidToken } from "@/lib/research-access";
+import { SITE_URL } from "@/lib/site-url";
 
 /**
  * Validate redirect URL to prevent open redirect attacks.
@@ -31,7 +32,7 @@ export function GET(request: NextRequest) {
 
   // Handle revoke request
   if (revoke === "true") {
-    const response = NextResponse.redirect(new URL(redirectTo, request.url));
+    const response = NextResponse.redirect(new URL(redirectTo, SITE_URL));
     response.cookies.set(COOKIE_NAME, "", { maxAge: 0, path: "/" });
     return response;
   }
@@ -48,7 +49,7 @@ export function GET(request: NextRequest) {
     return NextResponse.json({ error: "Invalid token" }, { status: 403 });
   }
 
-  const response = NextResponse.redirect(new URL(redirectTo, request.url));
+  const response = NextResponse.redirect(new URL(redirectTo, SITE_URL));
   response.cookies.set(COOKIE_NAME, token, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",


### PR DESCRIPTION
## Summary
- fix(research-access): use `SITE_URL` for the OAuth redirect origin, with a fallback to the request origin when the env var is unset (#629)

## Commits
- 0e93ebbf fix(research-access): fall back to request origin when env var unset
- 72b9ad2d fix(research-access): use SITE_URL for redirect origin

## Test plan
- [ ] Verify research-access sign-in redirects to the correct origin in production
- [ ] Confirm fallback to request origin works when `SITE_URL` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)