### PR TITLE
feat: add People's Cathedral Primary School to primary schools list

### DIFF
--- a/src/data/schools.ts
+++ b/src/data/schools.ts
@@ -35,6 +35,10 @@ export const primarySchools: SelectOption[] = [
   { label: "Mount Tabor Primary School", value: "mount-tabor-primary-school" },
   { label: "New Horizon Academy", value: "new-horizon-academy" },
   {
+    label: "People's Cathedral Primary School",
+    value: "peoples-cathedral-primary-school",
+  },
+  {
     label: "Reynold Weekes Primary School",
     value: "reynold-weekes-primary-school",
   },


### PR DESCRIPTION
## Summary

Adds the missing **People's Cathedral Primary School** to the `primarySchools` list in `src/data/schools.ts`. The entry is placed alphabetically between `New Horizon Academy` and `Reynold Weekes Primary School`.

```ts
{
  label: "People's Cathedral Primary School",
  value: "peoples-cathedral-primary-school",
},
```

The `value` slug follows the existing convention (lowercase, apostrophes/periods stripped, spaces → hyphens — matching e.g. `st-margarets-primary-school`).

## Verification

The **Primary School Textbook Grant** form is correctly wired to this list — no hardcoded school source. The chain is:

- `src/data/schools.ts` → exports `primarySchools`
- `src/schema/primary-school-textbook-grant.ts:9` → imports `primarySchools`, uses it as `options` for the "Name of institution" field (line 110)
- `src/components/forms/primary-school-textbook-grant-form.tsx` → renders the schema via `DynamicMultiStepForm`
- `src/lib/form-registry.ts` → registers `get-a-primary-school-textbook-grant`

So the new school automatically appears in the textbook grant school dropdown.

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)