### PR TITLE
Release: feature flag renew-reminder

### DIFF
--- a/src/data/content-directory.ts
+++ b/src/data/content-directory.ts
@@ -440,6 +440,7 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
       {
         title: "Get a reminder before a document expires",
         slug: "renew-reminder",
+        protected: true,
         keywords: [
           "reminder",
           "renew",


### PR DESCRIPTION
## Release

Merges `main` into `prod`.

### Changes
- **feat(content): feature flag renew-reminder as protected** (#643) — marks the "Get a reminder before a document expires" page as `protected: true`, hiding it from public listings, search, sitemap and the services page until ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)