### PR TITLE
feat(content): Find an emergency shelter service

### DIFF
--- a/src/components/content-component-pages.ts
+++ b/src/components/content-component-pages.ts
@@ -13,6 +13,18 @@
 import type { Metadata } from "next";
 import type { ComponentType } from "react";
 import {
+  FindEmergencyShelterPage,
+  findEmergencyShelterMetadata,
+} from "@/components/emergency-shelter/find-page";
+import {
+  EmergencyShelterGuidancePage,
+  emergencyShelterGuidanceMetadata,
+} from "@/components/emergency-shelter/guidance-page";
+import {
+  EmergencyShelterLandingPage,
+  emergencyShelterLandingMetadata,
+} from "@/components/emergency-shelter/landing-page";
+import {
   FindJusticeOfThePeacePage,
   findJusticeOfThePeaceMetadata,
 } from "@/components/justice-of-the-peace/find-page";
@@ -48,5 +60,17 @@ export const COMPONENT_PAGES: Record<string, ComponentPage> = {
   "health-and-emergency-services/stormready/checklist": {
     Component: StormReadyChecklistPage,
     metadata: stormReadyChecklistMetadata,
+  },
+  "health-and-emergency-services/find-an-emergency-shelter": {
+    Component: EmergencyShelterLandingPage,
+    metadata: emergencyShelterLandingMetadata,
+  },
+  "health-and-emergency-services/find-an-emergency-shelter/find": {
+    Component: FindEmergencyShelterPage,
+    metadata: findEmergencyShelterMetadata,
+  },
+  "health-and-emergency-services/find-an-emergency-shelter/guidance": {
+    Component: EmergencyShelterGuidancePage,
+    metadata: emergencyShelterGuidanceMetadata,
   },
 };

--- a/src/components/emergency-shelter/find-page.tsx
+++ b/src/components/emergency-shelter/find-page.tsx
@@ -1,0 +1,87 @@
+/**
+ * Emergency shelter finder — page wrapper
+ * --------------------------------------------------------------
+ * Server component for
+ * /health-and-emergency-services/find-an-emergency-shelter/find. Renders the
+ * static heading, freshness, activation notice and source, and hands the
+ * interactive list off to the client <ShelterFinder>.
+ */
+
+import { Heading, Link, Text } from "@govtech-bb/react";
+import { format, parseISO } from "date-fns";
+import NextLink from "next/link";
+import { ShelterFinder } from "@/components/emergency-shelter/shelter-finder";
+import {
+  SHELTER_COUNT,
+  SHELTERS_LAST_UPDATED,
+  SHELTERS_NEXT_REVIEW,
+} from "@/data/emergency-shelters";
+import { buildPageMetadata } from "@/lib/page-metadata";
+import {
+  EMERGENCY_SHELTER_GUIDANCE_HREF,
+  EMERGENCY_SHELTER_LANDING_HREF,
+} from "./routes";
+
+const DEM_TEL = "tel:+12464387575";
+const DEM_NUMBER = "438-7575";
+
+export const findEmergencyShelterMetadata = buildPageMetadata({
+  title: "Search shelters",
+  description: `Search and filter all ${SHELTER_COUNT} emergency shelters in Barbados by parish, accessibility and category.`,
+  path: `${EMERGENCY_SHELTER_LANDING_HREF}/find`,
+});
+
+export function FindEmergencyShelterPage() {
+  return (
+    <div className="mb-l flex flex-col gap-m">
+      <div className="flex flex-col gap-xs">
+        <Heading as="h1">Search shelters</Heading>
+        <div className="border-blue-10 border-b-4 pb-4 text-mid-grey-00">
+          <Text as="p" size="caption">
+            Last updated on {format(parseISO(SHELTERS_LAST_UPDATED), "PPP")}.
+            Next review: {format(parseISO(SHELTERS_NEXT_REVIEW), "PPP")}.
+          </Text>
+        </div>
+      </div>
+
+      <div className="border-red-00 border-l-4 bg-red-10 px-s py-xm">
+        <Text as="p">
+          <strong>No shelter is currently open.</strong> This page lists every
+          shelter in the 2026 booklet — not the live status. The Department of
+          Emergency Management activates shelters only during a hurricane or
+          tropical storm. For the official list of open shelters, listen to
+          local radio, follow DEM on social media, or call DEM on{" "}
+          <Link href={DEM_TEL}>{DEM_NUMBER}</Link>.
+        </Text>
+      </div>
+
+      <Text as="p" className="text-mid-grey-00">
+        Search all {SHELTER_COUNT} emergency shelters in Barbados. Filter by
+        parish, category and accessibility.
+      </Text>
+
+      <ShelterFinder />
+
+      <aside
+        aria-labelledby="going-to-shelter-heading"
+        className="flex flex-col gap-xs border-grey-00 border-t pt-m"
+      >
+        <Heading as="h2" id="going-to-shelter-heading" size="h3">
+          Going to a shelter?
+        </Heading>
+        <Text as="p">
+          <Link as={NextLink} href={EMERGENCY_SHELTER_GUIDANCE_HREF}>
+            Read what to bring, shelter rules and other guidance
+          </Link>{" "}
+          before you leave.
+        </Text>
+      </aside>
+
+      <Text as="p" className="text-mid-grey-00" size="caption">
+        Source: 2026 Emergency Shelter Booklet, Department of Emergency
+        Management. Distance is calculated from the centre of each parish.
+        Parish coordinates © OpenStreetMap contributors.
+      </Text>
+    </div>
+  );
+}

--- a/src/components/emergency-shelter/guidance-data.ts
+++ b/src/components/emergency-shelter/guidance-data.ts
@@ -1,0 +1,350 @@
+/**
+ * Static reference content for the shelter guidance page.
+ * --------------------------------------------------------------
+ * District Emergency Organisation chairpersons, hurricane terminology and the
+ * phone directory, from the 2026 Emergency Shelter Booklet. The accessible-
+ * shelter list is NOT here — it is derived from EMERGENCY_SHELTERS so there is
+ * one source of truth for which shelters have an accessible bathroom.
+ */
+
+export interface DistrictChair {
+  district: string;
+  name: string;
+  number: string;
+  tel: string;
+}
+
+export const DISTRICT_CHAIRS: DistrictChair[] = [
+  {
+    district: "Christ Church East",
+    name: "Mr. Kwame Bradshaw",
+    number: "832-0295",
+    tel: "tel:+12468320295",
+  },
+  {
+    district: "Christ Church East Central",
+    name: "Mr. Jason Griffith",
+    number: "825-4346",
+    tel: "tel:+12468254346",
+  },
+  {
+    district: "Christ Church West",
+    name: "Mr. Ian Smitten",
+    number: "245-7606",
+    tel: "tel:+12462457606",
+  },
+  {
+    district: "City of Bridgetown",
+    name: "Ms. Dorcus Williams",
+    number: "261-9792",
+    tel: "tel:+12462619792",
+  },
+  {
+    district: "St. Andrew",
+    name: "Ms. Corlita Andrews",
+    number: "261-6380",
+    tel: "tel:+12462616380",
+  },
+  {
+    district: "St. George North",
+    name: "Mr. Roderick Yarde",
+    number: "252-1944",
+    tel: "tel:+12462521944",
+  },
+  {
+    district: "St. George South",
+    name: "Mr. Roger Padmore",
+    number: "230-6493",
+    tel: "tel:+12462306493",
+  },
+  {
+    district: "St. James Central",
+    name: "Mrs. Chery Griffith",
+    number: "826-7798",
+    tel: "tel:+12468267798",
+  },
+  {
+    district: "St. James North",
+    name: "Mrs. Joyanne Forde-Craigg",
+    number: "824-5935",
+    tel: "tel:+12468245935",
+  },
+  {
+    district: "St. James South",
+    name: "Mr. John Flemming",
+    number: "851-4010",
+    tel: "tel:+12468514010",
+  },
+  {
+    district: "St. John",
+    name: "Mr. Winston Millington",
+    number: "263-3041",
+    tel: "tel:+12462633041",
+  },
+  {
+    district: "St. Joseph",
+    name: "Mr. Matthew Alleyne",
+    number: "237-2674",
+    tel: "tel:+12462372674",
+  },
+  {
+    district: "St. Lucy",
+    name: "Ms. Rontae Johnson-Annius",
+    number: "268-5122",
+    tel: "tel:+12462685122",
+  },
+  {
+    district: "St. Michael Central",
+    name: "Mrs. Gail Powers-Yard",
+    number: "255-2372",
+    tel: "tel:+12462552372",
+  },
+  {
+    district: "St. Michael East",
+    name: "Mr. Kirt Trotman",
+    number: "262-5074",
+    tel: "tel:+12462625074",
+  },
+  {
+    district: "St. Michael Northeast",
+    name: "Mr. Michael Carrington",
+    number: "843-9381",
+    tel: "tel:+12468439381",
+  },
+  {
+    district: "St. Michael Northwest",
+    name: "Ms. Doriel Gill JP",
+    number: "240-8559",
+    tel: "tel:+12462408559",
+  },
+  {
+    district: "St. Michael South",
+    name: "Ms. Richelle Brathwaite",
+    number: "262-1093",
+    tel: "tel:+12462621093",
+  },
+  {
+    district: "St. Michael South Central",
+    name: "Mrs. Charone Holder-Parris",
+    number: "232-7352",
+    tel: "tel:+12462327352",
+  },
+  {
+    district: "St. Michael Southeast",
+    name: "Ms. Sophia Greaves-Broome",
+    number: "832-4130",
+    tel: "tel:+12468324130",
+  },
+  {
+    district: "St. Michael West",
+    name: "Ms. Kathy Harris",
+    number: "240-3189",
+    tel: "tel:+12462403189",
+  },
+  {
+    district: "St. Michael West Central",
+    name: "Ms. Quostan Peters",
+    number: "282-7616",
+    tel: "tel:+12462827616",
+  },
+  {
+    district: "St. Peter",
+    name: "Mr. Dave Hurley",
+    number: "838-8338",
+    tel: "tel:+12468388338",
+  },
+  {
+    district: "St. Philip North",
+    name: "Ms. Ermenta King",
+    number: "236-2220",
+    tel: "tel:+12462362220",
+  },
+  {
+    district: "St. Philip South",
+    name: "Mrs. Sharon-Rose Gittens",
+    number: "230-3641",
+    tel: "tel:+12462303641",
+  },
+  {
+    district: "St. Philip West",
+    name: "Ms. Natasha Morgan",
+    number: "253-1811",
+    tel: "tel:+12462531811",
+  },
+  {
+    district: "St. Thomas",
+    name: "Mr. Rodney Francis",
+    number: "232-9853",
+    tel: "tel:+12462329853",
+  },
+];
+
+export interface HurricaneTerm {
+  term: string;
+  definition: string;
+}
+
+export const HURRICANE_TERMS: HurricaneTerm[] = [
+  {
+    term: "Tropical wave",
+    definition:
+      "A bend in the normally straight flow of surface air in the tropics, with showers and thunderstorms. Can develop into a tropical cyclone.",
+  },
+  {
+    term: "Tropical depression",
+    definition: "A tropical cyclone with maximum sustained winds below 39 mph.",
+  },
+  {
+    term: "Tropical storm",
+    definition: "A tropical cyclone with winds of 39–73 mph.",
+  },
+  {
+    term: "Tropical storm watch",
+    definition: "Tropical storm conditions are possible within 48 hours.",
+  },
+  {
+    term: "Tropical storm warning",
+    definition: "Tropical storm conditions are expected within 36 hours.",
+  },
+  {
+    term: "Hurricane",
+    definition: "A tropical cyclone with winds of 74 mph or more.",
+  },
+  {
+    term: "Hurricane watch",
+    definition: "Hurricane conditions are possible within 48 hours.",
+  },
+  {
+    term: "Hurricane warning",
+    definition:
+      "Hurricane conditions are expected to make landfall within 36 hours.",
+  },
+  {
+    term: "All clear",
+    definition:
+      "The storm or hurricane has left the area, but you should still be cautious.",
+  },
+  {
+    term: "Storm surge",
+    definition:
+      "The dome of water that builds up as a hurricane moves over the sea. When it comes ashore it causes flooding — usually a hurricane's biggest killer.",
+  },
+  {
+    term: "Eye",
+    definition:
+      "The low-pressure centre of a hurricane. Winds are normally calm and the sky can clear. Do not be fooled — the worst part comes after the eye passes and the winds blow from the opposite direction.",
+  },
+  {
+    term: "Eye wall",
+    definition:
+      "The ring of thunderstorms that surrounds the eye. The heaviest rain, strongest winds and worst turbulence are normally here.",
+  },
+];
+
+export interface PhoneContact {
+  display: string;
+  tel: string;
+  /** e.g. "in an emergency", "(direct)", "(mobile)". */
+  note?: string;
+}
+
+export interface PhoneEntry {
+  label: string;
+  contacts: PhoneContact[];
+}
+
+export interface PhoneGroup {
+  heading: string;
+  entries: PhoneEntry[];
+}
+
+export const PHONE_DIRECTORY: PhoneGroup[] = [
+  {
+    heading: "Emergency services",
+    entries: [
+      {
+        label: "Police",
+        contacts: [
+          { display: "211", tel: "tel:211", note: "in an emergency" },
+          {
+            display: "430-7100",
+            tel: "tel:+12464307100",
+            note: "for non-emergencies",
+          },
+        ],
+      },
+      {
+        label: "Fire Service",
+        contacts: [
+          { display: "311", tel: "tel:311", note: "in an emergency" },
+          {
+            display: "535-7824",
+            tel: "tel:+12465357824",
+            note: "for non-emergencies",
+          },
+        ],
+      },
+      { label: "Ambulance", contacts: [{ display: "511", tel: "tel:511" }] },
+      {
+        label: "Queen Elizabeth Hospital",
+        contacts: [{ display: "436-6450", tel: "tel:+12464366450" }],
+      },
+      {
+        label: "Barbados Defence Force",
+        contacts: [{ display: "536-2000", tel: "tel:+12465362000" }],
+      },
+      {
+        label: "Veterinary Services Department",
+        contacts: [{ display: "535-0221", tel: "tel:+12465350221" }],
+      },
+    ],
+  },
+  {
+    heading: "Department of Emergency Management (DEM)",
+    entries: [
+      {
+        label: "DEM main switchboard",
+        contacts: [{ display: "438-7575", tel: "tel:+12464387575" }],
+      },
+      {
+        label: "Director — Ms. Kerry Hinds",
+        contacts: [
+          { display: "535-7153", tel: "tel:+12465357153", note: "(direct)" },
+        ],
+      },
+      {
+        label: "Deputy Director — Maj. Robert Harewood",
+        contacts: [
+          { display: "535-7166", tel: "tel:+12465357166", note: "(direct)" },
+        ],
+      },
+    ],
+  },
+  {
+    heading: "Shelter Wardens (Ministry of Educational Transformation)",
+    entries: [
+      {
+        label:
+          "Chief Shelter Warden — Dr. Ramona Archer-Bradshaw, Chief Education Officer",
+        contacts: [
+          { display: "535-0609", tel: "tel:+12465350609", note: "(work)" },
+          { display: "850-7457", tel: "tel:+12468507457", note: "(mobile)" },
+        ],
+      },
+      {
+        label: "Deputy Chief Shelter Warden — Rev. Stephen Scott",
+        contacts: [
+          { display: "535-0614", tel: "tel:+12465350614", note: "(work)" },
+          { display: "230-6946", tel: "tel:+12462306946", note: "(mobile)" },
+        ],
+      },
+      {
+        label: "Deputy Chief Shelter Warden — Ms. Julia Beckles",
+        contacts: [
+          { display: "535-0613", tel: "tel:+12465350613", note: "(work)" },
+          { display: "233-6023", tel: "tel:+12462336023", note: "(mobile)" },
+        ],
+      },
+    ],
+  },
+];

--- a/src/components/emergency-shelter/guidance-page.tsx
+++ b/src/components/emergency-shelter/guidance-page.tsx
@@ -1,0 +1,361 @@
+/**
+ * Before you go to a shelter — guidance page
+ * --------------------------------------------------------------
+ * Server component for
+ * /health-and-emergency-services/find-an-emergency-shelter/guidance. Long-form
+ * reference content: Go Bag, shelter rules, entry protocol, accessible
+ * shelters, District Emergency Organisation contacts, hurricane terms and the
+ * phone directory.
+ */
+
+import { Heading, Link, ShowHide, Text } from "@govtech-bb/react";
+import { format, parseISO } from "date-fns";
+import NextLink from "next/link";
+import {
+  EMERGENCY_SHELTERS,
+  SHELTERS_LAST_UPDATED,
+  SHELTERS_NEXT_REVIEW,
+} from "@/data/emergency-shelters";
+import { buildPageMetadata } from "@/lib/page-metadata";
+import {
+  DISTRICT_CHAIRS,
+  HURRICANE_TERMS,
+  PHONE_DIRECTORY,
+  type PhoneEntry,
+} from "./guidance-data";
+import {
+  EMERGENCY_SHELTER_FIND_HREF,
+  EMERGENCY_SHELTER_GUIDANCE_HREF,
+} from "./routes";
+
+const DEM_TEL = "tel:+12464387575";
+
+export const emergencyShelterGuidanceMetadata = buildPageMetadata({
+  title: "Before you go to a shelter",
+  description:
+    "What to bring, shelter rules, accessibility, the entry protocol, District Emergency Organisations, hurricane terms and emergency phone numbers for Barbados emergency shelters.",
+  path: EMERGENCY_SHELTER_GUIDANCE_HREF,
+});
+
+const CONTENTS = [
+  { id: "go-bag", label: "What to bring (Emergency Go Bag)" },
+  { id: "before-you-leave", label: "Before you leave home" },
+  { id: "what-to-expect", label: "What to expect when you arrive" },
+  { id: "rules", label: "Shelter rules" },
+  { id: "protocol", label: "Protocol for entering shelters" },
+  { id: "accessible-shelters", label: "Shelters with an accessible bathroom" },
+  {
+    id: "district-organisations",
+    label: "Your District Emergency Organisation",
+  },
+  { id: "hurricane-terms", label: "Hurricane terms" },
+  { id: "phone-numbers", label: "All phone numbers" },
+];
+
+const accessibleShelters = EMERGENCY_SHELTERS.filter(
+  (shelter) => shelter.access
+);
+const accessibleCategory1 = accessibleShelters.filter((s) => s.category === 1);
+const accessibleCategory2 = accessibleShelters.filter((s) => s.category === 2);
+
+export function EmergencyShelterGuidancePage() {
+  return (
+    <div className="mb-l flex max-w-[44rem] flex-col gap-m">
+      <div className="flex flex-col gap-xs">
+        <Heading as="h1">Before you go to a shelter</Heading>
+        <div className="border-blue-10 border-b-4 pb-4 text-mid-grey-00">
+          <Text as="p" size="caption">
+            Last updated on {format(parseISO(SHELTERS_LAST_UPDATED), "PPP")}.
+            Next review: {format(parseISO(SHELTERS_NEXT_REVIEW), "PPP")}.
+          </Text>
+        </div>
+      </div>
+
+      <Text as="p" className="text-mid-grey-00">
+        Read this guidance before you go to an emergency shelter in Barbados.
+      </Text>
+
+      <nav
+        aria-labelledby="contents-heading"
+        className="flex flex-col gap-s border-teal-00 border-l-4 bg-teal-10 p-s"
+      >
+        <Heading as="h2" id="contents-heading" size="h3">
+          Contents
+        </Heading>
+        <ul className="list-disc space-y-xs pl-6">
+          {CONTENTS.map((item) => (
+            <li key={item.id}>
+              <Link href={`#${item.id}`}>{item.label}</Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <GuidanceSection heading="What to bring (Emergency Go Bag)" id="go-bag">
+        <Text as="p">
+          Pack a Go Bag that is easy to grab if you have to leave home. Refresh
+          it at the start of the hurricane season on 1 June.
+        </Text>
+        <BulletList
+          items={[
+            "Bottled water",
+            "A small first aid kit and any prescription medication",
+            "A small flashlight and spare batteries",
+            "Infant essentials — medicine, sterile water, diapers, ready formula, bottles",
+            "Your ID, passport or driver's licence, in water-tight plastic bags",
+            "Cash, in denominations of $20 and less",
+            "Hand sanitiser and wipes",
+            "Personal toiletries and sanitary items",
+            "A whistle",
+            "A portable radio and batteries",
+            "Ready-to-eat food (canned, packaged or boxed) and a can opener",
+          ]}
+        />
+        <Text as="p">
+          Also keep a <strong>Household Disaster Supply Kit</strong> at home for
+          use after the storm — drinking water, two weeks of non-perishable
+          food, a tarpaulin, clean-up supplies and a fire extinguisher.
+        </Text>
+      </GuidanceSection>
+
+      <GuidanceSection heading="Before you leave home" id="before-you-leave">
+        <BulletList
+          items={[
+            "Listen for evacuation advice on local radio, TV news and official social media. Leave when you are told to.",
+            "Fill containers with water — the bathtub, sinks and the washing machine.",
+            "Shut off water and electricity at the mains.",
+            "Close the valve on large propane tanks and anchor them.",
+            "Lock all windows and doors.",
+            "Take your Go Bag and any prescription medication.",
+            "Leave early, in daylight if you can. Do not drive through floodwater.",
+          ]}
+        />
+        <Text as="p">
+          <strong>Pets are not allowed in shelters.</strong> Arrange to leave
+          them with friends or family, and pack a Pet Survival Kit.
+        </Text>
+      </GuidanceSection>
+
+      <GuidanceSection
+        heading="What to expect when you arrive"
+        id="what-to-expect"
+      >
+        <BulletList
+          items={[
+            "A warden will register you and your family at the door. Have your ID ready.",
+            "The warden will assign you a space — this may be a hall, a classroom or a smaller individual room.",
+            "Food is not provided. Bring your own from your Go Bag and Disaster Supply Kit.",
+            "Bedding is not provided either. Bring a pillow, blanket or sleeping bag if you can.",
+            "The space is shared. Be considerate of other occupants and follow the warden's instructions.",
+            "Cell signal, internet and electricity may be down. Keep a portable radio with you for updates.",
+            "Wardens may ask you to help with simple shelter tasks. You are expected to cooperate.",
+          ]}
+        />
+      </GuidanceSection>
+
+      <GuidanceSection heading="Shelter rules" id="rules">
+        <Text as="p">
+          The Senior Warden runs the shelter and their decisions are final.
+          Every occupant must cooperate, including helping with shelter tasks if
+          the Warden asks.
+        </Text>
+        <Text as="p">
+          You <strong>cannot</strong> bring:
+        </Text>
+        <BulletList items={["pets", "firearms or other weapons", "alcohol"]} />
+        <Text as="p">
+          You <strong>cannot</strong>:
+        </Text>
+        <BulletList
+          items={[
+            "smoke in the shelter",
+            "damage the building, furniture or equipment — you will be prosecuted",
+            "use violence, profane language or behave in an anti-social way",
+          ]}
+        />
+        <Text as="p">
+          Shelter staff are <strong>not</strong> responsible for any belongings
+          you bring. The Department of Emergency Management is not liable for
+          lost or damaged property.
+        </Text>
+        <Text as="p">
+          If a State of Emergency is declared under the Emergency Management Act
+          (CAP 160A), you must follow any orders made under the Act.
+        </Text>
+      </GuidanceSection>
+
+      <GuidanceSection heading="Protocol for entering shelters" id="protocol">
+        <BulletList
+          items={[
+            "You do not have to wear a face mask, but you can if you want to.",
+            "If you have new respiratory symptoms, you must wear a face mask.",
+            "Hand sanitiser is available on entry — using it is optional.",
+            "If you have been isolating at home with a communicable illness, tell the warden on arrival and wear a face mask.",
+          ]}
+        />
+        <Text as="p">
+          Shelters can open at any time during the Atlantic hurricane season,
+          between 1 June and 30 November.
+        </Text>
+      </GuidanceSection>
+
+      <GuidanceSection
+        heading="Shelters with an accessible bathroom"
+        id="accessible-shelters"
+      >
+        <Text as="p">
+          {accessibleShelters.length} shelters have a bathroom suitable for
+          people who use a wheelchair. The rest of the building may not be
+          step-free — call ahead if you need to check.
+        </Text>
+        <Heading as="h3" size="h3">
+          Category 1 (used during a hurricane)
+        </Heading>
+        <BulletList
+          items={accessibleCategory1.map((s) => `${s.name} — ${s.parish}`)}
+        />
+        <Heading as="h3" size="h3">
+          Category 2 (used after a hurricane)
+        </Heading>
+        <BulletList
+          items={accessibleCategory2.map((s) => `${s.name} — ${s.parish}`)}
+        />
+      </GuidanceSection>
+
+      <GuidanceSection
+        heading="Your District Emergency Organisation"
+        id="district-organisations"
+      >
+        <Text as="p">
+          A District Emergency Organisation (DEO) is a network of trained
+          volunteers who coordinate the emergency response for your community.
+          Contact your local chairperson if you need community-level help
+          before, during or after an emergency.
+        </Text>
+        <ShowHide summary="Find your district chairperson">
+          <ul className="m-0 flex list-none flex-col p-0">
+            {DISTRICT_CHAIRS.map((chair) => (
+              <li
+                className="grid gap-0.5 border-grey-00 border-b py-s sm:grid-cols-[1fr_1fr] sm:items-baseline sm:gap-6"
+                key={chair.district}
+              >
+                <span className="font-bold">{chair.district}</span>
+                <span>
+                  {chair.name} — <Link href={chair.tel}>{chair.number}</Link>
+                </span>
+              </li>
+            ))}
+          </ul>
+          <Text as="p" className="mt-s text-mid-grey-00" size="caption">
+            Some districts (Christ Church South, Christ Church West Central and
+            St. Michael North) currently have no listed chairperson. Contact DEM
+            on <Link href={DEM_TEL}>438-7575</Link> if your district is not
+            shown.
+          </Text>
+        </ShowHide>
+      </GuidanceSection>
+
+      <GuidanceSection heading="Hurricane terms" id="hurricane-terms">
+        <Text as="p">
+          Words you may hear on local radio or TV during a storm.
+        </Text>
+        <dl className="m-0 flex flex-col">
+          {HURRICANE_TERMS.map((entry) => (
+            <div
+              className="flex flex-col gap-0.5 border-grey-00 border-b py-s"
+              key={entry.term}
+            >
+              <dt className="font-bold">{entry.term}</dt>
+              <dd className="m-0 text-mid-grey-00">{entry.definition}</dd>
+            </div>
+          ))}
+        </dl>
+      </GuidanceSection>
+
+      <GuidanceSection heading="All phone numbers" id="phone-numbers">
+        <Text as="p">
+          Save these numbers ahead of the hurricane season. All numbers below
+          are published in the 2026 Emergency Shelter Booklet.
+        </Text>
+        {PHONE_DIRECTORY.map((group) => (
+          <div className="flex flex-col gap-s" key={group.heading}>
+            <Heading as="h3" size="h3">
+              {group.heading}
+            </Heading>
+            <ul className="m-0 flex list-none flex-col p-0">
+              {group.entries.map((entry) => (
+                <PhoneRow entry={entry} key={entry.label} />
+              ))}
+            </ul>
+          </div>
+        ))}
+      </GuidanceSection>
+
+      <aside className="border-grey-00 border-t pt-m">
+        <Heading as="h2" size="h3">
+          Ready to find a shelter?
+        </Heading>
+        <Text as="p">
+          <Link as={NextLink} href={EMERGENCY_SHELTER_FIND_HREF}>
+            Find a shelter near you
+          </Link>
+        </Text>
+      </aside>
+
+      <Text as="p" className="text-mid-grey-00" size="caption">
+        Source: 2026 Emergency Shelter Booklet, Department of Emergency
+        Management.
+      </Text>
+    </div>
+  );
+}
+
+function GuidanceSection({
+  id,
+  heading,
+  children,
+}: {
+  id: string;
+  heading: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section
+      aria-labelledby={`${id}-heading`}
+      className="flex scroll-mt-m flex-col gap-s"
+      id={id}
+    >
+      <Heading as="h2" id={`${id}-heading`}>
+        {heading}
+      </Heading>
+      {children}
+    </section>
+  );
+}
+
+function BulletList({ items }: { items: string[] }) {
+  return (
+    <ul className="list-disc space-y-xs pl-6">
+      {items.map((item) => (
+        <li key={item}>{item}</li>
+      ))}
+    </ul>
+  );
+}
+
+function PhoneRow({ entry }: { entry: PhoneEntry }) {
+  return (
+    <li className="grid gap-0.5 border-grey-00 border-b py-s sm:grid-cols-[1fr_1fr] sm:items-baseline sm:gap-6">
+      <span className="font-bold">{entry.label}</span>
+      <span>
+        {entry.contacts.map((contact, index) => (
+          <span key={contact.tel}>
+            {index > 0 && ", "}
+            <Link href={contact.tel}>{contact.display}</Link>
+            {contact.note ? ` ${contact.note}` : ""}
+          </span>
+        ))}
+      </span>
+    </li>
+  );
+}

--- a/src/components/emergency-shelter/icons.tsx
+++ b/src/components/emergency-shelter/icons.tsx
@@ -1,0 +1,98 @@
+/**
+ * Small inline icons for the emergency shelter finder.
+ */
+
+export function Chevron({ open }: { open: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={`size-6 shrink-0 transition-transform ${open ? "rotate-180" : ""}`}
+      fill="none"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="m6 9 6 6 6-6"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+}
+
+export function CloseIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="size-5 shrink-0"
+      fill="none"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M6 6l12 12M18 6 6 18"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+}
+
+export function LocationIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="size-4"
+      fill="none"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M12 2v3M12 19v3M2 12h3M19 12h3"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="2"
+      />
+      <circle
+        cx="12"
+        cy="12"
+        fill="none"
+        r="5"
+        stroke="currentColor"
+        strokeWidth="2"
+      />
+      <circle cx="12" cy="12" fill="currentColor" r="1.5" />
+    </svg>
+  );
+}
+
+/** Hollow teardrop pin with a ring hole — scales with surrounding text. */
+export function MapPinIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="size-4 shrink-0"
+      fill="none"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M12 21s7-7.25 7-12a7 7 0 1 0-14 0c0 4.75 7 12 7 12z"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="2"
+      />
+      <circle
+        cx="12"
+        cy="9"
+        fill="none"
+        r="2.5"
+        stroke="currentColor"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+}

--- a/src/components/emergency-shelter/landing-page.tsx
+++ b/src/components/emergency-shelter/landing-page.tsx
@@ -1,0 +1,225 @@
+/**
+ * Find an emergency shelter — landing page
+ * --------------------------------------------------------------
+ * Server component for
+ * /health-and-emergency-services/find-an-emergency-shelter. Breadcrumbs, the
+ * alpha StageBanner and the "Was this helpful?" box come from the (content)
+ * layout, so this renders only the page body.
+ */
+
+import { Heading, Link, LinkButton, Text } from "@govtech-bb/react";
+import { format, parseISO } from "date-fns";
+import NextLink from "next/link";
+import {
+  SHELTERS_LAST_UPDATED,
+  SHELTERS_NEXT_REVIEW,
+  STORM_SEASON_LABEL,
+} from "@/data/emergency-shelters";
+import { buildPageMetadata } from "@/lib/page-metadata";
+import {
+  EMERGENCY_SHELTER_FIND_HREF,
+  EMERGENCY_SHELTER_GUIDANCE_HREF,
+  EMERGENCY_SHELTER_LANDING_HREF,
+} from "./routes";
+
+const TITLE = "Find an emergency shelter";
+const DESCRIPTION =
+  "Find an emergency shelter in Barbados to use during a hurricane or tropical storm.";
+
+export const emergencyShelterLandingMetadata = buildPageMetadata({
+  title: TITLE,
+  description: DESCRIPTION,
+  path: EMERGENCY_SHELTER_LANDING_HREF,
+});
+
+interface EmergencyPhone {
+  service: string;
+  number: string;
+  tel: string;
+}
+
+const EMERGENCY_PHONES: EmergencyPhone[] = [
+  { service: "Police", number: "211", tel: "tel:211" },
+  { service: "Fire Service", number: "311", tel: "tel:311" },
+  { service: "Ambulance", number: "511", tel: "tel:511" },
+  {
+    service: "Department of Emergency Management",
+    number: "438-7575",
+    tel: "tel:+12464387575",
+  },
+];
+
+export function EmergencyShelterLandingPage() {
+  return (
+    <div className="mb-l flex max-w-[42rem] flex-col gap-m">
+      <div className="flex flex-col gap-xs">
+        <Heading as="h1">{TITLE}</Heading>
+        <div className="border-blue-10 border-b-4 pb-4 text-mid-grey-00">
+          <Text as="p" size="caption">
+            Last updated on {format(parseISO(SHELTERS_LAST_UPDATED), "PPP")}.
+            Next review: {format(parseISO(SHELTERS_NEXT_REVIEW), "PPP")}.
+          </Text>
+        </div>
+        <Text as="p" className="text-mid-grey-00">
+          Search emergency shelters to use in the event of a hurricane or
+          tropical storm.
+        </Text>
+      </div>
+
+      <div className="flex flex-col gap-xs">
+        <LinkButton
+          as={NextLink}
+          className="self-start"
+          href={EMERGENCY_SHELTER_FIND_HREF}
+        >
+          Find a shelter
+        </LinkButton>
+        <Text as="p" className="text-mid-grey-00" size="caption">
+          It&apos;s free and you don&apos;t need to sign in.
+        </Text>
+      </div>
+
+      <section aria-labelledby="how-it-works" className="flex flex-col gap-s">
+        <Heading as="h2" id="how-it-works">
+          How this service works
+        </Heading>
+        <Text as="p">You can search for shelters online.</Text>
+        <Text as="p">
+          This service is for anyone in Barbados, including residents and
+          visitors.
+        </Text>
+        <Text as="p">
+          You may go to a shelter once it is open. Shelters open only when the
+          Department of Emergency Management announces that they are ready,
+          during the Atlantic hurricane season (
+          <strong>{STORM_SEASON_LABEL}</strong>).
+        </Text>
+      </section>
+
+      <section aria-labelledby="help-now" className="flex flex-col gap-s">
+        <Heading as="h2" id="help-now">
+          If you need help now, call:
+        </Heading>
+        <ul className="grid list-none auto-rows-fr grid-cols-1 gap-xs p-0 sm:grid-cols-2">
+          {EMERGENCY_PHONES.map((phone) => (
+            <li key={phone.service}>
+              <a
+                className="flex h-full flex-col gap-xxs border-red-00 border-l-4 bg-red-10 p-s text-current no-underline transition-colors hover:bg-red-40 focus-visible:outline focus-visible:outline-4 focus-visible:outline-red-100 focus-visible:outline-offset-2"
+                href={phone.tel}
+              >
+                <span className="font-bold">{phone.service}</span>
+                <span className="font-bold text-red-00 text-xl">
+                  {phone.number}
+                </span>
+              </a>
+            </li>
+          ))}
+        </ul>
+        <Text as="p" size="caption">
+          <Link
+            as={NextLink}
+            href={`${EMERGENCY_SHELTER_GUIDANCE_HREF}#phone-numbers`}
+          >
+            See all phone numbers
+          </Link>
+        </Text>
+      </section>
+
+      <section aria-labelledby="use-this" className="flex flex-col gap-s">
+        <Heading as="h2" id="use-this">
+          Use this service to
+        </Heading>
+        <ul className="list-disc space-y-xxs pl-6">
+          <li>find shelters in your parish</li>
+          <li>see which shelters have accessible bathrooms or potable water</li>
+          <li>
+            see which shelters are used during or after a hurricane or storm
+          </li>
+        </ul>
+      </section>
+
+      <section
+        aria-labelledby="what-youll-need"
+        className="flex flex-col gap-s"
+      >
+        <Heading as="h2" id="what-youll-need">
+          What you&apos;ll need
+        </Heading>
+        <Text as="p">
+          Pack a Go Bag with bottled water, your ID, any prescription
+          medication, a flashlight, and some cash.{" "}
+          <Link
+            as={NextLink}
+            href={`${EMERGENCY_SHELTER_GUIDANCE_HREF}#go-bag`}
+          >
+            See the full Go Bag list
+          </Link>
+          .
+        </Text>
+      </section>
+
+      <section aria-labelledby="key-things" className="flex flex-col gap-s">
+        <Heading as="h2" id="key-things">
+          Key things to know
+        </Heading>
+        <ul className="list-disc space-y-xxs pl-6">
+          <li>
+            Stay at home, or with family or friends, if it is safe to do so.
+          </li>
+          <li>
+            Pets, alcohol, firearms and other weapons are not allowed in
+            shelters.
+          </li>
+          <li>Smoking is not allowed inside shelters.</li>
+          <li>You are responsible for your belongings.</li>
+        </ul>
+        <Text as="p">
+          <Link as={NextLink} href={`${EMERGENCY_SHELTER_GUIDANCE_HREF}#rules`}>
+            See the full shelter rules
+          </Link>{" "}
+          before you go.
+        </Text>
+      </section>
+
+      <section aria-labelledby="other-ways" className="flex flex-col gap-s">
+        <Heading as="h2" id="other-ways">
+          Other ways to find a shelter
+        </Heading>
+        <Text as="p">You can also:</Text>
+        <ul className="list-disc space-y-xxs pl-6">
+          <li>
+            listen to local radio or watch TV news for the official list of open
+            shelters
+          </li>
+          <li>
+            follow the Department of Emergency Management, the Ministry of
+            Educational Transformation, and the Barbados Government Information
+            Service on social media
+          </li>
+          <li>
+            call the Department of Emergency Management at{" "}
+            <Link href="tel:+12464387575">438-7575</Link>
+          </li>
+        </ul>
+      </section>
+
+      <aside className="border-blue-100 border-l-4 bg-blue-10 px-s py-xm">
+        <Heading as="h2" size="h3">
+          Before you go to a shelter
+        </Heading>
+        <Text as="p">
+          <Link as={NextLink} href={EMERGENCY_SHELTER_GUIDANCE_HREF}>
+            Read the full guidance
+          </Link>{" "}
+          on rules, what to bring, accessibility, entry procedures and emergency
+          phone numbers.
+        </Text>
+      </aside>
+
+      <Text as="p" className="text-mid-grey-00" size="caption">
+        Source: 2026 Emergency Shelter Booklet, Department of Emergency
+        Management.
+      </Text>
+    </div>
+  );
+}

--- a/src/components/emergency-shelter/routes.ts
+++ b/src/components/emergency-shelter/routes.ts
@@ -1,0 +1,5 @@
+/** Canonical paths for the Find an emergency shelter pages. */
+export const EMERGENCY_SHELTER_LANDING_HREF =
+  "/health-and-emergency-services/find-an-emergency-shelter";
+export const EMERGENCY_SHELTER_FIND_HREF = `${EMERGENCY_SHELTER_LANDING_HREF}/find`;
+export const EMERGENCY_SHELTER_GUIDANCE_HREF = `${EMERGENCY_SHELTER_LANDING_HREF}/guidance`;

--- a/src/components/emergency-shelter/shelter-card.tsx
+++ b/src/components/emergency-shelter/shelter-card.tsx
@@ -1,0 +1,111 @@
+/**
+ * Emergency shelter result card.
+ * --------------------------------------------------------------
+ * Presentational — given a shelter (and an optional distance from the user),
+ * renders its status, name, capacity, address, amenity tags and a directions
+ * link. No finder state.
+ */
+
+import { Heading, Link, Text } from "@govtech-bb/react";
+import type { ReactNode } from "react";
+import type { Shelter } from "@/data/emergency-shelters";
+import { formatDistance, type ShelterDistance } from "@/lib/shelter-distance";
+import { MapPinIcon } from "./icons";
+
+function mapsUrl(shelter: Shelter): string {
+  const query = encodeURIComponent(
+    `${shelter.name}, ${shelter.parish}, Barbados`
+  );
+  return `https://www.google.com/maps/search/?api=1&query=${query}`;
+}
+
+const TAG_TONES = {
+  category: "bg-yellow-40 text-blue-100",
+  access: "bg-teal-10 text-teal-00",
+  water: "bg-green-10 text-green-100",
+  warning: "bg-red-10 text-red-00",
+} as const;
+
+function Tag({
+  tone,
+  children,
+}: {
+  tone: keyof typeof TAG_TONES;
+  children: ReactNode;
+}) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-md px-3 py-1 font-semibold text-sm ${TAG_TONES[tone]}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function ShelterCard({
+  shelter,
+  distance,
+}: {
+  shelter: Shelter;
+  distance: ShelterDistance | null;
+}) {
+  const ownership =
+    shelter.ownership === "Public" ? "public" : "privately owned";
+
+  return (
+    <li className="flex h-full flex-col gap-xs rounded-lg border-4 border-grey-00 bg-white-00 p-s">
+      <p className="inline-flex w-fit items-center gap-2 rounded-full bg-grey-00 px-3 py-1 font-bold text-mid-grey-00 text-xs uppercase tracking-wide">
+        <span
+          aria-hidden="true"
+          className="size-2 rounded-full bg-mid-grey-00"
+        />
+        Not currently open
+      </p>
+
+      {shelter.restriction && (
+        <p className="inline-flex w-fit items-center gap-1 rounded-full bg-red-10 px-3 py-1 font-semibold text-red-00 text-sm">
+          <strong>Restricted:</strong> {shelter.restriction}
+        </p>
+      )}
+
+      <Heading as="h3" size="h3">
+        {shelter.name}
+      </Heading>
+
+      <Text as="p" className="text-mid-grey-00">
+        {shelter.parish}, {ownership}, holds up to {shelter.capacity} people
+        (booklet planning figure — not live availability)
+      </Text>
+
+      {shelter.address && (
+        <p className="inline-flex items-center gap-1.5">
+          <MapPinIcon />
+          {shelter.address}
+        </p>
+      )}
+
+      {distance && (
+        <p className="inline-flex items-center gap-1.5 font-semibold text-blue-100">
+          <MapPinIcon />
+          {formatDistance(distance)}
+        </p>
+      )}
+
+      <div className="mt-auto flex flex-wrap gap-xs">
+        <Tag tone="category">Category {shelter.category}</Tag>
+        {shelter.access && <Tag tone="access">Accessible bathroom</Tag>}
+        {shelter.water ? (
+          <Tag tone="water">Potable water</Tag>
+        ) : (
+          <Tag tone="warning">No potable water</Tag>
+        )}
+      </div>
+
+      <p>
+        <Link external href={mapsUrl(shelter)}>
+          Get directions on Google Maps
+        </Link>
+      </p>
+    </li>
+  );
+}

--- a/src/components/emergency-shelter/shelter-finder.tsx
+++ b/src/components/emergency-shelter/shelter-finder.tsx
@@ -1,0 +1,572 @@
+/**
+ * Emergency shelter finder (interactive)
+ * --------------------------------------------------------------
+ * Search 70 shelters by name; filter by parish, category and amenities using
+ * the GOV.BB Filter pattern (collapsible panel of accordion checkbox groups
+ * with removable filter tags); sort by parish, name, capacity or distance.
+ * "Use my location" enables nearest-first ordering. Filter state is mirrored
+ * to the URL so a filtered view can be shared.
+ *
+ * No live activation feed exists, so every shelter shows "Not currently open".
+ */
+
+"use client";
+
+import {
+  Button,
+  Checkbox,
+  Heading,
+  Input,
+  Link,
+  Select,
+  Text,
+} from "@govtech-bb/react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  type ReactNode,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import {
+  EMERGENCY_SHELTERS,
+  type LatLon,
+  PARISHES,
+  type Shelter,
+} from "@/data/emergency-shelters";
+import { shelterDistance, userIsOnIsland } from "@/lib/shelter-distance";
+import { Chevron, CloseIcon, LocationIcon } from "./icons";
+import { ShelterCard } from "./shelter-card";
+
+const DEM_TEL = "tel:+12464387575";
+const DEM_NUMBER = "438-7575";
+
+type SortKey = "parish" | "name" | "capacity" | "distance";
+type LocationState = "idle" | "loading" | "success";
+
+interface Filters {
+  parishes: string[];
+  categories: string[];
+  accessible: boolean;
+  search: string;
+}
+
+function parseList(value: string | null): string[] {
+  return value ? value.split(",").filter(Boolean) : [];
+}
+
+const SORT_KEYS: readonly SortKey[] = [
+  "parish",
+  "name",
+  "capacity",
+  "distance",
+];
+
+function parseSort(value: string | null): SortKey {
+  return value && (SORT_KEYS as readonly string[]).includes(value)
+    ? (value as SortKey)
+    : "parish";
+}
+
+function toggleValue(list: string[], value: string): string[] {
+  return list.includes(value)
+    ? list.filter((item) => item !== value)
+    : [...list, value];
+}
+
+function matchesFilters(shelter: Shelter, f: Filters): boolean {
+  if (f.parishes.length > 0 && !f.parishes.includes(shelter.parish)) {
+    return false;
+  }
+  if (
+    f.categories.length > 0 &&
+    !f.categories.includes(String(shelter.category))
+  ) {
+    return false;
+  }
+  if (f.accessible && !shelter.access) {
+    return false;
+  }
+  const query = f.search.trim().toLowerCase();
+  if (
+    query &&
+    !(
+      shelter.name.toLowerCase().includes(query) ||
+      shelter.parish.toLowerCase().includes(query)
+    )
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function compareForSort(
+  a: Shelter,
+  b: Shelter,
+  sort: SortKey,
+  user: LatLon | null
+): number {
+  if (sort === "name") {
+    return a.name.localeCompare(b.name);
+  }
+  if (sort === "capacity") {
+    return b.capacity - a.capacity;
+  }
+  if (sort === "distance" && user) {
+    const da = shelterDistance(a, user);
+    const db = shelterDistance(b, user);
+    if (da === null) {
+      return 1;
+    }
+    if (db === null) {
+      return -1;
+    }
+    return da.km - db.km;
+  }
+  return a.parish === b.parish
+    ? a.name.localeCompare(b.name)
+    : a.parish.localeCompare(b.parish);
+}
+
+const GEO_OPTIONS: PositionOptions = {
+  enableHighAccuracy: false,
+  timeout: 10_000,
+  maximumAge: 60_000,
+};
+
+const LOCATION_ERRORS: Record<number, string> = {
+  1: "You blocked location access. Allow location in your browser, or filter by parish instead.",
+  2: "Your location is unavailable. Filter by parish instead.",
+  3: "The location request timed out. Filter by parish instead.",
+};
+
+/** Shelters shown before the "Show more" button appears. */
+const PAGE_SIZE = 12;
+
+export function ShelterFinder() {
+  return (
+    <Suspense fallback={null}>
+      <FinderContent />
+    </Suspense>
+  );
+}
+
+function FinderContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [parishes, setParishes] = useState(() =>
+    parseList(searchParams.get("parish"))
+  );
+  const [categories, setCategories] = useState(() =>
+    parseList(searchParams.get("cat"))
+  );
+  const [accessible, setAccessible] = useState(
+    () => searchParams.get("access") === "1"
+  );
+  const [search, setSearch] = useState(() => searchParams.get("q") ?? "");
+  const [sort, setSort] = useState<SortKey>(() =>
+    parseSort(searchParams.get("sort"))
+  );
+
+  const [userLocation, setUserLocation] = useState<LatLon | null>(null);
+  const [locationStatus, setLocationStatus] = useState<string | null>(null);
+  const [locationState, setLocationState] = useState<LocationState>("idle");
+  const [filterOpen, setFilterOpen] = useState(true);
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+
+  // Reset to the first page whenever the filters or search change.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset on filter changes only
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [parishes, categories, accessible, search]);
+
+  // Mirror filters to the URL so a filtered view can be shared.
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (search) {
+      params.set("q", search);
+    }
+    if (parishes.length > 0) {
+      params.set("parish", parishes.join(","));
+    }
+    if (categories.length > 0) {
+      params.set("cat", categories.join(","));
+    }
+    if (accessible) {
+      params.set("access", "1");
+    }
+    if (sort !== "parish") {
+      params.set("sort", sort);
+    }
+    const qs = params.toString();
+    router.replace(qs ? `?${qs}` : "?", { scroll: false });
+  }, [search, parishes, categories, accessible, sort, router]);
+
+  const results = useMemo(() => {
+    const active: Filters = { parishes, categories, accessible, search };
+    return EMERGENCY_SHELTERS.filter((shelter) =>
+      matchesFilters(shelter, active)
+    ).sort((a, b) => compareForSort(a, b, sort, userLocation));
+  }, [parishes, categories, accessible, search, sort, userLocation]);
+
+  const visibleShelters = results.slice(0, visibleCount);
+
+  const requestLocation = useCallback(() => {
+    if (!navigator.geolocation) {
+      setLocationStatus(
+        "Your device does not support location. You can still filter by parish."
+      );
+      setSort("parish");
+      return;
+    }
+    setLocationStatus("Finding your location…");
+    setLocationState("loading");
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const found: LatLon = {
+          lat: position.coords.latitude,
+          lon: position.coords.longitude,
+        };
+        if (!userIsOnIsland(found)) {
+          setUserLocation(null);
+          setLocationState("idle");
+          setSort("parish");
+          setLocationStatus(
+            "You appear to be outside Barbados, so distance isn't meaningful. Filter by parish instead."
+          );
+          return;
+        }
+        setUserLocation(found);
+        setLocationState("success");
+        setSort("distance");
+        setLocationStatus(
+          "Sorted by distance from your parish. Two shelters in the same parish show the same distance."
+        );
+      },
+      (error) => {
+        setUserLocation(null);
+        setLocationState("idle");
+        setSort("parish");
+        setLocationStatus(
+          LOCATION_ERRORS[error.code] ??
+            "Could not get your location. Filter by parish instead."
+        );
+      },
+      GEO_OPTIONS
+    );
+  }, []);
+
+  const onSortChange = useCallback(
+    (value: SortKey) => {
+      setSort(value);
+      if (value === "distance" && !userLocation) {
+        requestLocation();
+      }
+    },
+    [userLocation, requestLocation]
+  );
+
+  const clearAll = useCallback(() => {
+    setParishes([]);
+    setCategories([]);
+    setAccessible(false);
+    setSearch("");
+  }, []);
+
+  const tags: { key: string; label: string; remove: () => void }[] = [
+    ...parishes.map((p) => ({
+      key: `parish:${p}`,
+      label: p,
+      remove: () => setParishes((list) => list.filter((x) => x !== p)),
+    })),
+    ...categories.map((c) => ({
+      key: `cat:${c}`,
+      label: `Category ${c}`,
+      remove: () => setCategories((list) => list.filter((x) => x !== c)),
+    })),
+    ...(accessible
+      ? [
+          {
+            key: "access",
+            label: "Accessible bathroom",
+            remove: () => setAccessible(false),
+          },
+        ]
+      : []),
+  ];
+
+  const locationLabel =
+    locationState === "loading"
+      ? "Finding your location…"
+      : locationState === "success"
+        ? "Location set — refresh"
+        : "Use my location";
+
+  return (
+    <section aria-label="Shelter finder">
+      <Text
+        as="p"
+        className="mb-s text-mid-grey-00 print:hidden"
+        size="caption"
+      >
+        <button
+          className="underline"
+          onClick={() => window.print()}
+          type="button"
+        >
+          Print this list
+        </button>{" "}
+        to keep a paper copy. Each shelter has a Google Maps directions link.
+      </Text>
+
+      <div className="lg:grid lg:grid-cols-[20rem_1fr] lg:gap-8">
+        {/* Sidebar: search, locate and filter */}
+        <div className="mb-m flex flex-col gap-m lg:mb-0 print:hidden">
+          {/* Filter — GOV.BB pattern: collapsible panel of checkbox groups */}
+          <div>
+            <button
+              aria-controls="shelter-filter-panel"
+              aria-expanded={filterOpen}
+              className="flex w-full items-center gap-xs border-mid-grey-00 border-b py-3 text-green-00"
+              onClick={() => setFilterOpen((open) => !open)}
+              type="button"
+            >
+              <span className="font-bold text-[20px] underline">Filter</span>
+              <Chevron open={filterOpen} />
+            </button>
+
+            {filterOpen && (
+              <div
+                className="flex flex-col gap-xm border-grey-00 border-b bg-grey-00 p-xm"
+                id="shelter-filter-panel"
+              >
+                <Input
+                  autoComplete="off"
+                  label="Search by name"
+                  onChange={(event) => setSearch(event.target.value)}
+                  placeholder="e.g. Combermere"
+                  type="search"
+                  value={search}
+                />
+
+                <div className="flex flex-col gap-xs">
+                  <Button
+                    aria-busy={locationState === "loading"}
+                    className="self-start"
+                    disabled={locationState === "loading"}
+                    onClick={requestLocation}
+                    type="button"
+                  >
+                    <span className="inline-flex items-center gap-2">
+                      <LocationIcon />
+                      {locationLabel}
+                    </span>
+                  </Button>
+                  {locationStatus && (
+                    <Text
+                      aria-live="polite"
+                      as="p"
+                      className="text-mid-grey-00"
+                      size="caption"
+                    >
+                      {locationStatus}
+                    </Text>
+                  )}
+                </div>
+
+                <Select
+                  label="Sort by"
+                  onChange={(event) =>
+                    onSortChange(event.target.value as SortKey)
+                  }
+                  value={sort}
+                >
+                  <option value="parish">Parish (default)</option>
+                  <option value="name">Name</option>
+                  <option value="capacity">Largest first</option>
+                  <option value="distance">Nearest first</option>
+                </Select>
+
+                <FilterGroup defaultOpen={false} title="Parish">
+                  {PARISHES.map((name) => (
+                    <Checkbox
+                      checked={parishes.includes(name)}
+                      id={`parish-${name}`}
+                      key={name}
+                      label={name}
+                      onCheckedChange={() =>
+                        setParishes((list) => toggleValue(list, name))
+                      }
+                    />
+                  ))}
+                </FilterGroup>
+
+                <FilterGroup
+                  hint="Category 1 is used during a hurricane; Category 2 is used after one has passed."
+                  title="Category"
+                >
+                  <Checkbox
+                    checked={categories.includes("1")}
+                    id="cat-1"
+                    label="Category 1"
+                    onCheckedChange={() =>
+                      setCategories((list) => toggleValue(list, "1"))
+                    }
+                  />
+                  <Checkbox
+                    checked={categories.includes("2")}
+                    id="cat-2"
+                    label="Category 2"
+                    onCheckedChange={() =>
+                      setCategories((list) => toggleValue(list, "2"))
+                    }
+                  />
+                </FilterGroup>
+
+                <FilterGroup
+                  hint="Only 14 shelters have a bathroom suitable for people who use a wheelchair. The rest of the building may not be step-free — call ahead if you need to check."
+                  title="Accessibility"
+                >
+                  <Checkbox
+                    checked={accessible}
+                    id="filter-access"
+                    label="Has an accessible bathroom"
+                    onCheckedChange={(checked) =>
+                      setAccessible(checked === true)
+                    }
+                  />
+                </FilterGroup>
+              </div>
+            )}
+
+            {tags.length > 0 && (
+              <div className="flex flex-col gap-s pt-xs">
+                <div className="flex flex-wrap items-center gap-xs">
+                  {tags.map((tag) => (
+                    <button
+                      className="inline-flex items-center gap-2 bg-teal-10 p-2.5 font-medium hover:bg-teal-40"
+                      key={tag.key}
+                      onClick={tag.remove}
+                      type="button"
+                    >
+                      {tag.label}
+                      <CloseIcon />
+                      <span className="sr-only">Remove filter</span>
+                    </button>
+                  ))}
+                </div>
+                <button
+                  className="self-start font-semibold text-red-00 underline"
+                  onClick={clearAll}
+                  type="button"
+                >
+                  Clear all
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Results — single column on mobile, grid on desktop */}
+        <div>
+          <Text as="p" className="mb-s font-bold" role="status">
+            {resultCountLabel(visibleShelters.length, results.length)}
+          </Text>
+
+          {results.length === 0 ? (
+            <div className="border-blue-100 border-l-4 bg-blue-10 px-s py-xm">
+              <Text as="p">
+                Try clearing a filter above, or call the Department of Emergency
+                Management on <Link href={DEM_TEL}>{DEM_NUMBER}</Link> for help.
+              </Text>
+            </div>
+          ) : (
+            <>
+              <ul className="grid list-none auto-rows-fr grid-cols-1 gap-s p-0 lg:grid-cols-2">
+                {visibleShelters.map((shelter) => (
+                  <ShelterCard
+                    distance={shelterDistance(shelter, userLocation)}
+                    key={shelter.name}
+                    shelter={shelter}
+                  />
+                ))}
+              </ul>
+              {visibleShelters.length < results.length && (
+                <div className="mt-m flex justify-center print:hidden">
+                  <Button
+                    onClick={() =>
+                      setVisibleCount((count) => count + PAGE_SIZE)
+                    }
+                    type="button"
+                    variant="secondary"
+                  >
+                    Show{" "}
+                    {Math.min(
+                      PAGE_SIZE,
+                      results.length - visibleShelters.length
+                    )}{" "}
+                    more shelters
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FilterGroup({
+  title,
+  hint,
+  defaultOpen = true,
+  children,
+}: {
+  title: string;
+  hint?: string;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="flex w-full flex-col gap-s border-mid-grey-00 border-b pb-s">
+      <button
+        aria-expanded={open}
+        className="flex w-full items-center justify-between gap-2.5"
+        onClick={() => setOpen((value) => !value)}
+        type="button"
+      >
+        <Heading as="h3" size="h4">
+          {title}
+        </Heading>
+        <span className="text-teal-00">
+          <Chevron open={open} />
+        </span>
+      </button>
+      {open && (
+        <div className="flex flex-col gap-s">
+          {hint && (
+            <Text as="p" className="text-mid-grey-00" size="caption">
+              {hint}
+            </Text>
+          )}
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function resultCountLabel(visible: number, matched: number): string {
+  if (matched === 0) {
+    return "No shelters match your filters";
+  }
+  if (visible >= matched) {
+    return `Showing all ${matched} shelters`;
+  }
+  return `Showing ${visible} of ${matched} shelters`;
+}

--- a/src/data/content-directory.ts
+++ b/src/data/content-directory.ts
@@ -685,6 +685,37 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
           },
         ],
       },
+      {
+        title: "Find an emergency shelter",
+        slug: "find-an-emergency-shelter",
+        keywords: [
+          "shelter",
+          "emergency shelter",
+          "hurricane",
+          "storm",
+          "evacuation",
+          "DEM",
+          "Department of Emergency Management",
+          "parish",
+          "Go Bag",
+          "warden",
+          "disaster",
+        ],
+        description:
+          "Search all 70 emergency shelters in Barbados to use during a hurricane or tropical storm. Filter by parish, category and accessibility, and read what to bring before you go.",
+        subPages: [
+          {
+            slug: "find",
+            title: "Search shelters",
+            type: "component",
+          },
+          {
+            slug: "guidance",
+            title: "Before you go to a shelter",
+            type: "component",
+          },
+        ],
+      },
     ],
   },
   {

--- a/src/data/emergency-shelters.json
+++ b/src/data/emergency-shelters.json
@@ -1,0 +1,878 @@
+[
+  {
+    "name": "Blackman and Gollop Primary School",
+    "parish": "Christ Church",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 80,
+    "water": true,
+    "access": true,
+    "coords": {
+      "lat": 13.09797,
+      "lon": -59.5572201
+    },
+    "address": "Staple Grove, Christ Church, BB17003"
+  },
+  {
+    "name": "Gordon Walters Primary School",
+    "parish": "Christ Church",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 40,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.0962666,
+      "lon": -59.4945239
+    },
+    "address": "Highway P, Bright Hill, St. Patrick's"
+  },
+  {
+    "name": "St. Christopher Primary School",
+    "parish": "Christ Church",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 75,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.0532305,
+      "lon": -59.5177023
+    },
+    "address": "St Christopher's Road, St. Christopher, Hopewell"
+  },
+  {
+    "name": "Cuthbert Moore Primary School",
+    "parish": "St. George",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 36,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1525839,
+      "lon": -59.5649785
+    },
+    "address": "Highway 3, Astoria, Market Hill"
+  },
+  {
+    "name": "Gordon Greenidge Primary School",
+    "parish": "St. James",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 40,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.2292129,
+      "lon": -59.6233299
+    },
+    "address": "Ronald Mapp Highway, Westmoreland, Saint Peter"
+  },
+  {
+    "name": "Queens College",
+    "parish": "St. James",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 100,
+    "water": true,
+    "access": false
+  },
+  {
+    "name": "St. Silas Primary School",
+    "parish": "St. James",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 40,
+    "water": true,
+    "access": false
+  },
+  {
+    "name": "The Lodge School",
+    "parish": "St. John",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 195,
+    "water": true,
+    "access": true,
+    "coords": {
+      "lat": 13.1675413,
+      "lon": -59.4878405
+    },
+    "address": "Highway H, Green Point, Society"
+  },
+  {
+    "name": "Mount Tabor Primary School",
+    "parish": "St. John",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 40,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1821049,
+      "lon": -59.5237049
+    },
+    "address": "Mount Tabor Church Road, Mount Tabor, Sherbourne"
+  },
+  {
+    "name": "Tamarind Hall Branch Library (Eric Holder Municipal Complex)",
+    "parish": "St. Joseph",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 54,
+    "water": true,
+    "access": true,
+    "coords": {
+      "lat": 13.1931231,
+      "lon": -59.5437155
+    },
+    "address": "Eric J Holder Municipal Complex, Surinam, Bowling Alley Hill"
+  },
+  {
+    "name": "Ignatius Byer Primary School",
+    "parish": "St. Lucy",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 35,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.3091402,
+      "lon": -59.5946079
+    },
+    "address": "Lowlands Road, Lowland, Pie Corner"
+  },
+  {
+    "name": "Combermere School",
+    "parish": "St. Michael",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 100,
+    "water": true,
+    "access": true,
+    "coords": {
+      "lat": 13.1167423,
+      "lon": -59.6021111
+    },
+    "address": "Garlow Path, Bush Hall, Bridgetown"
+  },
+  {
+    "name": "George Lamming Primary School",
+    "parish": "St. Michael",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 79,
+    "water": true,
+    "access": true,
+    "coords": {
+      "lat": 13.1056377,
+      "lon": -59.6019488
+    },
+    "address": "Bridge Road, Carrington Village, Saint Michael"
+  },
+  {
+    "name": "Harrison College",
+    "parish": "St. Michael",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 81,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1001042,
+      "lon": -59.6100881
+    },
+    "address": "Crumpton's Street, Bridgetown, Saint Michael"
+  },
+  {
+    "name": "Lloyd Erskine Sandiford Centre",
+    "parish": "St. Michael",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 365,
+    "water": true,
+    "access": true,
+    "coords": {
+      "lat": 13.1039434,
+      "lon": -59.5830398
+    },
+    "address": "Two Mile Hill, Bridgetown, Saint Michael"
+  },
+  {
+    "name": "The University of the West Indies (Sagicor Building)",
+    "parish": "St. Michael",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 100,
+    "water": true,
+    "access": true
+  },
+  {
+    "name": "Westbury Primary School",
+    "parish": "St. Michael",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 61,
+    "water": true,
+    "access": true,
+    "coords": {
+      "lat": 13.1055624,
+      "lon": -59.6199231
+    },
+    "address": "Westbury Road, New Orleans, Bridgetown"
+  },
+  {
+    "name": "Coleridge and Parry School",
+    "parish": "St. Peter",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 140,
+    "water": true,
+    "access": true,
+    "coords": {
+      "lat": 13.2598169,
+      "lon": -59.6383268
+    },
+    "address": "Douglas Road, Speightstown, Saint Peter"
+  },
+  {
+    "name": "Lester Vaughan School",
+    "parish": "St. Thomas",
+    "category": 1,
+    "ownership": "Public",
+    "capacity": 115,
+    "water": true,
+    "access": true
+  },
+  {
+    "name": "Hillaby Seventh Day Adventist Church",
+    "parish": "St. Andrew",
+    "category": 1,
+    "ownership": "Privately Owned",
+    "capacity": 32,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.2128905,
+      "lon": -59.5878026
+    },
+    "address": "Highway D, Gregg Farm, Hillaby"
+  },
+  {
+    "name": "Ellerton Wesleyan Holiness Church",
+    "parish": "St. George",
+    "category": 1,
+    "ownership": "Privately Owned",
+    "capacity": 24,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1290645,
+      "lon": -59.5411593
+    },
+    "address": "Eustace Lashley Road, Ellerton, Saint George"
+  },
+  {
+    "name": "Church of God Orange Hill",
+    "parish": "St. James",
+    "category": 1,
+    "ownership": "Privately Owned",
+    "capacity": 106,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.2041326,
+      "lon": -59.6051784
+    },
+    "address": "Endeavour Cul-de-sac, Endeavour, Orange Hill"
+  },
+  {
+    "name": "Connell Town Pentecostal House of Prayer",
+    "parish": "St. Lucy",
+    "category": 1,
+    "ownership": "Privately Owned",
+    "capacity": 21,
+    "water": true,
+    "access": false
+  },
+  {
+    "name": "William Donald George Parish Centre (St. Lucy Parish Church)",
+    "parish": "St. Lucy",
+    "category": 1,
+    "ownership": "Privately Owned",
+    "capacity": 20,
+    "water": true,
+    "access": true
+  },
+  {
+    "name": "Black Rock Seventh Day Adventist Church",
+    "parish": "St. Michael",
+    "category": 1,
+    "ownership": "Privately Owned",
+    "capacity": 32,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1282351,
+      "lon": -59.6258395
+    },
+    "address": "Ellerslie School Road, Black Rock, Saint Michael"
+  },
+  {
+    "name": "Faith Wesleyan Holiness Church",
+    "parish": "St. Michael",
+    "category": 1,
+    "ownership": "Privately Owned",
+    "capacity": 30,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1369325,
+      "lon": -59.592313
+    },
+    "address": "Highway E, Lears Court, Jackmans"
+  },
+  {
+    "name": "St. Barnabas Senior Citizens Centre",
+    "parish": "St. Michael",
+    "category": 1,
+    "ownership": "Privately Owned",
+    "capacity": 46,
+    "water": true,
+    "access": false
+  },
+  {
+    "name": "Ruby Church of the Nazarene",
+    "parish": "St. Philip",
+    "category": 1,
+    "ownership": "Privately Owned",
+    "capacity": 45,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1274867,
+      "lon": -59.4479606
+    },
+    "address": "Highway 5, Ruby Tenantry, Robinsons"
+  },
+  {
+    "name": "Six Roads Church of Christ",
+    "parish": "St. Philip",
+    "category": 1,
+    "ownership": "Privately Owned",
+    "capacity": 40,
+    "water": true,
+    "access": false
+  },
+  {
+    "name": "Christ Church Foundation School",
+    "parish": "Christ Church",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 75,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.0661926,
+      "lon": -59.540469
+    },
+    "address": "Church Hill Main Road, Oistins, Christ Church"
+  },
+  {
+    "name": "Deighton Griffith School",
+    "parish": "Christ Church",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 40,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.079015,
+      "lon": -59.5522755
+    },
+    "address": "Kingsland, Christ Church, BB15028"
+  },
+  {
+    "name": "St. Bartholomew Primary School",
+    "parish": "Christ Church",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 35,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.0749627,
+      "lon": -59.5141774
+    },
+    "address": "Parish Land Road, Parish Land, Chancery Lane"
+  },
+  {
+    "name": "Ellerton Primary School",
+    "parish": "St. George",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 25,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1317408,
+      "lon": -59.5411571
+    },
+    "address": "Ellerton Road, Ellerton, Saint George"
+  },
+  {
+    "name": "St. George Secondary",
+    "parish": "St. George",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 80,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1272196,
+      "lon": -59.563281
+    },
+    "address": "Highway W, Constant, Saint George"
+  },
+  {
+    "name": "West Terrace Primary School",
+    "parish": "St. James",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 40,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1450271,
+      "lon": -59.6311782
+    },
+    "address": "Wanstead Drive, West Terrace, Bagatelle"
+  },
+  {
+    "name": "St. Margaret's Primary School",
+    "parish": "St. John",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 40,
+    "water": true,
+    "access": false
+  },
+  {
+    "name": "Grantley Adams Memorial",
+    "parish": "St. Joseph",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 120,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1882724,
+      "lon": -59.5429165
+    },
+    "address": "Highway 3, Casuarina Hill, Horse Hill"
+  },
+  {
+    "name": "St. Bernard Primary School",
+    "parish": "St. Joseph",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 40,
+    "water": true,
+    "access": false
+  },
+  {
+    "name": "St. Joseph Primary School",
+    "parish": "St. Joseph",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 35,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1937681,
+      "lon": -59.5447443
+    },
+    "address": "Highway 3, Casuarina Hill, Horse Hill"
+  },
+  {
+    "name": "Daryll Jordan Secondary",
+    "parish": "St. Lucy",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 150,
+    "water": true,
+    "access": true
+  },
+  {
+    "name": "Selah Primary School",
+    "parish": "St. Lucy",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 40,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.3142642,
+      "lon": -59.6351882
+    },
+    "address": "Highway 1B, Content, Greenidge"
+  },
+  {
+    "name": "Barbados Community College (Commerce Division)",
+    "parish": "St. Michael",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 244,
+    "water": false,
+    "access": true
+  },
+  {
+    "name": "Bay Primary School",
+    "parish": "St. Michael",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 50,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.0891058,
+      "lon": -59.6023449
+    },
+    "address": "Bay Gardens, Bayland, Saint Michael"
+  },
+  {
+    "name": "The Ellerslie School",
+    "parish": "St. Michael",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 55,
+    "water": true,
+    "access": false
+  },
+  {
+    "name": "Grazettes Primary School",
+    "parish": "St. Michael",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 50,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1310222,
+      "lon": -59.6177211
+    },
+    "address": "Denton Road, White Hall, Saint Michael"
+  },
+  {
+    "name": "Lawrence T. Gay Memorial",
+    "parish": "St. Michael",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 40,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1236502,
+      "lon": -59.6089401
+    },
+    "address": "Spooners Hill Main Road, Spooners Hill, Saint Michael"
+  },
+  {
+    "name": "Luther Thorne Memorial",
+    "parish": "St. Michael",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 100,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.0904114,
+      "lon": -59.5849019
+    },
+    "address": "Wildey Road, Wildey Industrial Park, Wildey"
+  },
+  {
+    "name": "Parkinson Memorial School",
+    "parish": "St. Michael",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 215,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.0981946,
+      "lon": -59.5810359
+    },
+    "address": "Pine East West Boulevard, The Pine, Saint Michael"
+  },
+  {
+    "name": "Springer Memorial School",
+    "parish": "St. Michael",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 66,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1016624,
+      "lon": -59.5960977
+    },
+    "address": "Government Hill, Saint Michael, BB14004"
+  },
+  {
+    "name": "St. Ambrose Primary School",
+    "parish": "St. Michael",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 40,
+    "water": true,
+    "access": false
+  },
+  {
+    "name": "St. Leonard's Boys' School",
+    "parish": "St. Michael",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 55,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.11187,
+      "lon": -59.617969
+    },
+    "address": "President Kennedy Drive, Eagle Hall, Saint Michael"
+  },
+  {
+    "name": "The St. Michael School",
+    "parish": "St. Michael",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 37,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.0968678,
+      "lon": -59.6047107
+    },
+    "address": "Martindales Road, Bridgetown, Saint Michael"
+  },
+  {
+    "name": "Princess Margaret Secondary",
+    "parish": "St. Philip",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 60,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1190052,
+      "lon": -59.4752183
+    },
+    "address": "Highway 5, Six Roads, Saint Philip"
+  },
+  {
+    "name": "Reynold Weekes Primary School",
+    "parish": "St. Philip",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 45,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1089569,
+      "lon": -59.4699699
+    },
+    "address": "Four Roads, Saint Philip, BB18053"
+  },
+  {
+    "name": "Sharon Primary School",
+    "parish": "St. Thomas",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 40,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1519468,
+      "lon": -59.6021556
+    },
+    "address": "Jackson Arthur Seat Road, Arthur Seat, Saint Thomas"
+  },
+  {
+    "name": "Welches Primary School",
+    "parish": "St. Thomas",
+    "category": 2,
+    "ownership": "Public",
+    "capacity": 22,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.1569988,
+      "lon": -59.6127065
+    },
+    "address": "Highway 2A, Welches, Saint Thomas"
+  },
+  {
+    "name": "Hawthorn Methodist Church",
+    "parish": "Christ Church",
+    "category": 2,
+    "ownership": "Privately Owned",
+    "capacity": 27,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.0739936,
+      "lon": -59.5821481
+    },
+    "address": "Worthing, Christ Church, BB15137"
+  },
+  {
+    "name": "Ivan Harewood Centre (Christ Church Parish Church)",
+    "parish": "Christ Church",
+    "category": 2,
+    "ownership": "Privately Owned",
+    "capacity": 75,
+    "water": true,
+    "access": false
+  },
+  {
+    "name": "Salvation Army Church (Wotton)",
+    "parish": "Christ Church",
+    "category": 2,
+    "ownership": "Privately Owned",
+    "capacity": 14,
+    "water": true,
+    "access": false
+  },
+  {
+    "name": "St. Christopher Anglican Church",
+    "parish": "Christ Church",
+    "category": 2,
+    "ownership": "Privately Owned",
+    "capacity": 35,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.050674,
+      "lon": -59.5195226
+    },
+    "address": "Enterprise Coast Road, Green Garden, Goodland"
+  },
+  {
+    "name": "St. Matthias Anglican Church",
+    "parish": "Christ Church",
+    "category": 2,
+    "ownership": "Privately Owned",
+    "capacity": 23,
+    "water": false,
+    "access": true,
+    "coords": {
+      "lat": 13.0759679,
+      "lon": -59.5994563
+    },
+    "address": "St. Matthias Road, St. Matthias, Hastings"
+  },
+  {
+    "name": "St. George Anglican Church",
+    "parish": "St. George",
+    "category": 2,
+    "ownership": "Privately Owned",
+    "capacity": 22,
+    "water": false,
+    "access": false
+  },
+  {
+    "name": "Salvation Army Checker Hall Church",
+    "parish": "St. Lucy",
+    "category": 2,
+    "ownership": "Privately Owned",
+    "capacity": 14,
+    "water": true,
+    "access": false
+  },
+  {
+    "name": "St. Clement's Centre (St. Clement's Anglican Church)",
+    "parish": "St. Lucy",
+    "category": 2,
+    "ownership": "Privately Owned",
+    "capacity": 30,
+    "water": true,
+    "access": false
+  },
+  {
+    "name": "Dalkeith Methodist Church",
+    "parish": "St. Michael",
+    "category": 2,
+    "ownership": "Privately Owned",
+    "capacity": 34,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.0875931,
+      "lon": -59.6001907
+    },
+    "address": "Dalkeith Hill, Brittons Hill, Saint Michael"
+  },
+  {
+    "name": "People's Cathedral Primary",
+    "parish": "St. Michael",
+    "category": 2,
+    "ownership": "Privately Owned",
+    "capacity": 60,
+    "water": true,
+    "access": false
+  },
+  {
+    "name": "The Salvation Army Lighthouse Centre",
+    "parish": "St. Peter",
+    "category": 2,
+    "ownership": "Privately Owned",
+    "capacity": 12,
+    "water": false,
+    "access": false,
+    "restriction": "Women and children only"
+  },
+  {
+    "name": "St. Philip-the-Less Anglican Church",
+    "parish": "St. Peter",
+    "category": 2,
+    "ownership": "Privately Owned",
+    "capacity": 45,
+    "water": false,
+    "access": false,
+    "coords": {
+      "lat": 13.2844894,
+      "lon": -59.5819329
+    },
+    "address": "Highway B1, Mount Stepney, Saint Peter"
+  },
+  {
+    "name": "Gemswick Nazarene Church",
+    "parish": "St. Philip",
+    "category": 2,
+    "ownership": "Privately Owned",
+    "capacity": 45,
+    "water": false,
+    "access": false,
+    "coords": {
+      "lat": 13.0844603,
+      "lon": -59.4686072
+    },
+    "address": "Gemswick, Saint Philip, BB18093"
+  },
+  {
+    "name": "St. Catherine's Anglican Church",
+    "parish": "St. Philip",
+    "category": 2,
+    "ownership": "Privately Owned",
+    "capacity": 45,
+    "water": true,
+    "access": false,
+    "coords": {
+      "lat": 13.156438,
+      "lon": -59.441359
+    },
+    "address": "St. Catherine Road, St. Catherine's, Saint Philip"
+  }
+]

--- a/src/data/emergency-shelters.ts
+++ b/src/data/emergency-shelters.ts
@@ -1,0 +1,84 @@
+/**
+ * Emergency shelters — Barbados
+ * --------------------------------------------------------------
+ * Single source of truth for the shelter finder at
+ * /health-and-emergency-services/find-an-emergency-shelter/find.
+ *
+ * Records come from the 2026 Emergency Shelter Booklet (Department of
+ * Emergency Management). Coordinates and addresses (49 of 70 shelters) are
+ * geocoded from OpenStreetMap via Nominatim and stored inline in
+ * emergency-shelters.json. The rest fall back to the parish centroid for
+ * distance ordering and show no street address. © OpenStreetMap contributors.
+ */
+
+// biome-ignore-all lint/style/useNumericSeparators: latitude/longitude read more clearly without digit grouping
+import shelterData from "./emergency-shelters.json";
+
+export const PARISHES = [
+  "Christ Church",
+  "St. Andrew",
+  "St. George",
+  "St. James",
+  "St. John",
+  "St. Joseph",
+  "St. Lucy",
+  "St. Michael",
+  "St. Peter",
+  "St. Philip",
+  "St. Thomas",
+] as const;
+
+export type Parish = (typeof PARISHES)[number];
+
+export interface LatLon {
+  lat: number;
+  lon: number;
+}
+
+export interface Shelter {
+  name: string;
+  parish: Parish;
+  /** 1 = used during a hurricane; 2 = used after one has passed. */
+  category: 1 | 2;
+  ownership: "Public" | "Privately Owned";
+  /** Booklet planning figure — not live availability. */
+  capacity: number;
+  /** Has potable water on site. */
+  water: boolean;
+  /** Has a bathroom suitable for people who use a wheelchair. */
+  access: boolean;
+  notes?: string;
+  /** Eligibility restriction, e.g. "Women and children only". */
+  restriction?: string;
+  /** Geocoded coordinates, when available. */
+  coords?: LatLon;
+  /** Street address, when geocoded. */
+  address?: string;
+}
+
+export const STORM_SEASON_LABEL = "1 June to 30 November";
+export const SHELTERS_LAST_UPDATED = "2026-05-27";
+export const SHELTERS_NEXT_REVIEW = "2027-05-01";
+
+/**
+ * Approximate centre of each parish, used to estimate distance for the
+ * shelters without a geocoded point. Barbados is small (~21 × 14 km), so
+ * parish-centre accuracy is fine for "near me" ordering.
+ * Coordinates from OpenStreetMap parish boundary centroids.
+ */
+export const PARISH_CENTROIDS: Record<Parish, LatLon> = {
+  "Christ Church": { lat: 13.0689, lon: -59.5469 },
+  "St. Andrew": { lat: 13.2167, lon: -59.5667 },
+  "St. George": { lat: 13.1564, lon: -59.5294 },
+  "St. James": { lat: 13.1833, lon: -59.6333 },
+  "St. John": { lat: 13.1833, lon: -59.4833 },
+  "St. Joseph": { lat: 13.2167, lon: -59.55 },
+  "St. Lucy": { lat: 13.3, lon: -59.6167 },
+  "St. Michael": { lat: 13.1, lon: -59.6167 },
+  "St. Peter": { lat: 13.2667, lon: -59.6333 },
+  "St. Philip": { lat: 13.15, lon: -59.45 },
+  "St. Thomas": { lat: 13.1833, lon: -59.5833 },
+};
+
+export const EMERGENCY_SHELTERS = shelterData as Shelter[];
+export const SHELTER_COUNT = EMERGENCY_SHELTERS.length;

--- a/src/lib/shelter-distance.ts
+++ b/src/lib/shelter-distance.ts
@@ -1,0 +1,77 @@
+/**
+ * Distance helpers for the emergency shelter finder.
+ * --------------------------------------------------------------
+ * Barbados is small (~21 × 14 km), so for the 21 shelters without a geocoded
+ * point we fall back to the parish centroid — good enough for "nearest first"
+ * ordering. Pure functions; no DOM or browser APIs.
+ */
+
+import {
+  type LatLon,
+  PARISH_CENTROIDS,
+  type Shelter,
+} from "@/data/emergency-shelters";
+
+const EARTH_RADIUS_KM = 6371;
+
+/**
+ * Largest distance between any two points in Barbados is ~30 km. If the user
+ * is further than this from every parish centroid, they are not on the island
+ * and distance ordering is meaningless.
+ */
+const MAX_PLAUSIBLE_DISTANCE_KM = 50;
+
+const toRadians = (degrees: number): number => (degrees * Math.PI) / 180;
+
+/** Great-circle distance between two points in kilometres. */
+export function haversineKm(a: LatLon, b: LatLon): number {
+  const dLat = toRadians(b.lat - a.lat);
+  const dLon = toRadians(b.lon - a.lon);
+  const lat1 = toRadians(a.lat);
+  const lat2 = toRadians(b.lat);
+  const x =
+    Math.sin(dLat / 2) ** 2 +
+    Math.sin(dLon / 2) ** 2 * Math.cos(lat1) * Math.cos(lat2);
+  return 2 * EARTH_RADIUS_KM * Math.atan2(Math.sqrt(x), Math.sqrt(1 - x));
+}
+
+export interface ShelterDistance {
+  km: number;
+  /** True when measured from the shelter's own coordinates, false when from the parish centre. */
+  exact: boolean;
+}
+
+/** Distance from the user to a shelter, or null if it cannot be determined. */
+export function shelterDistance(
+  shelter: Shelter,
+  user: LatLon | null
+): ShelterDistance | null {
+  if (!user) {
+    return null;
+  }
+  if (shelter.coords) {
+    return { km: haversineKm(user, shelter.coords), exact: true };
+  }
+  const centroid = PARISH_CENTROIDS[shelter.parish];
+  return centroid ? { km: haversineKm(user, centroid), exact: false } : null;
+}
+
+/** True when the user's position is close enough to Barbados for distances to mean anything. */
+export function userIsOnIsland(user: LatLon): boolean {
+  let nearest = Number.POSITIVE_INFINITY;
+  for (const centroid of Object.values(PARISH_CENTROIDS)) {
+    nearest = Math.min(nearest, haversineKm(user, centroid));
+  }
+  return nearest <= MAX_PLAUSIBLE_DISTANCE_KM;
+}
+
+const VERY_CLOSE_KM = 0.5;
+
+/** Human-readable distance, e.g. "2.4 km away" or "In your parish". */
+export function formatDistance(distance: ShelterDistance): string {
+  if (distance.km < VERY_CLOSE_KM) {
+    return distance.exact ? "Very close" : "In your parish";
+  }
+  const value = `${distance.km.toFixed(1)} km`;
+  return distance.exact ? `${value} away` : `${value} from your parish`;
+}


### PR DESCRIPTION
## What

Adds a public **Find an emergency shelter** service under *Health and emergency services* — three component pages registered via `COMPONENT_PAGES`:

- **Landing** (`/health-and-emergency-services/find-an-emergency-shelter`) — overview, emergency phone tiles, what to bring, key rules.
- **Find** (`…/find`) — interactive finder over all **70 shelters** from the 2026 Emergency Shelter Booklet.
- **Guidance** (`…/guidance`) — Go Bag, shelter rules, entry protocol, accessible shelters (derived from the data), DEO chairpersons, hurricane terms and the full phone directory.

## Finder

- **Search** by name; **filter** by parish, category and accessibility using the GOV.BB **Filter** pattern (collapsible panel of accordion checkbox groups + removable tag chips + Clear all); **sort** by parish, name, capacity or distance.
- **Use my location** → nearest-first ordering via geolocation, with an on-island sanity check and a parish-centroid fallback for the 21 shelters without exact coordinates.
- Filter state **syncs to the URL** (shareable); results show 12 then a **Show more** button.
- Single column on mobile, two-column grid on desktop. "Not currently open" status on every card (no live activation feed).

## Data & structure

- `emergency-shelters.json` — flat records, coordinates/address inline on the 49 geocoded shelters (matches the `pharmacies.json` pattern).
- `emergency-shelters.ts` — types, parish centroids, `EMERGENCY_SHELTERS`.
- `lib/shelter-distance.ts` — pure haversine / formatting helpers.
- Finder decomposed into `shelter-finder` / `shelter-card` / `icons`.

## Verification

`next build` passes; `tsc` clean (only a pre-existing test-file error). All three routes return 200, filtering + pagination + geolocation sort verified. New files Biome-clean.