### PR TITLE
feat(content): feature flag renew-reminder as protected

### DIFF
--- a/src/data/content-directory.ts
+++ b/src/data/content-directory.ts
@@ -440,6 +440,7 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
       {
         title: "Get a reminder before a document expires",
         slug: "renew-reminder",
+        protected: true,
         keywords: [
           "reminder",
           "renew",


### PR DESCRIPTION
## Summary
Marks the **Get a reminder before a document expires** (`renew-reminder`) page as `protected: true` in `content-directory.ts`, feature-flagging it behind research access. This hides it from public listings, search, sitemap and the services page until it's ready to launch.

This follows the same pattern used previously for this page (commit `20bf2f5d`) and for the youth-and-community pages. As a standard page, the generic `[...slug]` route already gates `protected` entries, so no route changes are needed.

## Changes
- Add `protected: true` to the `renew-reminder` entry in `src/data/content-directory.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)