### PR TITLE
Release: feature flag certificate forms to offline-only

### DIFF
--- a/src/app/(content)/[...slug]/page.tsx
+++ b/src/app/(content)/[...slug]/page.tsx
@@ -155,6 +155,19 @@ export default async function Page({ params }: ContentPageProps) {
       notFound();
     }
 
+    // When a page's form/start subpages are protected, the overview stays
+    // public but the online "start" link must be hidden for non-research
+    // users. Passing the real research-access value lets rehypeHideStartLinks
+    // strip the online method (and renumber "ways to apply") for the public,
+    // while research-access users still see and can test the online form.
+    const hasGatedSubPage =
+      page.subPages?.some((subPage) => subPage.protected) ?? false;
+    // A protected page has already returned notFound above for non-research
+    // users, so reaching here means either the page is public or the user has
+    // research access. Hide the online "start" link only when a form/start
+    // subpage is gated and the user lacks research access.
+    const showOnlineStartLinks = researchAccess || !hasGatedSubPage;
+
     const componentPage = COMPONENT_PAGES[slug.join("/")];
     if (componentPage) {
       const { Component } = componentPage;
@@ -196,7 +209,7 @@ export default async function Page({ params }: ContentPageProps) {
               </ContactCallout>
             ) : undefined
           }
-          hasResearchAccess={!page.protected || researchAccess}
+          hasResearchAccess={showOnlineStartLinks}
           markdown={markdownContent}
         />
       </>

--- a/src/content/get-death-certificate/index.md
+++ b/src/content/get-death-certificate/index.md
@@ -19,7 +19,7 @@ You can request a copy on someone else’s behalf but you must disclose:
 
 ## How to get a copy of a death certificate
 
-### Complete the form online
+### Complete the form
 
 1. #### Request a copy online
 

--- a/src/content/get-marriage-certificate/index.md
+++ b/src/content/get-marriage-certificate/index.md
@@ -19,28 +19,28 @@ You can request a copy on someone else’s behalf but you must disclose:
 
 ## How to get a copy of a marriage certificate
 
-### Complete the form online
+### Complete the form
 
 There are two ways to get a copy of a marriage certificate. You can:
 
-1. Request a copy online
+1. #### Request a copy online
 
-You must pay online so you will need a debit or credit card, and you will need to have (or create) an EZPay+ account.
-Every question is compulsory so if you are unsure about the basic information asked for, you should complete the paper form instead.
+   You must pay online so you will need a debit or credit card, and you will need to have (or create) an EZPay+ account.<br />
+   Every question is compulsory so if you are unsure about the basic information asked for, you should complete the paper form instead.
 
-<a data-start-link href="/family-birth-relationships/get-marriage-certificate/start">Complete the online form</a>
+   <a data-start-link href="/family-birth-relationships/get-marriage-certificate/start">Complete the online form</a>
 
-2. Get a paper Application for marriage certificate form from the Registration Department
+2. #### Get a paper Application for marriage certificate form from the Registration Department
 
-You must complete it by hand and return it to the department. You can pay with cash or by card when you collect it.
-If you are unsure about the basic details asked for (for example, if there is estrangement in the family), you should complete the paper form.
+   You must complete it by hand and return it to the department. You can pay with cash or by card when you collect it.<br />
+   If you are unsure about the basic details asked for (for example, if there is estrangement in the family), you should complete the paper form.
 
-    Registration Department
-    Supreme Court Complex
-    Whitepark Road
-    St. Michael
-    (246) 535-9700
-    Open Monday to Friday: 8:30am to 3:15pm
+   Registration Department<br>
+   Supreme Court Complex<br>
+   Whitepark Road<br>
+   St. Michael<br>
+   (246) 535-9700<br>
+   Open Monday to Friday: 8:30am to 3:15pm
 
 ## Cost of certificates
 

--- a/src/data/content-directory.ts
+++ b/src/data/content-directory.ts
@@ -32,11 +32,12 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
         description:
           "Information on how to obtain a birth certificate in Barbados, including required documents and contact details for the Registration Department.",
         subPages: [
-          { slug: "start", type: "markdown" },
+          { slug: "start", type: "markdown", protected: true },
           {
             slug: "form",
             title: "Get a Birth Certificate form",
             type: "component",
+            protected: true,
           },
         ],
       },
@@ -47,11 +48,12 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
         description:
           "Information on how to obtain a copy of a death certificate in Barbados.",
         subPages: [
-          { slug: "start", type: "markdown" },
+          { slug: "start", type: "markdown", protected: true },
           {
             slug: "form",
             title: "Get a Death Certificate form",
             type: "component",
+            protected: true,
           },
         ],
       },
@@ -62,11 +64,12 @@ export const INFORMATION_ARCHITECTURE: InformationContent[] = [
         description:
           "Information on how to obtain a copy of a marriage certificate in Barbados.",
         subPages: [
-          { slug: "start", type: "markdown" },
+          { slug: "start", type: "markdown", protected: true },
           {
             slug: "form",
             title: "Get a Marriage Certificate form",
             type: "component",
+            protected: true,
           },
         ],
       },

--- a/tests/e2e/feature-flag-certificates.spec.ts
+++ b/tests/e2e/feature-flag-certificates.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test";
+import { COOKIE_NAME } from "@/lib/research-access";
+
+/**
+ * Verifies the certificate forms are feature-flagged: for the public the
+ * online "start" link is hidden (only the offline / Registration Department
+ * method remains) and the form + start routes are unreachable, while
+ * research-access users can still see and reach the online form.
+ *
+ * The research-access gate is only enforced when RESEARCH_ACCESS_TOKEN is set
+ * (see src/lib/research-access.ts — it returns true when the token is unset).
+ * CI does not set the token, so the whole suite skips there. To run it:
+ *   RESEARCH_ACCESS_TOKEN=demo npm run dev        # in one shell
+ *   RESEARCH_ACCESS_TOKEN=demo npx playwright test feature-flag-certificates
+ */
+const TOKEN = process.env.RESEARCH_ACCESS_TOKEN;
+
+const CATEGORY = "family-birth-relationships";
+const FLAGGED_FORMS = [
+  "get-birth-certificate",
+  "get-death-certificate",
+  "get-marriage-certificate",
+] as const;
+
+const ONLINE_START_LINK = /complete the online form/i;
+const OFFLINE_METHOD = /get a paper application/i;
+
+test.describe("Certificate forms are feature-flagged", () => {
+  // biome-ignore lint/suspicious/noSkippedTests: conditional skip — the gate is only enforced when RESEARCH_ACCESS_TOKEN is set
+  test.skip(
+    !TOKEN,
+    "research-access gate inactive (RESEARCH_ACCESS_TOKEN unset)"
+  );
+
+  for (const form of FLAGGED_FORMS) {
+    const overviewUrl = `/${CATEGORY}/${form}`;
+    const startUrl = `${overviewUrl}/start`;
+    const formUrl = `${overviewUrl}/form`;
+
+    test.describe(form, () => {
+      test("public: overview hides the online start-link, shows offline method", async ({
+        page,
+      }) => {
+        const response = await page.goto(overviewUrl);
+        expect(response?.status()).toBe(200);
+
+        await expect(page.getByText(ONLINE_START_LINK)).toHaveCount(0);
+        await expect(page.getByText(OFFLINE_METHOD).first()).toBeVisible();
+      });
+
+      test("public: the form route is not reachable", async ({ page }) => {
+        const response = await page.goto(formUrl);
+        expect(response?.status()).toBe(404);
+        await expect(page.locator("form")).toHaveCount(0);
+      });
+
+      test("public: the start route is not reachable", async ({ page }) => {
+        const response = await page.goto(startUrl);
+        expect(response?.status()).toBe(404);
+      });
+
+      test("research-access: online form remains reachable", async ({
+        page,
+        context,
+        baseURL,
+      }) => {
+        await context.addCookies([
+          {
+            name: COOKIE_NAME,
+            value: TOKEN as string,
+            url: baseURL as string,
+          },
+        ]);
+
+        const response = await page.goto(formUrl);
+        expect(response?.status()).toBe(200);
+        await expect(page.locator("form")).toBeVisible({ timeout: 10_000 });
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Release

Promotes `main` → `prod`.

### Included

- **#648 — feat(content): feature flag certificate forms to offline-only**
  Gates the online application path for the birth, death and marriage certificate services behind research access. The public sees only the offline (Registration Department) method and the `/form` + `/start` routes return 404; research-access users retain full access to the online forms.

### Post-deploy note

The flag engages where `RESEARCH_ACCESS_TOKEN` is set (which prod has). Confirm after deploy: as a public user the three certificate overviews show offline-only with no online start-link, and `/family-birth-relationships/get-{birth,death,marriage}-certificate/form` return 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)