### PR TITLE
feat(content): StormReady Barbados hurricane-prep page

### DIFF
--- a/src/app/(content)/[...slug]/page.tsx
+++ b/src/app/(content)/[...slug]/page.tsx
@@ -4,18 +4,11 @@ import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { ClearFormStorage } from "@/components/clear-form-storage";
 import { ContactCallout } from "@/components/contact-callout";
+import { COMPONENT_PAGES } from "@/components/content-component-pages";
 import { DynamicFormLoader } from "@/components/dynamic-form-loader";
 import { FormSkeleton } from "@/components/forms/form-skeleton";
-import {
-  FindJusticeOfThePeacePage,
-  findJusticeOfThePeaceMetadata,
-} from "@/components/justice-of-the-peace/find-page";
 import { Breadcrumbs } from "@/components/layout/breadcrumbs";
 import { MarkdownContent } from "@/components/markdown-content";
-import {
-  FindOpenPharmacyPage,
-  findOpenPharmacyMetadata,
-} from "@/components/open-pharmacy/find-page";
 import { OpportunityDetail } from "@/components/opportunity-detail";
 import { PageViewTracker } from "@/components/page-view-tracker";
 import { YouthOpportunityForm } from "@/components/youth-opportunity-form/youth-opportunity-form";
@@ -159,6 +152,12 @@ export default async function Page({ params }: ContentPageProps) {
       notFound();
     }
 
+    const componentPage = COMPONENT_PAGES[slug.join("/")];
+    if (componentPage) {
+      const { Component } = componentPage;
+      return <Component />;
+    }
+
     const markdownContent = await getMarkdownContent([pageSlug]);
     if (!markdownContent) {
       notFound();
@@ -247,20 +246,10 @@ export default async function Page({ params }: ContentPageProps) {
       notFound();
     }
 
-    if (
-      categorySlug === "travel-id-citizenship" &&
-      pageSlug === "justice-of-the-peace" &&
-      subPageSlug === "find"
-    ) {
-      return <FindJusticeOfThePeacePage />;
-    }
-
-    if (
-      categorySlug === "health-and-emergency-services" &&
-      pageSlug === "open-pharmacy" &&
-      subPageSlug === "find"
-    ) {
-      return <FindOpenPharmacyPage />;
+    const componentPage = COMPONENT_PAGES[slug.join("/")];
+    if (componentPage) {
+      const { Component } = componentPage;
+      return <Component />;
     }
 
     // Handle form pages (JSX components)
@@ -437,20 +426,9 @@ export async function generateMetadata({ params }: ContentPageProps) {
       }
     }
 
-    if (
-      slug[0] === "travel-id-citizenship" &&
-      slug[1] === "justice-of-the-peace" &&
-      slug[2] === "find"
-    ) {
-      return findJusticeOfThePeaceMetadata;
-    }
-
-    if (
-      slug[0] === "health-and-emergency-services" &&
-      slug[1] === "open-pharmacy" &&
-      slug[2] === "find"
-    ) {
-      return findOpenPharmacyMetadata;
+    const componentPage = COMPONENT_PAGES[slug.join("/")];
+    if (componentPage) {
+      return componentPage.metadata;
     }
 
     if (subPageSlug === "form") {
@@ -541,6 +519,11 @@ export async function generateMetadata({ params }: ContentPageProps) {
           images: [`${SITE_URL}/og-image.png`],
         },
       };
+    }
+
+    const componentPage = COMPONENT_PAGES[slug.join("/")];
+    if (componentPage) {
+      return componentPage.metadata;
     }
 
     const contentSlug = [slug[1]];

--- a/src/app/(content)/layout.tsx
+++ b/src/app/(content)/layout.tsx
@@ -8,7 +8,7 @@ export default function EntryPointLayout({
 }>) {
   return (
     <div className="w-full overflow-x-clip bg-white-00">
-      <div className="bg-blue-10">
+      <div className="bg-blue-10 print:hidden">
         <div className="container">
           <StageBanner stage="alpha" />
         </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -175,3 +175,13 @@
 .leaflet-tooltip.jp-here-tooltip::before {
   border-top-color: var(--color-green-00);
 }
+
+/* Print margin for the whole site. Chrome (header/footer/alpha banner/
+   breadcrumbs/feedback box) is hidden with `print:hidden` on the elements
+   themselves, and the body grid is neutralised with `print:block` in the
+   root layout, so printed pages carry only their content. */
+@media print {
+  @page {
+    margin: 1.4cm;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,7 +45,7 @@ export default function RootLayout({
   return (
     <html className="bg-blue-100" lang="en">
       <body
-        className={`${figtree.variable} ${textVariants({ size: "body" })} grid min-h-screen grid-rows-[auto_1fr_auto] bg-white-00 font-sans antialiased`}
+        className={`${figtree.variable} ${textVariants({ size: "body" })} grid min-h-screen grid-rows-[auto_1fr_auto] bg-white-00 font-sans antialiased print:block print:min-h-0`}
       >
         <Header />
         <main>{children}</main>

--- a/src/components/content-component-pages.ts
+++ b/src/components/content-component-pages.ts
@@ -1,0 +1,52 @@
+/**
+ * Component-backed content pages.
+ * --------------------------------------------------------------
+ * Some IA pages (marked `type: "component"` in the content directory) render
+ * a React component instead of markdown. This registry maps the full slug
+ * path to its component and metadata so the catch-all route can dispatch with
+ * a single lookup instead of a growing chain of hardcoded conditionals.
+ *
+ * To add a component page: register it here and mark the subpage (or page)
+ * `type: "component"` in `content-directory.ts`. No route edits required.
+ */
+
+import type { Metadata } from "next";
+import type { ComponentType } from "react";
+import {
+  FindJusticeOfThePeacePage,
+  findJusticeOfThePeaceMetadata,
+} from "@/components/justice-of-the-peace/find-page";
+import {
+  FindOpenPharmacyPage,
+  findOpenPharmacyMetadata,
+} from "@/components/open-pharmacy/find-page";
+import { StormReadyChecklistPage } from "@/components/stormready/checklist-page";
+import {
+  StormReadyLandingPage,
+  stormReadyChecklistMetadata,
+  stormReadyLandingMetadata,
+} from "@/components/stormready/landing-page";
+
+interface ComponentPage {
+  Component: ComponentType;
+  metadata: Metadata;
+}
+
+export const COMPONENT_PAGES: Record<string, ComponentPage> = {
+  "travel-id-citizenship/justice-of-the-peace/find": {
+    Component: FindJusticeOfThePeacePage,
+    metadata: findJusticeOfThePeaceMetadata,
+  },
+  "health-and-emergency-services/open-pharmacy/find": {
+    Component: FindOpenPharmacyPage,
+    metadata: findOpenPharmacyMetadata,
+  },
+  "health-and-emergency-services/stormready": {
+    Component: StormReadyLandingPage,
+    metadata: stormReadyLandingMetadata,
+  },
+  "health-and-emergency-services/stormready/checklist": {
+    Component: StormReadyChecklistPage,
+    metadata: stormReadyChecklistMetadata,
+  },
+};

--- a/src/components/layout/entry-point-wrapper.tsx
+++ b/src/components/layout/entry-point-wrapper.tsx
@@ -14,12 +14,12 @@ export function EntryPointWrapper({ children }: { children: React.ReactNode }) {
 
   return (
     <>
-      <div className="container py-4 lg:py-6">
+      <div className="container py-4 lg:py-6 print:hidden">
         <Breadcrumbs />
       </div>
       <div className="container pt-4 pb-8 lg:py-8">
         {children}
-        {pathname !== "/feedback" && <HelpfulBox />}
+        {pathname !== "/feedback" && <HelpfulBox className="print:hidden" />}
       </div>
     </>
   );

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import NextLink from "next/link";
 
 export const Footer = () => (
-  <footer className="bg-blue-100">
+  <footer className="bg-blue-100 print:hidden">
     <div className="container">
       <div className="grid lg:grid-cols-2 lg:gap-8">
         <div className="flex flex-col items-start gap-2 py-8 lg:pb-0">

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -4,7 +4,7 @@ import { Banner } from "./banner";
 import { MobileNav } from "./mobile-nav";
 
 export const Header = () => (
-  <div>
+  <div className="print:hidden">
     <Banner />
     <header className="relative bg-yellow-100">
       <div className="container">

--- a/src/components/stormready/checklist-page.tsx
+++ b/src/components/stormready/checklist-page.tsx
@@ -1,0 +1,181 @@
+/**
+ * StormReady Barbados — household preparation checklist
+ * --------------------------------------------------------------
+ * Client component rendered for
+ * /health-and-emergency-services/stormready/checklist via the catch-all
+ * content route. Progress is saved to localStorage so it survives a refresh,
+ * and the page prints to a clean PDF — site chrome carries `print:hidden` and
+ * the root layout neutralises its grid for print, so only content is printed.
+ */
+
+"use client";
+
+import { Button, Checkbox, Heading, Text } from "@govtech-bb/react";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  STORMREADY_CHECKLIST,
+  STORMREADY_CHECKLIST_TOTAL,
+} from "@/data/stormready-checklist";
+
+const STORAGE_KEY = "stormready-checklist-v1";
+
+type ChecklistState = Record<string, boolean>;
+
+function loadState(): ChecklistState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as ChecklistState) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveState(state: ChecklistState) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Ignore — storage may be unavailable (private mode, quota).
+  }
+}
+
+export function StormReadyChecklistPage() {
+  return (
+    <Suspense fallback={null}>
+      <ChecklistContent />
+    </Suspense>
+  );
+}
+
+function ChecklistContent() {
+  const searchParams = useSearchParams();
+  const [state, setState] = useState<ChecklistState>({});
+  const [hydrated, setHydrated] = useState(false);
+
+  // Restore saved progress after mount to keep server and client markup in sync.
+  useEffect(() => {
+    setState(loadState());
+    setHydrated(true);
+  }, []);
+
+  const setItem = useCallback((id: string, checked: boolean) => {
+    setState((prev) => {
+      const next = { ...prev, [id]: checked };
+      saveState(next);
+      return next;
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    setState({});
+    saveState({});
+  }, []);
+
+  const doneCount = useMemo(
+    () => Object.values(state).filter(Boolean).length,
+    [state]
+  );
+
+  const percent = STORMREADY_CHECKLIST_TOTAL
+    ? Math.round((doneCount / STORMREADY_CHECKLIST_TOTAL) * 100)
+    : 0;
+
+  // Auto-open the print dialog when arriving from the "Save checklist as PDF"
+  // link (?print=1 or ?format=pdf). Wait for paint, then print.
+  const autoPrint =
+    searchParams.has("print") || searchParams.get("format") === "pdf";
+  useEffect(() => {
+    if (!(autoPrint && hydrated)) {
+      return;
+    }
+    const timer = setTimeout(() => window.print(), 350);
+    return () => clearTimeout(timer);
+  }, [autoPrint, hydrated]);
+
+  return (
+    <div className="mb-l flex max-w-176 flex-col gap-m print:mb-0">
+      {/* Print-only sheet header. */}
+      <div className="hidden border-black-00 border-b-2 pb-xs print:block">
+        <Heading as="h1" size="h2">
+          Household preparation checklist
+        </Heading>
+        <Text as="p" size="caption">
+          StormReady Barbados — Government of Barbados
+        </Text>
+        <Text as="p" className="text-mid-grey-00" size="caption">
+          Name: _______________________ Date: ______________
+        </Text>
+      </div>
+
+      <div className="flex flex-col gap-xs print:hidden">
+        <Heading as="h1">Household preparation checklist</Heading>
+        <Text as="p" className="text-mid-grey-00">
+          Tick items as you get ready. Save as PDF or print to keep a copy at
+          home. Your progress is saved on this device.
+        </Text>
+      </div>
+
+      <div className="flex flex-col gap-s sm:flex-row print:hidden">
+        <Button onClick={() => window.print()} type="button">
+          Save as PDF or print
+        </Button>
+        <Button onClick={reset} type="button" variant="secondary">
+          Reset
+        </Button>
+      </div>
+
+      <div className="flex flex-col gap-xs bg-teal-10 p-s print:hidden">
+        <div className="flex justify-between gap-s font-bold text-teal-00">
+          <span>Your progress</span>
+          <span>
+            {doneCount} of {STORMREADY_CHECKLIST_TOTAL} items
+          </span>
+        </div>
+        <div
+          aria-label="Checklist progress"
+          aria-valuemax={STORMREADY_CHECKLIST_TOTAL}
+          aria-valuemin={0}
+          aria-valuenow={doneCount}
+          className="h-2 overflow-hidden rounded-full bg-grey-00"
+          role="progressbar"
+        >
+          <div
+            className="h-full rounded-full bg-teal-00 transition-[width] duration-200"
+            style={{ width: `${percent}%` }}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-m">
+        {STORMREADY_CHECKLIST.map((section) => (
+          <fieldset
+            className="flex flex-col gap-s border-0 p-0"
+            key={section.id}
+          >
+            <legend className="w-full border-grey-00 border-b pb-xs">
+              <Heading as="h2">{section.title}</Heading>
+            </legend>
+            {section.hint && (
+              <Text as="p" className="text-mid-grey-00">
+                {section.hint}
+              </Text>
+            )}
+            <div className="mt-xs flex flex-col gap-s">
+              {section.items.map((item) => (
+                <Checkbox
+                  checked={state[item.id] ?? false}
+                  id={item.id}
+                  key={item.id}
+                  label={item.label}
+                  onCheckedChange={(checked) =>
+                    setItem(item.id, checked === true)
+                  }
+                />
+              ))}
+            </div>
+          </fieldset>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/stormready/landing-page.tsx
+++ b/src/components/stormready/landing-page.tsx
@@ -1,0 +1,203 @@
+/**
+ * StormReady Barbados — landing page
+ * --------------------------------------------------------------
+ * Server component rendered for /health-and-emergency-services/stormready
+ * via the catch-all content route. Breadcrumbs, the alpha StageBanner and
+ * the "Was this helpful?" box are supplied by the (content) layout, so this
+ * component renders only the page body.
+ */
+
+import { Heading, LinkButton, Text } from "@govtech-bb/react";
+import { format, parseISO } from "date-fns";
+import NextLink from "next/link";
+import {
+  HURRICANE_SEASON_LABEL,
+  STORMREADY_LAST_UPDATED,
+} from "@/data/stormready-checklist";
+import { buildPageMetadata } from "@/lib/page-metadata";
+
+const TITLE = "StormReady Barbados";
+const DESCRIPTION =
+  "Get ready for hurricane season and stay up to date with Department of Emergency Management (DEM) alerts. Household checklist and key storm contacts for Barbados.";
+const LANDING_HREF = "/health-and-emergency-services/stormready";
+const CHECKLIST_HREF = "/health-and-emergency-services/stormready/checklist";
+
+export const stormReadyLandingMetadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: LANDING_HREF,
+});
+
+export const stormReadyChecklistMetadata = buildPageMetadata({
+  title: "Household preparation checklist",
+  description:
+    "Tick off water, food, documents, first aid, communication and pre-storm tasks to make sure your household is ready for a hurricane. Save your progress or print a copy.",
+  path: CHECKLIST_HREF,
+});
+
+interface Highlight {
+  title: string;
+  body: string;
+}
+
+const HIGHLIGHTS: Highlight[] = [
+  {
+    title: "Water",
+    body: "Store at least 3 gallons of drinking water per person for 3 days. Fill baths, buckets and other containers before a storm.",
+  },
+  {
+    title: "Documents",
+    body: "Keep your national ID, insurance documents and birth certificates in a waterproof bag. Have cash in small bills available.",
+  },
+  {
+    title: "Communication",
+    body: "Charge all devices and power banks. Keep a battery-powered radio to receive DEM updates. Write down important phone numbers and emergency contacts.",
+  },
+  {
+    title: "Before a storm",
+    body: "Board up windows if needed, bring in outdoor items, fill your vehicle with gas, and make sure family members know your emergency plan and shelter arrangements.",
+  },
+];
+
+interface Contact {
+  label: string;
+  number: string;
+  tel: string;
+  ariaLabel: string;
+}
+
+const CONTACTS: Contact[] = [
+  {
+    label: "Barbados Met Office",
+    number: "246-535-0021",
+    tel: "tel:+12465350021",
+    ariaLabel: "Call the Barbados Met Office on 246 535 0021",
+  },
+  {
+    label: "Police",
+    number: "211",
+    tel: "tel:211",
+    ariaLabel: "Call the Police on 211",
+  },
+  {
+    label: "BWA (water outages)",
+    number: "246-426-3990",
+    tel: "tel:+12464263990",
+    ariaLabel: "Call the BWA water outages line on 246 426 3990",
+  },
+];
+
+export function StormReadyLandingPage() {
+  return (
+    <div className="mb-l flex max-w-[42rem] flex-col gap-m">
+      <div className="flex flex-col gap-xs">
+        <Heading as="h1">{TITLE}</Heading>
+        <Text as="p" className="text-mid-grey-00">
+          Get ready for hurricane season and stay up to date with Department of
+          Emergency Management (DEM) alerts.
+        </Text>
+      </div>
+
+      <div className="border-blue-10 border-b-4 pb-4 text-mid-grey-00">
+        <Text as="p" size="caption">
+          Last updated on {format(parseISO(STORMREADY_LAST_UPDATED), "PPP")}
+        </Text>
+      </div>
+
+      <div className="border-blue-100 border-l-4 bg-blue-10 px-s py-xm">
+        <Text as="p">
+          <strong>Hurricane season</strong> runs from{" "}
+          <strong>{HURRICANE_SEASON_LABEL}</strong>. Prepare before the season
+          starts &mdash; do not wait for a storm warning.
+        </Text>
+      </div>
+
+      <section
+        aria-labelledby="checklist-heading"
+        className="flex flex-col gap-s"
+      >
+        <Heading as="h2" id="checklist-heading">
+          Household checklist
+        </Heading>
+        <Text as="p">
+          Use this checklist to make sure your household is ready for a
+          hurricane. It covers water, food, documents, first aid, communication,
+          and the steps to take before a storm.
+        </Text>
+
+        <div className="flex flex-col gap-s sm:flex-row">
+          <LinkButton as={NextLink} href={CHECKLIST_HREF}>
+            Open household checklist
+          </LinkButton>
+          <LinkButton
+            as={NextLink}
+            href={`${CHECKLIST_HREF}?print=1`}
+            variant="secondary"
+          >
+            Save checklist as PDF
+          </LinkButton>
+        </div>
+        <Text as="p" className="text-mid-grey-00" size="caption">
+          The checklist lets you tick items off and saves your progress on this
+          device. &ldquo;Save checklist as PDF&rdquo; opens the checklist and
+          prompts your browser to save or print a copy.
+        </Text>
+
+        <Heading as="h3">Highlights from the checklist</Heading>
+        <ul className="grid list-none grid-cols-1 gap-s p-0 sm:grid-cols-2">
+          {HIGHLIGHTS.map((highlight) => (
+            <li
+              className="flex flex-col gap-xxs bg-teal-10 p-s"
+              key={highlight.title}
+            >
+              <Heading as="h4" size="h3">
+                {highlight.title}
+              </Heading>
+              <Text as="p">{highlight.body}</Text>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section
+        aria-labelledby="contacts-heading"
+        className="flex flex-col gap-s border-grey-00 border-t pt-m"
+      >
+        <Heading as="h2" id="contacts-heading">
+          Key contacts during a storm
+        </Heading>
+        <Text as="p" className="text-mid-grey-00">
+          Tap a number to call. Lines can be busy during a storm — keep trying.
+        </Text>
+
+        <div className="grid grid-cols-1 gap-s md:grid-cols-3">
+          <a
+            aria-label="Call the DEM Emergency Line on 246 438 7575"
+            className="col-span-full flex flex-col gap-xxs border-red-00 border-l-4 bg-red-10 p-s text-current no-underline transition-colors hover:bg-red-40 focus-visible:outline focus-visible:outline-4 focus-visible:outline-red-100 focus-visible:outline-offset-2"
+            href="tel:+12464387575"
+          >
+            <span className="font-bold text-red-00 text-xs uppercase tracking-wider">
+              Emergency
+            </span>
+            <span className="font-bold">DEM Emergency Line</span>
+            <span className="font-bold text-2xl text-red-00">246-438-7575</span>
+          </a>
+
+          {CONTACTS.map((contact) => (
+            <a
+              aria-label={contact.ariaLabel}
+              className="flex flex-col gap-xxs border-teal-00 border-l-4 bg-teal-10 p-s text-current no-underline transition-colors hover:bg-teal-40 focus-visible:outline focus-visible:outline-4 focus-visible:outline-teal-100 focus-visible:outline-offset-2"
+              href={contact.tel}
+              key={contact.label}
+            >
+              <span className="font-bold">{contact.label}</span>
+              <span className="font-bold text-teal-00 text-xl">
+                {contact.number}
+              </span>
+            </a>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/data/content-directory.ts
+++ b/src/data/content-directory.ts
@@ -659,6 +659,32 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
           },
         ],
       },
+      {
+        title: "StormReady Barbados",
+        slug: "stormready",
+        keywords: [
+          "hurricane",
+          "storm",
+          "hurricane season",
+          "emergency",
+          "DEM",
+          "Department of Emergency Management",
+          "disaster",
+          "preparedness",
+          "checklist",
+          "shelter",
+          "evacuation",
+        ],
+        description:
+          "Get ready for hurricane season with a household preparation checklist and key contacts, and stay up to date with Department of Emergency Management (DEM) alerts.",
+        subPages: [
+          {
+            slug: "checklist",
+            title: "Household preparation checklist",
+            type: "component",
+          },
+        ],
+      },
     ],
   },
   {

--- a/src/data/stormready-checklist.ts
+++ b/src/data/stormready-checklist.ts
@@ -1,0 +1,150 @@
+/**
+ * StormReady Barbados — household preparation checklist data
+ * --------------------------------------------------------------
+ * Single source of truth for the checklist rendered at
+ * /health-and-emergency-services/stormready/checklist and for the
+ * "Highlights from the checklist" cards on the landing page.
+ *
+ * Content is drawn from the Department of Emergency Management (DEM)
+ * 2026 guidance and the Barbados Water Authority's storm advice.
+ */
+
+export interface ChecklistItem {
+  /** Stable id — used as the localStorage key for this item's state. */
+  id: string;
+  label: string;
+}
+
+export interface ChecklistSection {
+  id: string;
+  title: string;
+  /** Optional guidance shown beneath the section heading. */
+  hint?: string;
+  items: ChecklistItem[];
+}
+
+/** ISO date — formatted for display the same way as markdown page freshness. */
+export const STORMREADY_LAST_UPDATED = "2026-06-04";
+
+/** Hurricane season runs 1 June to 30 November. */
+export const HURRICANE_SEASON_LABEL = "1 June to 30 November 2026";
+
+export const STORMREADY_CHECKLIST: ChecklistSection[] = [
+  {
+    id: "water",
+    title: "Water",
+    hint: "After the storm, do not drink tap water until BWA says it is safe. Boil all drinking water for at least 1 minute.",
+    items: [
+      {
+        id: "w1",
+        label: "At least 3 gallons of drinking water per person, for 3 days",
+      },
+      { id: "w2", label: "1 gallon of water per pet per day" },
+      {
+        id: "w3",
+        label:
+          "Filled bathtubs and large buckets before the storm (BWA advice)",
+      },
+      {
+        id: "w4",
+        label: "Water purification tablets or bleach (for emergencies)",
+      },
+    ],
+  },
+  {
+    id: "food",
+    title: "Food",
+    items: [
+      {
+        id: "f1",
+        label:
+          "At least 3 days of non-perishable food (tinned goods, dry crackers, peanut butter)",
+      },
+      { id: "f2", label: "Manual can opener" },
+      { id: "f3", label: "Disposable plates, cups, and forks" },
+      { id: "f4", label: "Baby formula and food (if you have an infant)" },
+    ],
+  },
+  {
+    id: "documents",
+    title: "Important documents",
+    hint: "Keep these in a waterproof bag or container.",
+    items: [
+      { id: "d1", label: "National ID card or passport" },
+      { id: "d2", label: "Insurance documents (home, health, vehicle)" },
+      { id: "d3", label: "Birth certificates for everyone in your household" },
+      { id: "d4", label: "Prescription details and medical records" },
+      {
+        id: "d5",
+        label: "Cash in small bills (ATMs may not work after the storm)",
+      },
+    ],
+  },
+  {
+    id: "health",
+    title: "Health and first aid",
+    items: [
+      { id: "h1", label: "First aid kit (plasters, bandages, antiseptic)" },
+      { id: "h2", label: "7-day supply of prescription medicines" },
+      { id: "h3", label: "Hearing aids with spare batteries" },
+      { id: "h4", label: "Glasses or contact lenses with enough solution" },
+      { id: "h5", label: "Nappies, wipes, and formula (if you have a baby)" },
+      { id: "h6", label: "Hand sanitiser and face masks" },
+    ],
+  },
+  {
+    id: "communication",
+    title: "Communication",
+    items: [
+      {
+        id: "c1",
+        label: "Battery-powered or wind-up radio (to hear DEM updates)",
+      },
+      { id: "c2", label: "Fully charged mobile phone and portable power bank" },
+      {
+        id: "c3",
+        label:
+          "Emergency contact list written on paper (not just on your phone)",
+      },
+      { id: "c4", label: "Whistle to signal for help if you get trapped" },
+    ],
+  },
+  {
+    id: "shelter",
+    title: "Shelter, tools, and safety",
+    items: [
+      { id: "s1", label: "Torches with spare batteries" },
+      { id: "s2", label: "Candles and waterproof matches or a lighter" },
+      { id: "s3", label: "Sturdy shoes or boots for every family member" },
+      { id: "s4", label: "Rain gear (waterproof jackets or ponchos)" },
+      { id: "s5", label: "Bedding or sleeping bag for each person" },
+      { id: "s6", label: "Change of clothes for 3 days" },
+      { id: "s7", label: "Tools to turn off gas and water at the mains" },
+      { id: "s8", label: "Heavy-duty rubbish bags" },
+    ],
+  },
+  {
+    id: "before",
+    title: "Before the storm hits",
+    items: [
+      { id: "b1", label: "Board up or shutter windows and glass doors" },
+      {
+        id: "b2",
+        label: "Bring in outdoor furniture, plants, and loose items",
+      },
+      { id: "b3", label: "Topped up vehicle with petrol" },
+      { id: "b4", label: "Charged all devices (phones, tablets, power banks)" },
+      { id: "b5", label: "Let friends or family know your shelter plan" },
+      {
+        id: "b6",
+        label: "Arranged help for any elderly or disabled neighbours",
+      },
+      { id: "b7", label: "Made a plan for your pets" },
+    ],
+  },
+];
+
+export const STORMREADY_CHECKLIST_TOTAL = STORMREADY_CHECKLIST.reduce(
+  (sum, section) => sum + section.items.length,
+  0
+);

--- a/src/lib/page-metadata.ts
+++ b/src/lib/page-metadata.ts
@@ -1,0 +1,39 @@
+/**
+ * Canonical page-metadata builder.
+ * --------------------------------------------------------------
+ * Collapses the repeated OpenGraph/Twitter/canonical boilerplate that
+ * otherwise gets copied into every page's `Metadata` object. Pass the
+ * page-specific bits; shared image and structure are filled in here.
+ */
+
+import type { Metadata } from "next";
+import { SITE_URL } from "@/lib/site-url";
+
+const OG_IMAGE = {
+  url: `${SITE_URL}/og-image.png`,
+  width: 1200,
+  height: 630,
+  alt: "Government of Barbados",
+} as const;
+
+interface PageMetadataInput {
+  title: string;
+  description: string;
+  /** Absolute path from the site root, e.g. "/health-and-emergency-services/stormready". */
+  path: string;
+}
+
+export function buildPageMetadata({
+  title,
+  description,
+  path,
+}: PageMetadataInput): Metadata {
+  const url = `${SITE_URL}${path}`;
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: { title, description, url, images: [OG_IMAGE] },
+    twitter: { title, description, images: [OG_IMAGE.url] },
+  };
+}


### PR DESCRIPTION
## What

Adds a public **StormReady Barbados** service under *Health and emergency services*:

- **Landing** (`/health-and-emergency-services/stormready`) — lede, last-updated freshness (matches markdown pages), hurricane-season notice, checklist CTAs, highlight cards, and tap-to-call storm contacts (DEM emergency hero + Met Office / Police / BWA).
- **Household checklist** (`/health-and-emergency-services/stormready/checklist`) — 38 items across 7 sections, progress bar, progress saved to `localStorage`, reset, and print-to-PDF (`?print=1` auto-opens the dialog).

Registered in the IA under `health-and-emergency-services`, so it appears in category nav and search, and inherits breadcrumbs / alpha banner / feedback box from the `(content)` layout.

## Routing cleanup

The catch-all route had a growing chain of hardcoded `category/page/subpage` conditionals for component-backed pages, duplicated across render **and** `generateMetadata`. Replaced with a **`COMPONENT_PAGES` registry** keyed by slug path — one lookup in each place, gating preserved, and adding a page is now a single registry entry. Also added a **`buildPageMetadata`** helper for the repeated OG/Twitter boilerplate.

## Print

Dropped a fragile `:has()` print stylesheet in favour of `print:hidden` on the chrome elements themselves (header, footer, alpha banner, breadcrumbs, feedback box) plus body-grid neutralisation for print — so every page now prints clean content, not just StormReady.

## Verification

- `next build` passes; `tsc` clean (only a pre-existing test-file error).
- All component-page routes verified: StormReady 200 (public); open-pharmacy / justice-of-the-peace gate without research access, serve 200 with it.
- New files are Biome-clean.