### PR TITLE
feat(youth): feature-flag all youth-and-community pages

### DIFF
--- a/src/app/(content)/[...slug]/page.tsx
+++ b/src/app/(content)/[...slug]/page.tsx
@@ -120,6 +120,9 @@ export default async function Page({ params }: ContentPageProps) {
     // Subcategory index for youth-and-community: derive opportunities from
     // opportunities.json, matching on `opportunity.subcategory === pageSlug`.
     if (categorySlug === "youth-and-community") {
+      if (page.protected && !(await hasResearchAccess())) {
+        notFound();
+      }
       const subcategoryOpportunities = opportunities.filter(
         (opp) => opp.subcategory === pageSlug
       );
@@ -219,6 +222,9 @@ export default async function Page({ params }: ContentPageProps) {
     // Opportunity detail under a youth-and-community subcategory: third slug
     // is the opportunity id, and the opportunity's subcategory must match.
     if (categorySlug === "youth-and-community") {
+      if (page.protected && !(await hasResearchAccess())) {
+        notFound();
+      }
       const opportunity = opportunities.find(
         (opp) => opp.id === subPageSlug && opp.subcategory === pageSlug
       );

--- a/src/data/content-directory.ts
+++ b/src/data/content-directory.ts
@@ -320,30 +320,35 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
       {
         title: "Youth development and leadership",
         slug: "youth-development-leadership",
+        protected: true,
         description:
           "Long-term training, mentorship and leadership pathways for young people.",
       },
       {
         title: "Skills, trades and vocational training",
         slug: "skills-trades-vocational-training",
+        protected: true,
         description:
           "Practical courses and workshops in trades, technology and creative skills.",
       },
       {
         title: "Entrepreneurship and business",
         slug: "entrepreneurship-business",
+        protected: true,
         description:
           "Support for young people starting and growing their own ventures.",
       },
       {
         title: "Arts and culture",
         slug: "arts-culture",
+        protected: true,
         description:
           "Creative programmes, performances and content celebrating Barbadian culture.",
       },
       {
         title: "Children, families and the wider community",
         slug: "children-families-community",
+        protected: true,
         description:
           "Programmes, volunteering opportunities and services for children, families and neighbourhoods.",
       },


### PR DESCRIPTION
## Summary

Feature-flags every page under the **Youth and Community Programmes** category so the whole category stays hidden from the public until it's ready, while remaining visible to research-access users.

This reuses the existing `protected` mechanism — there is no separate feature-flag system in the repo, and `protected` already provides hide-until-ready behaviour with a research-access bypass.

## Changes

- **`src/data/content-directory.ts`** — added `protected: true` to all five `youth-and-community` subcategory pages. Since *every* page in the category is now protected, `isCategoryHidden()` returns true, so the category automatically drops out of:
  - the category index route (`notFound()` for public users)
  - the sitemap (`sitemap.ts`)
  - the search index (`build-search-index.ts`)
  - the services page (`services/page.tsx`)
- **`src/app/(content)/[...slug]/page.tsx`** — the youth-and-community subcategory index (2-slug) and opportunity detail (3-slug) branches rendered *before* any `protected` check, so direct URLs (e.g. `/youth-and-community/arts-culture`) would have bypassed the flag. Both now `notFound()` for non-research users.

Research-access users continue to see everything, consistent with other protected pages.

## Test plan

- [ ] As a public (no research access) user, `/youth-and-community` and all subcategory / opportunity URLs return 404.
- [ ] The category no longer appears in the services list, search results, or sitemap.
- [ ] As a research-access user, the category, subcategories and opportunities all render as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)