### PR TITLE
RELEASE 2026-06-05: feature flag youth-and-community pages as protected

### DIFF
--- a/src/app/(content)/[...slug]/page.tsx
+++ b/src/app/(content)/[...slug]/page.tsx
@@ -120,6 +120,9 @@ export default async function Page({ params }: ContentPageProps) {
     // Subcategory index for youth-and-community: derive opportunities from
     // opportunities.json, matching on `opportunity.subcategory === pageSlug`.
     if (categorySlug === "youth-and-community") {
+      if (page.protected && !(await hasResearchAccess())) {
+        notFound();
+      }
       const subcategoryOpportunities = opportunities.filter(
         (opp) => opp.subcategory === pageSlug
       );
@@ -219,6 +222,9 @@ export default async function Page({ params }: ContentPageProps) {
     // Opportunity detail under a youth-and-community subcategory: third slug
     // is the opportunity id, and the opportunity's subcategory must match.
     if (categorySlug === "youth-and-community") {
+      if (page.protected && !(await hasResearchAccess())) {
+        notFound();
+      }
       const opportunity = opportunities.find(
         (opp) => opp.id === subPageSlug && opp.subcategory === pageSlug
       );

--- a/src/data/content-directory.ts
+++ b/src/data/content-directory.ts
@@ -320,30 +320,35 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
       {
         title: "Youth development and leadership",
         slug: "youth-development-leadership",
+        protected: true,
         description:
           "Long-term training, mentorship and leadership pathways for young people.",
       },
       {
         title: "Skills, trades and vocational training",
         slug: "skills-trades-vocational-training",
+        protected: true,
         description:
           "Practical courses and workshops in trades, technology and creative skills.",
       },
       {
         title: "Entrepreneurship and business",
         slug: "entrepreneurship-business",
+        protected: true,
         description:
           "Support for young people starting and growing their own ventures.",
       },
       {
         title: "Arts and culture",
         slug: "arts-culture",
+        protected: true,
         description:
           "Creative programmes, performances and content celebrating Barbadian culture.",
       },
       {
         title: "Children, families and the wider community",
         slug: "children-families-community",
+        protected: true,
         description:
           "Programmes, volunteering opportunities and services for children, families and neighbourhoods.",
       },


### PR DESCRIPTION
## Release

Promotes `main` to `prod`.

### Included

- **#637 — feature-flag all youth-and-community pages** (`feat/feature-flag-youth-community`)
  - Marks all five youth-and-community subcategory pages as `protected`, hiding the whole category from public listings, search, sitemap and the services page until ready.
  - Gates the youth-and-community subcategory index and opportunity detail routes behind research access so direct URLs no longer bypass the flag.
  - Research-access users continue to see everything.

### Test plan

- [ ] On prod, as a public user, `/youth-and-community` and all subcategory / opportunity URLs return 404.
- [ ] The category no longer appears in the services list, search results, or sitemap.
- [ ] As a research-access user, the category, subcategories and opportunities render as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)